### PR TITLE
Switch preformatted docs text from pluses to backticks

### DIFF
--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/asset_service_client.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/asset_service_client.rb
@@ -244,7 +244,7 @@ module Google
           #   asset_service_client = Google::Cloud::Asset.new(version: :v1beta1)
           #   formatted_parent = Google::Cloud::Asset::V1beta1::AssetServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +output_config+:
+          #   # TODO: Initialize `output_config`:
           #   output_config = {}
           #
           #   # Register a callback during the method call.
@@ -340,10 +340,10 @@ module Google
           #   asset_service_client = Google::Cloud::Asset.new(version: :v1beta1)
           #   formatted_parent = Google::Cloud::Asset::V1beta1::AssetServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +content_type+:
+          #   # TODO: Initialize `content_type`:
           #   content_type = :CONTENT_TYPE_UNSPECIFIED
           #
-          #   # TODO: Initialize +read_time_window+:
+          #   # TODO: Initialize `read_time_window`:
           #   read_time_window = {}
           #   response = asset_service_client.batch_get_assets_history(formatted_parent, content_type, read_time_window)
 

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/cloud/asset/v1beta1/assets.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/cloud/asset/v1beta1/assets.rb
@@ -81,7 +81,7 @@ module Google
         #     The REST URL for accessing the resource. An HTTP GET operation using this
         #     URL returns the resource itself.
         #     Example:
-        #     +https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123+.
+        #     `https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123`.
         #     It will be left unspecified for resources without a REST API.
         # @!attribute [rw] parent
         #   @return [String]

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/longrunning/operations.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/struct.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-asset/lib/google/cloud/asset/v1beta1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-asset/synth.py
+++ b/google-cloud-asset/synth.py
@@ -51,10 +51,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/data_transfer_service_client.rb
@@ -367,7 +367,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/\\{project_id}/dataSources/\\{data_source_id}+
+            #   `projects/{project_id}/dataSources/{data_source_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -399,7 +399,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id for which data sources should be returned.
-            #   Must be in the form: +projects/\\{project_id}+
+            #   Must be in the form: `projects/{project_id}`
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -464,7 +464,7 @@ module Google
             # @param authorization_code [String]
             #   Optional OAuth2 authorization code to use with this transfer configuration.
             #   This is required if new credentials are needed, as indicated by
-            #   +CheckValidCreds+.
+            #   `CheckValidCreds`.
             #   In order to obtain authorization_code, please make a
             #   request to
             #   https://www.gstatic.com/bigquerydatatransfer/oauthz/auth?client_id=<datatransferapiclientid>&scope=<data_source_scopes>&redirect_uri=<redirect_uri>
@@ -492,7 +492,7 @@ module Google
             #   data_transfer_service_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
             #   formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_path("[PROJECT]")
             #
-            #   # TODO: Initialize +transfer_config+:
+            #   # TODO: Initialize `transfer_config`:
             #   transfer_config = {}
             #   response = data_transfer_service_client.create_transfer_config(formatted_parent, transfer_config)
 
@@ -552,10 +552,10 @@ module Google
             #
             #   data_transfer_service_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
             #
-            #   # TODO: Initialize +transfer_config+:
+            #   # TODO: Initialize `transfer_config`:
             #   transfer_config = {}
             #
-            #   # TODO: Initialize +update_mask+:
+            #   # TODO: Initialize `update_mask`:
             #   update_mask = {}
             #   response = data_transfer_service_client.update_transfer_config(transfer_config, update_mask)
 
@@ -579,7 +579,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+
+            #   `projects/{project_id}/transferConfigs/{config_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -610,7 +610,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+
+            #   `projects/{project_id}/transferConfigs/{config_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -641,7 +641,7 @@ module Google
             #
             # @param parent [String]
             #   The BigQuery project id for which data sources
-            #   should be returned: +projects/\\{project_id}+.
+            #   should be returned: `projects/{project_id}`.
             # @param data_source_ids [Array<String>]
             #   When specified, only configurations of requested data sources are returned.
             # @param page_size [Integer]
@@ -703,15 +703,15 @@ module Google
             #
             # @param parent [String]
             #   Transfer configuration name in the form:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+.
+            #   `projects/{project_id}/transferConfigs/{config_id}`.
             # @param start_time [Google::Protobuf::Timestamp | Hash]
             #   Start time of the range of transfer runs. For example,
-            #   +"2017-05-25T00:00:00+00:00"+.
+            #   `"2017-05-25T00:00:00+00:00"`.
             #   A hash of the same form as `Google::Protobuf::Timestamp`
             #   can also be provided.
             # @param end_time [Google::Protobuf::Timestamp | Hash]
             #   End time of the range of transfer runs. For example,
-            #   +"2017-05-30T00:00:00+00:00"+.
+            #   `"2017-05-30T00:00:00+00:00"`.
             #   A hash of the same form as `Google::Protobuf::Timestamp`
             #   can also be provided.
             # @param options [Google::Gax::CallOptions]
@@ -728,10 +728,10 @@ module Google
             #   data_transfer_service_client = Google::Cloud::Bigquery::DataTransfer.new(version: :v1)
             #   formatted_parent = Google::Cloud::Bigquery::DataTransfer::V1::DataTransferServiceClient.project_transfer_config_path("[PROJECT]", "[TRANSFER_CONFIG]")
             #
-            #   # TODO: Initialize +start_time+:
+            #   # TODO: Initialize `start_time`:
             #   start_time = {}
             #
-            #   # TODO: Initialize +end_time+:
+            #   # TODO: Initialize `end_time`:
             #   end_time = {}
             #   response = data_transfer_service_client.schedule_transfer_runs(formatted_parent, start_time, end_time)
 
@@ -754,7 +754,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
+            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -785,7 +785,7 @@ module Google
             #
             # @param name [String]
             #   The field will contain name of the resource requested, for example:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
+            #   `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -817,7 +817,7 @@ module Google
             # @param parent [String]
             #   Name of transfer configuration for which transfer runs should be retrieved.
             #   Format of transfer configuration resource name is:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_id}+.
+            #   `projects/{project_id}/transferConfigs/{config_id}`.
             # @param states [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
             #   When specified, only transfer runs with requested states are returned.
             # @param page_size [Integer]
@@ -880,7 +880,7 @@ module Google
             #
             # @param parent [String]
             #   Transfer run name in the form:
-            #   +projects/\\{project_id}/transferConfigs/\\{config_Id}/runs/\\{run_id}+.
+            #   `projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}`.
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -945,7 +945,7 @@ module Google
             #
             # @param name [String]
             #   The data source in the form:
-            #   +projects/\\{project_id}/dataSources/\\{data_source_id}+
+            #   `projects/{project_id}/dataSources/{data_source_id}`
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/datatransfer.rb
@@ -119,7 +119,7 @@ module Google
           # @!attribute [rw] scopes
           #   @return [Array<String>]
           #     Api auth scopes for which refresh token needs to be obtained. Only valid
-          #     when +client_id+ is specified. Ignored otherwise. These are scopes needed
+          #     when `client_id` is specified. Ignored otherwise. These are scopes needed
           #     by a data source to prepare data and ingest them into BigQuery,
           #     e.g., https://www.googleapis.com/auth/bigquery
           # @!attribute [rw] transfer_type
@@ -137,14 +137,14 @@ module Google
           #   @return [String]
           #     Default data transfer schedule.
           #     Examples of valid schedules include:
-          #     +1st,3rd monday of month 15:30+,
-          #     +every wed,fri of jan,jun 13:15+, and
-          #     +first sunday of quarter 00:00+.
+          #     `1st,3rd monday of month 15:30`,
+          #     `every wed,fri of jan,jun 13:15`, and
+          #     `first sunday of quarter 00:00`.
           # @!attribute [rw] supports_custom_schedule
           #   @return [true, false]
           #     Specifies whether the data source supports a user defined schedule, or
           #     operates on the default schedule.
-          #     When set to +true+, user can override default schedule.
+          #     When set to `true`, user can override default schedule.
           # @!attribute [rw] parameters
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::DataSourceParameter>]
           #     Data source parameters.
@@ -163,7 +163,7 @@ module Google
           # @!attribute [rw] default_data_refresh_window_days
           #   @return [Integer]
           #     Default data refresh window on days.
-          #     Only meaningful when +data_refresh_type+ = +SLIDING_WINDOW+.
+          #     Only meaningful when `data_refresh_type` = `SLIDING_WINDOW`.
           # @!attribute [rw] manual_runs_disabled
           #   @return [true, false]
           #     Disables backfilling and manual run scheduling
@@ -207,21 +207,21 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
+          #     `projects/{project_id}/dataSources/{data_source_id}`
           class GetDataSourceRequest; end
 
           # Request to list supported data sources and their data transfer settings.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources should be returned.
-          #     Must be in the form: +projects/\\{project_id}+
+          #     Must be in the form: `projects/{project_id}`
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
-          #     of +ListDataSourcesRequest+ list results. For multiple-page
-          #     results, +ListDataSourcesResponse+ outputs
-          #     a +next_page+ token, which can be used as the
-          #     +page_token+ value to request the next page of list results.
+          #     of `ListDataSourcesRequest` list results. For multiple-page
+          #     results, `ListDataSourcesResponse` outputs
+          #     a `next_page` token, which can be used as the
+          #     `page_token` value to request the next page of list results.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Page size. The default page size is the maximum value of 1000 results.
@@ -235,7 +235,7 @@ module Google
           #   @return [String]
           #     Output only. The next-pagination token. For multiple-page list results,
           #     this token can be used as the
-          #     +ListDataSourcesRequest.page_token+
+          #     `ListDataSourcesRequest.page_token`
           #     to request the next page of list results.
           class ListDataSourcesResponse; end
 
@@ -258,7 +258,7 @@ module Google
           #   @return [String]
           #     Optional OAuth2 authorization code to use with this transfer configuration.
           #     This is required if new credentials are needed, as indicated by
-          #     +CheckValidCreds+.
+          #     `CheckValidCreds`.
           #     In order to obtain authorization_code, please make a
           #     request to
           #     https://www.gstatic.com/bigquerydatatransfer/oauthz/auth?client_id=<datatransferapiclientid>&scope=<data_source_scopes>&redirect_uri=<redirect_uri>
@@ -306,7 +306,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
+          #     `projects/{project_id}/transferConfigs/{config_id}`
           class GetTransferConfigRequest; end
 
           # A request to delete data transfer information. All associated transfer runs
@@ -314,38 +314,38 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+
+          #     `projects/{project_id}/transferConfigs/{config_id}`
           class DeleteTransferConfigRequest; end
 
           # A request to get data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
+          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
           class GetTransferRunRequest; end
 
           # A request to delete data transfer run information.
           # @!attribute [rw] name
           #   @return [String]
           #     The field will contain name of the resource requested, for example:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}/runs/\\{run_id}+
+          #     `projects/{project_id}/transferConfigs/{config_id}/runs/{run_id}`
           class DeleteTransferRunRequest; end
 
           # A request to list data transfers configured for a BigQuery project.
           # @!attribute [rw] parent
           #   @return [String]
           #     The BigQuery project id for which data sources
-          #     should be returned: +projects/\\{project_id}+.
+          #     should be returned: `projects/{project_id}`.
           # @!attribute [rw] data_source_ids
           #   @return [Array<String>]
           #     When specified, only configurations of requested data sources are returned.
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
-          #     of +ListTransfersRequest+ list results. For multiple-page
-          #     results, +ListTransfersResponse+ outputs
-          #     a +next_page+ token, which can be used as the
-          #     +page_token+ value to request the next page of list results.
+          #     of `ListTransfersRequest` list results. For multiple-page
+          #     results, `ListTransfersResponse` outputs
+          #     a `next_page` token, which can be used as the
+          #     `page_token` value to request the next page of list results.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Page size. The default page size is the maximum value of 1000 results.
@@ -359,7 +359,7 @@ module Google
           #   @return [String]
           #     Output only. The next-pagination token. For multiple-page list results,
           #     this token can be used as the
-          #     +ListTransferConfigsRequest.page_token+
+          #     `ListTransferConfigsRequest.page_token`
           #     to request the next page of list results.
           class ListTransferConfigsResponse; end
 
@@ -370,17 +370,17 @@ module Google
           #   @return [String]
           #     Name of transfer configuration for which transfer runs should be retrieved.
           #     Format of transfer configuration resource name is:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
+          #     `projects/{project_id}/transferConfigs/{config_id}`.
           # @!attribute [rw] states
           #   @return [Array<Google::Cloud::Bigquery::Datatransfer::V1::TransferState>]
           #     When specified, only transfer runs with requested states are returned.
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
-          #     of +ListTransferRunsRequest+ list results. For multiple-page
-          #     results, +ListTransferRunsResponse+ outputs
-          #     a +next_page+ token, which can be used as the
-          #     +page_token+ value to request the next page of list results.
+          #     of `ListTransferRunsRequest` list results. For multiple-page
+          #     results, `ListTransferRunsResponse` outputs
+          #     a `next_page` token, which can be used as the
+          #     `page_token` value to request the next page of list results.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Page size. The default page size is the maximum value of 1000 results.
@@ -406,7 +406,7 @@ module Google
           #   @return [String]
           #     Output only. The next-pagination token. For multiple-page list results,
           #     this token can be used as the
-          #     +ListTransferRunsRequest.page_token+
+          #     `ListTransferRunsRequest.page_token`
           #     to request the next page of list results.
           class ListTransferRunsResponse; end
 
@@ -414,14 +414,14 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer run name in the form:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_Id}/runs/\\{run_id}+.
+          #     `projects/{project_id}/transferConfigs/{config_Id}/runs/{run_id}`.
           # @!attribute [rw] page_token
           #   @return [String]
           #     Pagination token, which can be used to request a specific page
-          #     of +ListTransferLogsRequest+ list results. For multiple-page
-          #     results, +ListTransferLogsResponse+ outputs
-          #     a +next_page+ token, which can be used as the
-          #     +page_token+ value to request the next page of list results.
+          #     of `ListTransferLogsRequest` list results. For multiple-page
+          #     results, `ListTransferLogsResponse` outputs
+          #     a `next_page` token, which can be used as the
+          #     `page_token` value to request the next page of list results.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Page size. The default page size is the maximum value of 1000 results.
@@ -439,7 +439,7 @@ module Google
           #   @return [String]
           #     Output only. The next-pagination token. For multiple-page list results,
           #     this token can be used as the
-          #     +GetTransferRunLogRequest.page_token+
+          #     `GetTransferRunLogRequest.page_token`
           #     to request the next page of list results.
           class ListTransferLogsResponse; end
 
@@ -452,28 +452,28 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The data source in the form:
-          #     +projects/\\{project_id}/dataSources/\\{data_source_id}+
+          #     `projects/{project_id}/dataSources/{data_source_id}`
           class CheckValidCredsRequest; end
 
           # A response indicating whether the credentials exist and are valid.
           # @!attribute [rw] has_valid_creds
           #   @return [true, false]
-          #     If set to +true+, the credentials exist and are valid.
+          #     If set to `true`, the credentials exist and are valid.
           class CheckValidCredsResponse; end
 
           # A request to schedule transfer runs for a time range.
           # @!attribute [rw] parent
           #   @return [String]
           #     Transfer configuration name in the form:
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
+          #     `projects/{project_id}/transferConfigs/{config_id}`.
           # @!attribute [rw] start_time
           #   @return [Google::Protobuf::Timestamp]
           #     Start time of the range of transfer runs. For example,
-          #     +"2017-05-25T00:00:00+00:00"+.
+          #     `"2017-05-25T00:00:00+00:00"`.
           # @!attribute [rw] end_time
           #   @return [Google::Protobuf::Timestamp]
           #     End time of the range of transfer runs. For example,
-          #     +"2017-05-30T00:00:00+00:00"+.
+          #     `"2017-05-30T00:00:00+00:00"`.
           class ScheduleTransferRunsRequest; end
 
           # A response to schedule transfer runs for a time range.

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/cloud/bigquery/datatransfer/v1/transfer.rb
@@ -20,16 +20,16 @@ module Google
         module V1
           # Represents a data transfer configuration. A transfer configuration
           # contains all metadata needed to perform a data transfer. For example,
-          # +destination_dataset_id+ specifies where data should be stored.
+          # `destination_dataset_id` specifies where data should be stored.
           # When a new transfer configuration is created, the specified
-          # +destination_dataset_id+ is created when needed and shared with the
+          # `destination_dataset_id` is created when needed and shared with the
           # appropriate data source service account.
           # @!attribute [rw] name
           #   @return [String]
           #     The resource name of the transfer config.
           #     Transfer config names have the form
-          #     +projects/\\{project_id}/transferConfigs/\\{config_id}+.
-          #     Where +config_id+ is usually a uuid, even though it is not
+          #     `projects/{project_id}/transferConfigs/{config_id}`.
+          #     Where `config_id` is usually a uuid, even though it is not
           #     guaranteed or required. The name is ignored when creating a transfer
           #     config.
           # @!attribute [rw] destination_dataset_id
@@ -52,16 +52,16 @@ module Google
           #     used.
           #     The specified times are in UTC.
           #     Examples of valid format:
-          #     +1st,3rd monday of month 15:30+,
-          #     +every wed,fri of jan,jun 13:15+, and
-          #     +first sunday of quarter 00:00+.
+          #     `1st,3rd monday of month 15:30`,
+          #     `every wed,fri of jan,jun 13:15`, and
+          #     `first sunday of quarter 00:00`.
           #     See more explanation about the format here:
           #     https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml#the_schedule_format
           #     NOTE: the granularity should be at least 8 hours, or less frequent.
           # @!attribute [rw] data_refresh_window_days
           #   @return [Integer]
           #     The number of days to look back to automatically refresh the data.
-          #     For example, if +data_refresh_window_days = 10+, then every day
+          #     For example, if `data_refresh_window_days = 10`, then every day
           #     BigQuery reingests data for [today-10, today-1], rather than ingesting data
           #     for just [today-1].
           #     Only valid if the data source supports the feature. Set the value to  0
@@ -96,7 +96,7 @@ module Google
           #   @return [String]
           #     The resource name of the transfer run.
           #     Transfer run names have the form
-          #     +projects/\\{project_id}/locations/\\{location}/transferConfigs/\\{config_id}/runs/\\{run_id}+.
+          #     `projects/{project_id}/locations/{location}/transferConfigs/{config_id}/runs/{run_id}`.
           #     The name is ignored when creating a transfer run.
           # @!attribute [rw] schedule_time
           #   @return [Google::Protobuf::Timestamp]
@@ -144,7 +144,7 @@ module Google
           #     created as part of a regular schedule. For batch transfer runs that are
           #     scheduled manually, this is empty.
           #     NOTE: the system might choose to delay the schedule depending on the
-          #     current load, so +schedule_time+ doesn't always matches this.
+          #     current load, so `schedule_time` doesn't always matches this.
           class TransferRun; end
 
           # Represents a user facing message for a particular data transfer run.

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/struct.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/rpc/status.rb
+++ b/google-cloud-bigquery-data_transfer/lib/google/cloud/bigquery/data_transfer/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-bigquery-data_transfer/synth.py
+++ b/google-cloud-bigquery-data_transfer/synth.py
@@ -59,10 +59,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_instance_admin_client.rb
@@ -444,21 +444,21 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the project in which to create the new instance.
-            #   Values are of the form +projects/<project>+.
+            #   Values are of the form `projects/<project>`.
             # @param instance_id [String]
             #   The ID to be used when referring to the new instance within its project,
-            #   e.g., just +myinstance+ rather than
-            #   +projects/myproject/instances/myinstance+.
+            #   e.g., just `myinstance` rather than
+            #   `projects/myproject/instances/myinstance`.
             # @param instance [Google::Bigtable::Admin::V2::Instance | Hash]
             #   The instance to create.
-            #   Fields marked +OutputOnly+ must be left blank.
+            #   Fields marked `OutputOnly` must be left blank.
             #   A hash of the same form as `Google::Bigtable::Admin::V2::Instance`
             #   can also be provided.
             # @param clusters [Hash{String => Google::Bigtable::Admin::V2::Cluster | Hash}]
             #   The clusters to be created within the instance, mapped by desired
-            #   cluster ID, e.g., just +mycluster+ rather than
-            #   +projects/myproject/instances/myinstance/clusters/mycluster+.
-            #   Fields marked +OutputOnly+ must be left blank.
+            #   cluster ID, e.g., just `mycluster` rather than
+            #   `projects/myproject/instances/myinstance/clusters/mycluster`.
+            #   Fields marked `OutputOnly` must be left blank.
             #   Currently, at most two clusters can be specified.
             #   A hash of the same form as `Google::Bigtable::Admin::V2::Cluster`
             #   can also be provided.
@@ -473,13 +473,13 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.project_path("[PROJECT]")
             #
-            #   # TODO: Initialize +instance_id+:
+            #   # TODO: Initialize `instance_id`:
             #   instance_id = ''
             #
-            #   # TODO: Initialize +instance+:
+            #   # TODO: Initialize `instance`:
             #   instance = {}
             #
-            #   # TODO: Initialize +clusters+:
+            #   # TODO: Initialize `clusters`:
             #   clusters = {}
             #
             #   # Register a callback during the method call.
@@ -537,7 +537,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the requested instance. Values are of the form
-            #   +projects/<project>/instances/<instance>+.
+            #   `projects/<project>/instances/<instance>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -568,7 +568,7 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the project for which a list of instances is requested.
-            #   Values are of the form +projects/<project>+.
+            #   Values are of the form `projects/<project>`.
             # @param page_token [String]
             #   DEPRECATED: This field is unused and ignored.
             # @param options [Google::Gax::CallOptions]
@@ -602,15 +602,15 @@ module Google
             # Updates an instance within a project.
             #
             # @param name [String]
-            #   (+OutputOnly+)
+            #   (`OutputOnly`)
             #   The unique name of the instance. Values are of the form
-            #   +projects/<project>/instances/[a-z][a-z0-9\\-]+[a-z0-9]+.
+            #   `projects/<project>/instances/[a-z][a-z0-9\\-]+[a-z0-9]`.
             # @param display_name [String]
             #   The descriptive name for this instance as it appears in UIs.
             #   Can be changed at any time, but should be kept globally unique
             #   to avoid confusion.
             # @param type [Google::Bigtable::Admin::V2::Instance::Type]
-            #   The type of the instance. Defaults to +PRODUCTION+.
+            #   The type of the instance. Defaults to `PRODUCTION`.
             # @param labels [Hash{String => String}]
             #   Labels are a flexible and lightweight mechanism for organizing cloud
             #   resources into groups that reflect a customer's organizational needs and
@@ -618,13 +618,13 @@ module Google
             #   metrics.
             #
             #   * Label keys must be between 1 and 63 characters long and must conform to
-            #     the regular expression: +[\p\\{Ll}\p\\{Lo}][\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,62}+.
+            #     the regular expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`.
             #   * Label values must be between 0 and 63 characters long and must conform to
-            #     the regular expression: +[\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,63}+.
+            #     the regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`.
             #   * No more than 64 labels can be associated with a given resource.
             #   * Keys and values must both be under 128 bytes.
             # @param state [Google::Bigtable::Admin::V2::Instance::State]
-            #   (+OutputOnly+)
+            #   (`OutputOnly`)
             #   The current state of the instance.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
@@ -640,13 +640,13 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +display_name+:
+            #   # TODO: Initialize `display_name`:
             #   display_name = ''
             #
-            #   # TODO: Initialize +type+:
+            #   # TODO: Initialize `type`:
             #   type = :TYPE_UNSPECIFIED
             #
-            #   # TODO: Initialize +labels+:
+            #   # TODO: Initialize `labels`:
             #   labels = {}
             #   response = bigtable_instance_admin_client.update_instance(formatted_name, display_name, type, labels)
 
@@ -690,10 +690,10 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #
-            #   # TODO: Initialize +instance+:
+            #   # TODO: Initialize `instance`:
             #   instance = {}
             #
-            #   # TODO: Initialize +update_mask+:
+            #   # TODO: Initialize `update_mask`:
             #   update_mask = {}
             #
             #   # Register a callback during the method call.
@@ -747,7 +747,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the instance to be deleted.
-            #   Values are of the form +projects/<project>/instances/<instance>+.
+            #   Values are of the form `projects/<project>/instances/<instance>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -779,14 +779,14 @@ module Google
             # @param parent [String]
             #   The unique name of the instance in which to create the new cluster.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>+.
+            #   `projects/<project>/instances/<instance>`.
             # @param cluster_id [String]
             #   The ID to be used when referring to the new cluster within its instance,
-            #   e.g., just +mycluster+ rather than
-            #   +projects/myproject/instances/myinstance/clusters/mycluster+.
+            #   e.g., just `mycluster` rather than
+            #   `projects/myproject/instances/myinstance/clusters/mycluster`.
             # @param cluster [Google::Bigtable::Admin::V2::Cluster | Hash]
             #   The cluster to be created.
-            #   Fields marked +OutputOnly+ must be left blank.
+            #   Fields marked `OutputOnly` must be left blank.
             #   A hash of the same form as `Google::Bigtable::Admin::V2::Cluster`
             #   can also be provided.
             # @param options [Google::Gax::CallOptions]
@@ -800,10 +800,10 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +cluster_id+:
+            #   # TODO: Initialize `cluster_id`:
             #   cluster_id = ''
             #
-            #   # TODO: Initialize +cluster+:
+            #   # TODO: Initialize `cluster`:
             #   cluster = {}
             #
             #   # Register a callback during the method call.
@@ -859,7 +859,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the requested cluster. Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -890,9 +890,9 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the instance for which a list of clusters is requested.
-            #   Values are of the form +projects/<project>/instances/<instance>+.
-            #   Use +<instance> = '-'+ to list Clusters for all Instances in a project,
-            #   e.g., +projects/myproject/instances/-+.
+            #   Values are of the form `projects/<project>/instances/<instance>`.
+            #   Use `<instance> = '-'` to list Clusters for all Instances in a project,
+            #   e.g., `projects/myproject/instances/-`.
             # @param page_token [String]
             #   DEPRECATED: This field is unused and ignored.
             # @param options [Google::Gax::CallOptions]
@@ -926,23 +926,23 @@ module Google
             # Updates a cluster within an instance.
             #
             # @param name [String]
-            #   (+OutputOnly+)
+            #   (`OutputOnly`)
             #   The unique name of the cluster. Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*+.
+            #   `projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*`.
             # @param serve_nodes [Integer]
             #   The number of nodes allocated to this cluster. More nodes enable higher
             #   throughput and more consistent performance.
             # @param location [String]
-            #   (+CreationOnly+)
+            #   (`CreationOnly`)
             #   The location where this cluster's nodes and storage reside. For best
             #   performance, clients should be located as close as possible to this
             #   cluster. Currently only zones are supported, so values should be of the
-            #   form +projects/<project>/locations/<zone>+.
+            #   form `projects/<project>/locations/<zone>`.
             # @param state [Google::Bigtable::Admin::V2::Cluster::State]
-            #   (+OutputOnly+)
+            #   (`OutputOnly`)
             #   The current state of the cluster.
             # @param default_storage_type [Google::Bigtable::Admin::V2::StorageType]
-            #   (+CreationOnly+)
+            #   (`CreationOnly`)
             #   The type of storage used by this cluster to serve its
             #   parent instance's tables, unless explicitly overridden.
             # @param options [Google::Gax::CallOptions]
@@ -956,7 +956,7 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.cluster_path("[PROJECT]", "[INSTANCE]", "[CLUSTER]")
             #
-            #   # TODO: Initialize +serve_nodes+:
+            #   # TODO: Initialize `serve_nodes`:
             #   serve_nodes = 0
             #
             #   # Register a callback during the method call.
@@ -1016,7 +1016,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the cluster to be deleted. Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -1048,14 +1048,14 @@ module Google
             # @param parent [String]
             #   The unique name of the instance in which to create the new app profile.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>+.
+            #   `projects/<project>/instances/<instance>`.
             # @param app_profile_id [String]
             #   The ID to be used when referring to the new app profile within its
-            #   instance, e.g., just +myprofile+ rather than
-            #   +projects/myproject/instances/myinstance/appProfiles/myprofile+.
+            #   instance, e.g., just `myprofile` rather than
+            #   `projects/myproject/instances/myinstance/appProfiles/myprofile`.
             # @param app_profile [Google::Bigtable::Admin::V2::AppProfile | Hash]
             #   The app profile to be created.
-            #   Fields marked +OutputOnly+ will be ignored.
+            #   Fields marked `OutputOnly` will be ignored.
             #   A hash of the same form as `Google::Bigtable::Admin::V2::AppProfile`
             #   can also be provided.
             # @param ignore_warnings [true, false]
@@ -1074,10 +1074,10 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +app_profile_id+:
+            #   # TODO: Initialize `app_profile_id`:
             #   app_profile_id = ''
             #
-            #   # TODO: Initialize +app_profile+:
+            #   # TODO: Initialize `app_profile`:
             #   app_profile = {}
             #   response = bigtable_instance_admin_client.create_app_profile(formatted_parent, app_profile_id, app_profile)
 
@@ -1102,7 +1102,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the requested app profile. Values are of the form
-            #   +projects/<project>/instances/<instance>/appProfiles/<app_profile>+.
+            #   `projects/<project>/instances/<instance>/appProfiles/<app_profile>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -1134,9 +1134,9 @@ module Google
             # @param parent [String]
             #   The unique name of the instance for which a list of app profiles is
             #   requested. Values are of the form
-            #   +projects/<project>/instances/<instance>+.
-            #   Use +<instance> = '-'+ to list AppProfiles for all Instances in a project,
-            #   e.g., +projects/myproject/instances/-+.
+            #   `projects/<project>/instances/<instance>`.
+            #   Use `<instance> = '-'` to list AppProfiles for all Instances in a project,
+            #   e.g., `projects/myproject/instances/-`.
             # @param page_size [Integer]
             #   Maximum number of results per page.
             #   CURRENTLY UNIMPLEMENTED AND IGNORED.
@@ -1207,10 +1207,10 @@ module Google
             #
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #
-            #   # TODO: Initialize +app_profile+:
+            #   # TODO: Initialize `app_profile`:
             #   app_profile = {}
             #
-            #   # TODO: Initialize +update_mask+:
+            #   # TODO: Initialize `update_mask`:
             #   update_mask = {}
             #
             #   # Register a callback during the method call.
@@ -1266,7 +1266,7 @@ module Google
             #
             # @param name [String]
             #   The unique name of the app profile to be deleted. Values are of the form
-            #   +projects/<project>/instances/<instance>/appProfiles/<app_profile>+.
+            #   `projects/<project>/instances/<instance>/appProfiles/<app_profile>`.
             # @param ignore_warnings [true, false]
             #   If true, ignore safety checks when deleting the app profile.
             # @param options [Google::Gax::CallOptions]
@@ -1282,7 +1282,7 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.app_profile_path("[PROJECT]", "[INSTANCE]", "[APP_PROFILE]")
             #
-            #   # TODO: Initialize +ignore_warnings+:
+            #   # TODO: Initialize `ignore_warnings`:
             #   ignore_warnings = false
             #   bigtable_instance_admin_client.delete_app_profile(formatted_name, ignore_warnings)
 
@@ -1305,8 +1305,8 @@ module Google
             #
             # @param resource [String]
             #   REQUIRED: The resource for which the policy is being requested.
-            #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/\\{project}+.
+            #   `resource` is usually specified as a path. For example, a Project
+            #   resource is specified as `projects/{project}`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -1338,10 +1338,10 @@ module Google
             #
             # @param resource [String]
             #   REQUIRED: The resource for which the policy is being specified.
-            #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/\\{project}+.
+            #   `resource` is usually specified as a path. For example, a Project
+            #   resource is specified as `projects/{project}`.
             # @param policy [Google::Iam::V1::Policy | Hash]
-            #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+            #   REQUIRED: The complete policy to be applied to the `resource`. The size of
             #   the policy is limited to a few 10s of KB. An empty policy is a
             #   valid policy but certain Cloud Platform services (such as Projects)
             #   might reject them.
@@ -1361,7 +1361,7 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_resource = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +policy+:
+            #   # TODO: Initialize `policy`:
             #   policy = {}
             #   response = bigtable_instance_admin_client.set_iam_policy(formatted_resource, policy)
 
@@ -1382,10 +1382,10 @@ module Google
             #
             # @param resource [String]
             #   REQUIRED: The resource for which the policy detail is being requested.
-            #   +resource+ is usually specified as a path. For example, a Project
-            #   resource is specified as +projects/\\{project}+.
+            #   `resource` is usually specified as a path. For example, a Project
+            #   resource is specified as `projects/{project}`.
             # @param permissions [Array<String>]
-            #   The set of permissions to check for the +resource+. Permissions with
+            #   The set of permissions to check for the `resource`. Permissions with
             #   wildcards (such as '*' or 'storage.*') are not allowed. For more
             #   information see
             #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -1403,7 +1403,7 @@ module Google
             #   bigtable_instance_admin_client = Google::Cloud::Bigtable::Admin::BigtableInstanceAdmin.new(version: :v2)
             #   formatted_resource = Google::Cloud::Bigtable::Admin::V2::BigtableInstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +permissions+:
+            #   # TODO: Initialize `permissions`:
             #   permissions = []
             #   response = bigtable_instance_admin_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/bigtable_table_admin_client.rb
@@ -393,10 +393,10 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the instance in which to create the table.
-            #   Values are of the form +projects/<project>/instances/<instance>+.
+            #   Values are of the form `projects/<project>/instances/<instance>`.
             # @param table_id [String]
             #   The name by which the new table should be referred to within the parent
-            #   instance, e.g., +foobar+ rather than +<parent>/tables/foobar+.
+            #   instance, e.g., `foobar` rather than `<parent>/tables/foobar`.
             # @param table [Google::Bigtable::Admin::V2::Table | Hash]
             #   The Table to create.
             #   A hash of the same form as `Google::Bigtable::Admin::V2::Table`
@@ -404,20 +404,20 @@ module Google
             # @param initial_splits [Array<Google::Bigtable::Admin::V2::CreateTableRequest::Split | Hash>]
             #   The optional list of row keys that will be used to initially split the
             #   table into several tablets (tablets are similar to HBase regions).
-            #   Given two split keys, +s1+ and +s2+, three tablets will be created,
-            #   spanning the key ranges: +[, s1), [s1, s2), [s2, )+.
+            #   Given two split keys, `s1` and `s2`, three tablets will be created,
+            #   spanning the key ranges: `[, s1), [s1, s2), [s2, )`.
             #
             #   Example:
             #
-            #   * Row keys := +["a", "apple", "custom", "customer_1", "customer_2",+
-            #     +"other", "zz"]+
-            #   * initial_split_keys := +["apple", "customer_1", "customer_2", "other"]+
+            #   * Row keys := `["a", "apple", "custom", "customer_1", "customer_2",`
+            #     `"other", "zz"]`
+            #   * initial_split_keys := `["apple", "customer_1", "customer_2", "other"]`
             #   * Key assignment:
-            #     * Tablet 1 +[, apple)                => {"a"}.+
-            #       * Tablet 2 +[apple, customer_1)      => {"apple", "custom"}.+
-            #       * Tablet 3 +[customer_1, customer_2) => {"customer_1"}.+
-            #       * Tablet 4 +[customer_2, other)      => {"customer_2"}.+
-            #       * Tablet 5 +[other, )                => {"other", "zz"}.+
+            #     * Tablet 1 `[, apple)                => {"a"}.`
+            #       * Tablet 2 `[apple, customer_1)      => {"apple", "custom"}.`
+            #       * Tablet 3 `[customer_1, customer_2) => {"customer_1"}.`
+            #       * Tablet 4 `[customer_2, other)      => {"customer_2"}.`
+            #       * Tablet 5 `[other, )                => {"other", "zz"}.`
             #   A hash of the same form as `Google::Bigtable::Admin::V2::CreateTableRequest::Split`
             #   can also be provided.
             # @param options [Google::Gax::CallOptions]
@@ -434,10 +434,10 @@ module Google
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +table_id+:
+            #   # TODO: Initialize `table_id`:
             #   table_id = ''
             #
-            #   # TODO: Initialize +table+:
+            #   # TODO: Initialize `table`:
             #   table = {}
             #   response = bigtable_table_admin_client.create_table(formatted_parent, table_id, table)
 
@@ -469,15 +469,15 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the instance in which to create the table.
-            #   Values are of the form +projects/<project>/instances/<instance>+.
+            #   Values are of the form `projects/<project>/instances/<instance>`.
             # @param table_id [String]
             #   The name by which the new table should be referred to within the parent
-            #   instance, e.g., +foobar+ rather than +<parent>/tables/foobar+.
+            #   instance, e.g., `foobar` rather than `<parent>/tables/foobar`.
             # @param source_snapshot [String]
             #   The unique name of the snapshot from which to restore the table. The
             #   snapshot and the table must be in the same instance.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -489,10 +489,10 @@ module Google
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
             #   formatted_parent = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
             #
-            #   # TODO: Initialize +table_id+:
+            #   # TODO: Initialize `table_id`:
             #   table_id = ''
             #
-            #   # TODO: Initialize +source_snapshot+:
+            #   # TODO: Initialize `source_snapshot`:
             #   source_snapshot = ''
             #
             #   # Register a callback during the method call.
@@ -548,10 +548,10 @@ module Google
             #
             # @param parent [String]
             #   The unique name of the instance for which tables should be listed.
-            #   Values are of the form +projects/<project>/instances/<instance>+.
+            #   Values are of the form `projects/<project>/instances/<instance>`.
             # @param view [Google::Bigtable::Admin::V2::Table::View]
             #   The view to be applied to the returned tables' fields.
-            #   Defaults to +NAME_ONLY+ if unspecified; no others are currently supported.
+            #   Defaults to `NAME_ONLY` if unspecified; no others are currently supported.
             # @param page_size [Integer]
             #   Maximum number of results per page.
             #   CURRENTLY UNIMPLEMENTED AND IGNORED.
@@ -606,10 +606,10 @@ module Google
             # @param name [String]
             #   The unique name of the requested table.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param view [Google::Bigtable::Admin::V2::Table::View]
             #   The view to be applied to the returned table's fields.
-            #   Defaults to +SCHEMA_VIEW+ if unspecified.
+            #   Defaults to `SCHEMA_VIEW` if unspecified.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -643,7 +643,7 @@ module Google
             # @param name [String]
             #   The unique name of the table to be deleted.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -678,7 +678,7 @@ module Google
             # @param name [String]
             #   The unique name of the table whose families should be modified.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param modifications [Array<Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification | Hash>]
             #   Modifications to be atomically applied to the specified table's families.
             #   Entries are applied in order, meaning that earlier modifications can be
@@ -700,7 +700,7 @@ module Google
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
             #
-            #   # TODO: Initialize +modifications+:
+            #   # TODO: Initialize `modifications`:
             #   modifications = []
             #   response = bigtable_table_admin_client.modify_column_families(formatted_name, modifications)
 
@@ -724,7 +724,7 @@ module Google
             # @param name [String]
             #   The unique name of the table on which to drop a range of rows.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param row_key_prefix [String]
             #   Delete all rows that start with this row key prefix. Prefix cannot be
             #   zero length.
@@ -768,7 +768,7 @@ module Google
             # @param name [String]
             #   The unique name of the Table for which to create a consistency token.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -802,7 +802,7 @@ module Google
             # @param name [String]
             #   The unique name of the Table for which to check replication consistency.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param consistency_token [String]
             #   The token created using GenerateConsistencyToken for the Table.
             # @param options [Google::Gax::CallOptions]
@@ -819,7 +819,7 @@ module Google
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
             #
-            #   # TODO: Initialize +consistency_token+:
+            #   # TODO: Initialize `consistency_token`:
             #   consistency_token = ''
             #   response = bigtable_table_admin_client.check_consistency(formatted_name, consistency_token)
 
@@ -848,16 +848,16 @@ module Google
             # @param name [String]
             #   The unique name of the table to have the snapshot taken.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/tables/<table>+.
+            #   `projects/<project>/instances/<instance>/tables/<table>`.
             # @param cluster [String]
             #   The name of the cluster where the snapshot will be created in.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>`.
             # @param snapshot_id [String]
             #   The ID by which the new snapshot should be referred to within the parent
-            #   cluster, e.g., +mysnapshot+ of the form: +[_a-zA-Z0-9][-_.a-zA-Z0-9]*+
+            #   cluster, e.g., `mysnapshot` of the form: `[_a-zA-Z0-9][-_.a-zA-Z0-9]*`
             #   rather than
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/mysnapshot+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/mysnapshot`.
             # @param description [String]
             #   Description of the snapshot.
             # @param ttl [Google::Protobuf::Duration | Hash]
@@ -878,13 +878,13 @@ module Google
             #   bigtable_table_admin_client = Google::Cloud::Bigtable::Admin::BigtableTableAdmin.new(version: :v2)
             #   formatted_name = Google::Cloud::Bigtable::Admin::V2::BigtableTableAdminClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
             #
-            #   # TODO: Initialize +cluster+:
+            #   # TODO: Initialize `cluster`:
             #   cluster = ''
             #
-            #   # TODO: Initialize +snapshot_id+:
+            #   # TODO: Initialize `snapshot_id`:
             #   snapshot_id = ''
             #
-            #   # TODO: Initialize +description+:
+            #   # TODO: Initialize `description`:
             #   description = ''
             #
             #   # Register a callback during the method call.
@@ -951,7 +951,7 @@ module Google
             # @param name [String]
             #   The unique name of the requested snapshot.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.
@@ -989,9 +989,9 @@ module Google
             # @param parent [String]
             #   The unique name of the cluster for which snapshots should be listed.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>+.
-            #   Use +<cluster> = '-'+ to list snapshots for all clusters in an instance,
-            #   e.g., +projects/<project>/instances/<instance>/clusters/-+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>`.
+            #   Use `<cluster> = '-'` to list snapshots for all clusters in an instance,
+            #   e.g., `projects/<project>/instances/<instance>/clusters/-`.
             # @param page_size [Integer]
             #   The maximum number of resources contained in the underlying API
             #   response. If page streaming is performed per-resource, this
@@ -1053,7 +1053,7 @@ module Google
             # @param name [String]
             #   The unique name of the snapshot to be deleted.
             #   Values are of the form
-            #   +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+            #   `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
             # @param options [Google::Gax::CallOptions]
             #   Overrides the default settings for this call, e.g, timeout,
             #   retries, etc.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_instance_admin.rb
@@ -21,22 +21,22 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the project in which to create the new instance.
-        #     Values are of the form +projects/<project>+.
+        #     Values are of the form `projects/<project>`.
         # @!attribute [rw] instance_id
         #   @return [String]
         #     The ID to be used when referring to the new instance within its project,
-        #     e.g., just +myinstance+ rather than
-        #     +projects/myproject/instances/myinstance+.
+        #     e.g., just `myinstance` rather than
+        #     `projects/myproject/instances/myinstance`.
         # @!attribute [rw] instance
         #   @return [Google::Bigtable::Admin::V2::Instance]
         #     The instance to create.
-        #     Fields marked +OutputOnly+ must be left blank.
+        #     Fields marked `OutputOnly` must be left blank.
         # @!attribute [rw] clusters
         #   @return [Hash{String => Google::Bigtable::Admin::V2::Cluster}]
         #     The clusters to be created within the instance, mapped by desired
-        #     cluster ID, e.g., just +mycluster+ rather than
-        #     +projects/myproject/instances/myinstance/clusters/mycluster+.
-        #     Fields marked +OutputOnly+ must be left blank.
+        #     cluster ID, e.g., just `mycluster` rather than
+        #     `projects/myproject/instances/myinstance/clusters/mycluster`.
+        #     Fields marked `OutputOnly` must be left blank.
         #     Currently, at most two clusters can be specified.
         class CreateInstanceRequest; end
 
@@ -44,14 +44,14 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the requested instance. Values are of the form
-        #     +projects/<project>/instances/<instance>+.
+        #     `projects/<project>/instances/<instance>`.
         class GetInstanceRequest; end
 
         # Request message for BigtableInstanceAdmin.ListInstances.
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the project for which a list of instances is requested.
-        #     Values are of the form +projects/<project>+.
+        #     Values are of the form `projects/<project>`.
         # @!attribute [rw] page_token
         #   @return [String]
         #     DEPRECATED: This field is unused and ignored.
@@ -66,9 +66,9 @@ module Google
         #     Locations from which Instance information could not be retrieved,
         #     due to an outage or some other transient condition.
         #     Instances whose Clusters are all in one of the failed locations
-        #     may be missing from +instances+, and Instances with at least one
+        #     may be missing from `instances`, and Instances with at least one
         #     Cluster in a failed location may only have partial information returned.
-        #     Values are of the form +projects/<project>/locations/<zone_id>+
+        #     Values are of the form `projects/<project>/locations/<zone_id>`
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     DEPRECATED: This field is unused and ignored.
@@ -88,7 +88,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the instance to be deleted.
-        #     Values are of the form +projects/<project>/instances/<instance>+.
+        #     Values are of the form `projects/<project>/instances/<instance>`.
         class DeleteInstanceRequest; end
 
         # Request message for BigtableInstanceAdmin.CreateCluster.
@@ -96,32 +96,32 @@ module Google
         #   @return [String]
         #     The unique name of the instance in which to create the new cluster.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>+.
+        #     `projects/<project>/instances/<instance>`.
         # @!attribute [rw] cluster_id
         #   @return [String]
         #     The ID to be used when referring to the new cluster within its instance,
-        #     e.g., just +mycluster+ rather than
-        #     +projects/myproject/instances/myinstance/clusters/mycluster+.
+        #     e.g., just `mycluster` rather than
+        #     `projects/myproject/instances/myinstance/clusters/mycluster`.
         # @!attribute [rw] cluster
         #   @return [Google::Bigtable::Admin::V2::Cluster]
         #     The cluster to be created.
-        #     Fields marked +OutputOnly+ must be left blank.
+        #     Fields marked `OutputOnly` must be left blank.
         class CreateClusterRequest; end
 
         # Request message for BigtableInstanceAdmin.GetCluster.
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the requested cluster. Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>`.
         class GetClusterRequest; end
 
         # Request message for BigtableInstanceAdmin.ListClusters.
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the instance for which a list of clusters is requested.
-        #     Values are of the form +projects/<project>/instances/<instance>+.
-        #     Use +<instance> = '-'+ to list Clusters for all Instances in a project,
-        #     e.g., +projects/myproject/instances/-+.
+        #     Values are of the form `projects/<project>/instances/<instance>`.
+        #     Use `<instance> = '-'` to list Clusters for all Instances in a project,
+        #     e.g., `projects/myproject/instances/-`.
         # @!attribute [rw] page_token
         #   @return [String]
         #     DEPRECATED: This field is unused and ignored.
@@ -135,9 +135,9 @@ module Google
         #   @return [Array<String>]
         #     Locations from which Cluster information could not be retrieved,
         #     due to an outage or some other transient condition.
-        #     Clusters from these locations may be missing from +clusters+,
+        #     Clusters from these locations may be missing from `clusters`,
         #     or may only have partial information returned.
-        #     Values are of the form +projects/<project>/locations/<zone_id>+
+        #     Values are of the form `projects/<project>/locations/<zone_id>`
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     DEPRECATED: This field is unused and ignored.
@@ -147,7 +147,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the cluster to be deleted. Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>`.
         class DeleteClusterRequest; end
 
         # The metadata for the Operation returned by CreateInstance.
@@ -203,16 +203,16 @@ module Google
         #   @return [String]
         #     The unique name of the instance in which to create the new app profile.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>+.
+        #     `projects/<project>/instances/<instance>`.
         # @!attribute [rw] app_profile_id
         #   @return [String]
         #     The ID to be used when referring to the new app profile within its
-        #     instance, e.g., just +myprofile+ rather than
-        #     +projects/myproject/instances/myinstance/appProfiles/myprofile+.
+        #     instance, e.g., just `myprofile` rather than
+        #     `projects/myproject/instances/myinstance/appProfiles/myprofile`.
         # @!attribute [rw] app_profile
         #   @return [Google::Bigtable::Admin::V2::AppProfile]
         #     The app profile to be created.
-        #     Fields marked +OutputOnly+ will be ignored.
+        #     Fields marked `OutputOnly` will be ignored.
         # @!attribute [rw] ignore_warnings
         #   @return [true, false]
         #     If true, ignore safety checks when creating the app profile.
@@ -222,7 +222,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the requested app profile. Values are of the form
-        #     +projects/<project>/instances/<instance>/appProfiles/<app_profile>+.
+        #     `projects/<project>/instances/<instance>/appProfiles/<app_profile>`.
         class GetAppProfileRequest; end
 
         # Request message for BigtableInstanceAdmin.ListAppProfiles.
@@ -230,16 +230,16 @@ module Google
         #   @return [String]
         #     The unique name of the instance for which a list of app profiles is
         #     requested. Values are of the form
-        #     +projects/<project>/instances/<instance>+.
-        #     Use +<instance> = '-'+ to list AppProfiles for all Instances in a project,
-        #     e.g., +projects/myproject/instances/-+.
+        #     `projects/<project>/instances/<instance>`.
+        #     Use `<instance> = '-'` to list AppProfiles for all Instances in a project,
+        #     e.g., `projects/myproject/instances/-`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Maximum number of results per page.
         #     CURRENTLY UNIMPLEMENTED AND IGNORED.
         # @!attribute [rw] page_token
         #   @return [String]
-        #     The value of +next_page_token+ returned by a previous call.
+        #     The value of `next_page_token` returned by a previous call.
         class ListAppProfilesRequest; end
 
         # Response message for BigtableInstanceAdmin.ListAppProfiles.
@@ -249,14 +249,14 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Set if not all app profiles could be returned in a single response.
-        #     Pass this value to +page_token+ in another request to get the next
+        #     Pass this value to `page_token` in another request to get the next
         #     page of results.
         # @!attribute [rw] failed_locations
         #   @return [Array<String>]
         #     Locations from which AppProfile information could not be retrieved,
         #     due to an outage or some other transient condition.
-        #     AppProfiles from these locations may be missing from +app_profiles+.
-        #     Values are of the form +projects/<project>/locations/<zone_id>+
+        #     AppProfiles from these locations may be missing from `app_profiles`.
+        #     Values are of the form `projects/<project>/locations/<zone_id>`
         class ListAppProfilesResponse; end
 
         # Request message for BigtableInstanceAdmin.UpdateAppProfile.
@@ -276,7 +276,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The unique name of the app profile to be deleted. Values are of the form
-        #     +projects/<project>/instances/<instance>/appProfiles/<app_profile>+.
+        #     `projects/<project>/instances/<instance>/appProfiles/<app_profile>`.
         # @!attribute [rw] ignore_warnings
         #   @return [true, false]
         #     If true, ignore safety checks when deleting the app profile.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/bigtable_table_admin.rb
@@ -22,11 +22,11 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the instance in which to create the table.
-        #     Values are of the form +projects/<project>/instances/<instance>+.
+        #     Values are of the form `projects/<project>/instances/<instance>`.
         # @!attribute [rw] table_id
         #   @return [String]
         #     The name by which the new table should be referred to within the parent
-        #     instance, e.g., +foobar+ rather than +<parent>/tables/foobar+.
+        #     instance, e.g., `foobar` rather than `<parent>/tables/foobar`.
         # @!attribute [rw] table
         #   @return [Google::Bigtable::Admin::V2::Table]
         #     The Table to create.
@@ -34,20 +34,20 @@ module Google
         #   @return [Array<Google::Bigtable::Admin::V2::CreateTableRequest::Split>]
         #     The optional list of row keys that will be used to initially split the
         #     table into several tablets (tablets are similar to HBase regions).
-        #     Given two split keys, +s1+ and +s2+, three tablets will be created,
-        #     spanning the key ranges: +[, s1), [s1, s2), [s2, )+.
+        #     Given two split keys, `s1` and `s2`, three tablets will be created,
+        #     spanning the key ranges: `[, s1), [s1, s2), [s2, )`.
         #
         #     Example:
         #
-        #     * Row keys := +["a", "apple", "custom", "customer_1", "customer_2",+
-        #       +"other", "zz"]+
-        #     * initial_split_keys := +["apple", "customer_1", "customer_2", "other"]+
+        #     * Row keys := `["a", "apple", "custom", "customer_1", "customer_2",`
+        #       `"other", "zz"]`
+        #     * initial_split_keys := `["apple", "customer_1", "customer_2", "other"]`
         #     * Key assignment:
-        #       * Tablet 1 +[, apple)                => {"a"}.+
-        #         * Tablet 2 +[apple, customer_1)      => {"apple", "custom"}.+
-        #         * Tablet 3 +[customer_1, customer_2) => {"customer_1"}.+
-        #         * Tablet 4 +[customer_2, other)      => {"customer_2"}.+
-        #         * Tablet 5 +[other, )                => {"other", "zz"}.+
+        #       * Tablet 1 `[, apple)                => {"a"}.`
+        #         * Tablet 2 `[apple, customer_1)      => {"apple", "custom"}.`
+        #         * Tablet 3 `[customer_1, customer_2) => {"customer_1"}.`
+        #         * Tablet 4 `[customer_2, other)      => {"customer_2"}.`
+        #         * Tablet 5 `[other, )                => {"other", "zz"}.`
         class CreateTableRequest
           # An initial split point for a newly created table.
           # @!attribute [rw] key
@@ -66,17 +66,17 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the instance in which to create the table.
-        #     Values are of the form +projects/<project>/instances/<instance>+.
+        #     Values are of the form `projects/<project>/instances/<instance>`.
         # @!attribute [rw] table_id
         #   @return [String]
         #     The name by which the new table should be referred to within the parent
-        #     instance, e.g., +foobar+ rather than +<parent>/tables/foobar+.
+        #     instance, e.g., `foobar` rather than `<parent>/tables/foobar`.
         # @!attribute [rw] source_snapshot
         #   @return [String]
         #     The unique name of the snapshot from which to restore the table. The
         #     snapshot and the table must be in the same instance.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
         class CreateTableFromSnapshotRequest; end
 
         # Request message for
@@ -85,7 +85,7 @@ module Google
         #   @return [String]
         #     The unique name of the table on which to drop a range of rows.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         # @!attribute [rw] row_key_prefix
         #   @return [String]
         #     Delete all rows that start with this row key prefix. Prefix cannot be
@@ -100,18 +100,18 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     The unique name of the instance for which tables should be listed.
-        #     Values are of the form +projects/<project>/instances/<instance>+.
+        #     Values are of the form `projects/<project>/instances/<instance>`.
         # @!attribute [rw] view
         #   @return [Google::Bigtable::Admin::V2::Table::View]
         #     The view to be applied to the returned tables' fields.
-        #     Defaults to +NAME_ONLY+ if unspecified; no others are currently supported.
+        #     Defaults to `NAME_ONLY` if unspecified; no others are currently supported.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Maximum number of results per page.
         #     CURRENTLY UNIMPLEMENTED AND IGNORED.
         # @!attribute [rw] page_token
         #   @return [String]
-        #     The value of +next_page_token+ returned by a previous call.
+        #     The value of `next_page_token` returned by a previous call.
         class ListTablesRequest; end
 
         # Response message for
@@ -122,7 +122,7 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Set if not all tables could be returned in a single response.
-        #     Pass this value to +page_token+ in another request to get the next
+        #     Pass this value to `page_token` in another request to get the next
         #     page of results.
         class ListTablesResponse; end
 
@@ -132,11 +132,11 @@ module Google
         #   @return [String]
         #     The unique name of the requested table.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         # @!attribute [rw] view
         #   @return [Google::Bigtable::Admin::V2::Table::View]
         #     The view to be applied to the returned table's fields.
-        #     Defaults to +SCHEMA_VIEW+ if unspecified.
+        #     Defaults to `SCHEMA_VIEW` if unspecified.
         class GetTableRequest; end
 
         # Request message for
@@ -145,7 +145,7 @@ module Google
         #   @return [String]
         #     The unique name of the table to be deleted.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         class DeleteTableRequest; end
 
         # Request message for
@@ -154,7 +154,7 @@ module Google
         #   @return [String]
         #     The unique name of the table whose families should be modified.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         # @!attribute [rw] modifications
         #   @return [Array<Google::Bigtable::Admin::V2::ModifyColumnFamiliesRequest::Modification>]
         #     Modifications to be atomically applied to the specified table's families.
@@ -187,7 +187,7 @@ module Google
         #   @return [String]
         #     The unique name of the Table for which to create a consistency token.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         class GenerateConsistencyTokenRequest; end
 
         # Response message for
@@ -203,7 +203,7 @@ module Google
         #   @return [String]
         #     The unique name of the Table for which to check replication consistency.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         # @!attribute [rw] consistency_token
         #   @return [String]
         #     The token created using GenerateConsistencyToken for the Table.
@@ -228,18 +228,18 @@ module Google
         #   @return [String]
         #     The unique name of the table to have the snapshot taken.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/<table>+.
+        #     `projects/<project>/instances/<instance>/tables/<table>`.
         # @!attribute [rw] cluster
         #   @return [String]
         #     The name of the cluster where the snapshot will be created in.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>`.
         # @!attribute [rw] snapshot_id
         #   @return [String]
         #     The ID by which the new snapshot should be referred to within the parent
-        #     cluster, e.g., +mysnapshot+ of the form: +[_a-zA-Z0-9][-_.a-zA-Z0-9]*+
+        #     cluster, e.g., `mysnapshot` of the form: `[_a-zA-Z0-9][-_.a-zA-Z0-9]*`
         #     rather than
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/mysnapshot+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/mysnapshot`.
         # @!attribute [rw] ttl
         #   @return [Google::Protobuf::Duration]
         #     The amount of time that the new snapshot can stay active after it is
@@ -262,7 +262,7 @@ module Google
         #   @return [String]
         #     The unique name of the requested snapshot.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
         class GetSnapshotRequest; end
 
         # Request message for
@@ -276,16 +276,16 @@ module Google
         #   @return [String]
         #     The unique name of the cluster for which snapshots should be listed.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>+.
-        #     Use +<cluster> = '-'+ to list snapshots for all clusters in an instance,
-        #     e.g., +projects/<project>/instances/<instance>/clusters/-+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>`.
+        #     Use `<cluster> = '-'` to list snapshots for all clusters in an instance,
+        #     e.g., `projects/<project>/instances/<instance>/clusters/-`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of snapshots to return per page.
         #     CURRENTLY UNIMPLEMENTED AND IGNORED.
         # @!attribute [rw] page_token
         #   @return [String]
-        #     The value of +next_page_token+ returned by a previous call.
+        #     The value of `next_page_token` returned by a previous call.
         class ListSnapshotsRequest; end
 
         # Response message for
@@ -301,7 +301,7 @@ module Google
         # @!attribute [rw] next_page_token
         #   @return [String]
         #     Set if not all snapshots could be returned in a single response.
-        #     Pass this value to +page_token+ in another request to get the next
+        #     Pass this value to `page_token` in another request to get the next
         #     page of results.
         class ListSnapshotsResponse; end
 
@@ -316,7 +316,7 @@ module Google
         #   @return [String]
         #     The unique name of the snapshot to be deleted.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
         class DeleteSnapshotRequest; end
 
         # The metadata for the Operation returned by SnapshotTable.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/instance.rb
@@ -23,9 +23,9 @@ module Google
         # {Google::Bigtable::Admin::V2::Cluster Cluster}.
         # @!attribute [rw] name
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The unique name of the instance. Values are of the form
-        #     +projects/<project>/instances/[a-z][a-z0-9\\-]+[a-z0-9]+.
+        #     `projects/<project>/instances/[a-z][a-z0-9\\-]+[a-z0-9]`.
         # @!attribute [rw] display_name
         #   @return [String]
         #     The descriptive name for this instance as it appears in UIs.
@@ -33,11 +33,11 @@ module Google
         #     to avoid confusion.
         # @!attribute [rw] state
         #   @return [Google::Bigtable::Admin::V2::Instance::State]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The current state of the instance.
         # @!attribute [rw] type
         #   @return [Google::Bigtable::Admin::V2::Instance::Type]
-        #     The type of the instance. Defaults to +PRODUCTION+.
+        #     The type of the instance. Defaults to `PRODUCTION`.
         # @!attribute [rw] labels
         #   @return [Hash{String => String}]
         #     Labels are a flexible and lightweight mechanism for organizing cloud
@@ -46,9 +46,9 @@ module Google
         #     metrics.
         #
         #     * Label keys must be between 1 and 63 characters long and must conform to
-        #       the regular expression: +[\p\\{Ll}\p\\{Lo}][\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,62}+.
+        #       the regular expression: `[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}`.
         #     * Label values must be between 0 and 63 characters long and must conform to
-        #       the regular expression: +[\p\\{Ll}\p\\{Lo}\p\\{N}_-]\\{0,63}+.
+        #       the regular expression: `[\p{Ll}\p{Lo}\p{N}_-]{0,63}`.
         #     * No more than 64 labels can be associated with a given resource.
         #     * Keys and values must both be under 128 bytes.
         class Instance
@@ -69,20 +69,20 @@ module Google
           # The type of the instance.
           module Type
             # The type of the instance is unspecified. If set when creating an
-            # instance, a +PRODUCTION+ instance will be created. If set when updating
+            # instance, a `PRODUCTION` instance will be created. If set when updating
             # an instance, the type will be left unchanged.
             TYPE_UNSPECIFIED = 0
 
-            # An instance meant for production use. +serve_nodes+ must be set
+            # An instance meant for production use. `serve_nodes` must be set
             # on the cluster.
             PRODUCTION = 1
 
             # The instance is meant for development and testing purposes only; it has
             # no performance or uptime guarantees and is not covered by SLA.
             # After a development instance is created, it can be upgraded by
-            # updating the instance to type +PRODUCTION+. An instance created
+            # updating the instance to type `PRODUCTION`. An instance created
             # as a production instance cannot be changed to a development instance.
-            # When creating a development instance, +serve_nodes+ on the cluster must
+            # When creating a development instance, `serve_nodes` on the cluster must
             # not be set.
             DEVELOPMENT = 2
           end
@@ -93,19 +93,19 @@ module Google
         # {Google::Bigtable::Admin::V2::Instance Instance}.
         # @!attribute [rw] name
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The unique name of the cluster. Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*+.
+        #     `projects/<project>/instances/<instance>/clusters/[a-z][-a-z0-9]*`.
         # @!attribute [rw] location
         #   @return [String]
-        #     (+CreationOnly+)
+        #     (`CreationOnly`)
         #     The location where this cluster's nodes and storage reside. For best
         #     performance, clients should be located as close as possible to this
         #     cluster. Currently only zones are supported, so values should be of the
-        #     form +projects/<project>/locations/<zone>+.
+        #     form `projects/<project>/locations/<zone>`.
         # @!attribute [rw] state
         #   @return [Google::Bigtable::Admin::V2::Cluster::State]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The current state of the cluster.
         # @!attribute [rw] serve_nodes
         #   @return [Integer]
@@ -113,7 +113,7 @@ module Google
         #     throughput and more consistent performance.
         # @!attribute [rw] default_storage_type
         #   @return [Google::Bigtable::Admin::V2::StorageType]
-        #     (+CreationOnly+)
+        #     (`CreationOnly`)
         #     The type of storage used by this cluster to serve its
         #     parent instance's tables, unless explicitly overridden.
         class Cluster
@@ -147,15 +147,15 @@ module Google
         # from a particular end user application.
         # @!attribute [rw] name
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The unique name of the app profile. Values are of the form
-        #     +projects/<project>/instances/<instance>/appProfiles/[_a-zA-Z0-9][-_.a-zA-Z0-9]*+.
+        #     `projects/<project>/instances/<instance>/appProfiles/[_a-zA-Z0-9][-_.a-zA-Z0-9]*`.
         # @!attribute [rw] etag
         #   @return [String]
         #     Strongly validated etag for optimistic concurrency control. Preserve the
-        #     value returned from +GetAppProfile+ when calling +UpdateAppProfile+ to
+        #     value returned from `GetAppProfile` when calling `UpdateAppProfile` to
         #     fail the request if there has been a modification in the mean time. The
-        #     +update_mask+ of the request need not include +etag+ for this protection
+        #     `update_mask` of the request need not include `etag` for this protection
         #     to apply.
         #     See [Wikipedia](https://en.wikipedia.org/wiki/HTTP_ETag) and
         #     [RFC 7232](https://tools.ietf.org/html/rfc7232#section-2.3) for more
@@ -184,7 +184,7 @@ module Google
           #     The cluster to which read/write requests should be routed.
           # @!attribute [rw] allow_transactional_writes
           #   @return [true, false]
-          #     Whether or not +CheckAndMutateRow+ and +ReadModifyWriteRow+ requests are
+          #     Whether or not `CheckAndMutateRow` and `ReadModifyWriteRow` requests are
           #     allowed by this app profile. It is unsafe to send these requests to
           #     the same table/row/column in multiple clusters.
           class SingleClusterRouting; end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/bigtable/admin/v2/table.rb
@@ -21,35 +21,35 @@ module Google
         # Each table is served using the resources of its parent cluster.
         # @!attribute [rw] name
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The unique name of the table. Values are of the form
-        #     +projects/<project>/instances/<instance>/tables/[_a-zA-Z0-9][-_.a-zA-Z0-9]*+.
-        #     Views: +NAME_ONLY+, +SCHEMA_VIEW+, +REPLICATION_VIEW+, +FULL+
+        #     `projects/<project>/instances/<instance>/tables/[_a-zA-Z0-9][-_.a-zA-Z0-9]*`.
+        #     Views: `NAME_ONLY`, `SCHEMA_VIEW`, `REPLICATION_VIEW`, `FULL`
         # @!attribute [rw] cluster_states
         #   @return [Hash{String => Google::Bigtable::Admin::V2::Table::ClusterState}]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     Map from cluster ID to per-cluster table state.
         #     If it could not be determined whether or not the table has data in a
         #     particular cluster (for example, if its zone is unavailable), then
-        #     there will be an entry for the cluster with UNKNOWN +replication_status+.
-        #     Views: +REPLICATION_VIEW+, +FULL+
+        #     there will be an entry for the cluster with UNKNOWN `replication_status`.
+        #     Views: `REPLICATION_VIEW`, `FULL`
         # @!attribute [rw] column_families
         #   @return [Hash{String => Google::Bigtable::Admin::V2::ColumnFamily}]
-        #     (+CreationOnly+)
+        #     (`CreationOnly`)
         #     The column families configured for this table, mapped by column family ID.
-        #     Views: +SCHEMA_VIEW+, +FULL+
+        #     Views: `SCHEMA_VIEW`, `FULL`
         # @!attribute [rw] granularity
         #   @return [Google::Bigtable::Admin::V2::Table::TimestampGranularity]
-        #     (+CreationOnly+)
-        #     The granularity (i.e. +MILLIS+) at which timestamps are stored in
+        #     (`CreationOnly`)
+        #     The granularity (i.e. `MILLIS`) at which timestamps are stored in
         #     this table. Timestamps not matching the granularity will be rejected.
-        #     If unspecified at creation time, the value will be set to +MILLIS+.
-        #     Views: +SCHEMA_VIEW+, +FULL+
+        #     If unspecified at creation time, the value will be set to `MILLIS`.
+        #     Views: `SCHEMA_VIEW`, `FULL`
         class Table
           # The state of a table's data in a particular cluster.
           # @!attribute [rw] replication_state
           #   @return [Google::Bigtable::Admin::V2::Table::ClusterState::ReplicationState]
-          #     (+OutputOnly+)
+          #     (`OutputOnly`)
           #     The state of replication for the table in this cluster.
           class ClusterState
             # Table replication states.
@@ -93,13 +93,13 @@ module Google
             # Uses the default view for each method as documented in its request.
             VIEW_UNSPECIFIED = 0
 
-            # Only populates +name+.
+            # Only populates `name`.
             NAME_ONLY = 1
 
-            # Only populates +name+ and fields related to the table's schema.
+            # Only populates `name` and fields related to the table's schema.
             SCHEMA_VIEW = 2
 
-            # Only populates +name+ and fields related to the table's
+            # Only populates `name` and fields related to the table's
             # replication state.
             REPLICATION_VIEW = 3
 
@@ -138,13 +138,13 @@ module Google
           # A GcRule which deletes cells matching all of the given rules.
           # @!attribute [rw] rules
           #   @return [Array<Google::Bigtable::Admin::V2::GcRule>]
-          #     Only delete cells which would be deleted by every element of +rules+.
+          #     Only delete cells which would be deleted by every element of `rules`.
           class Intersection; end
 
           # A GcRule which deletes cells matching any of the given rules.
           # @!attribute [rw] rules
           #   @return [Array<Google::Bigtable::Admin::V2::GcRule>]
-          #     Delete cells which would be deleted by any element of +rules+.
+          #     Delete cells which would be deleted by any element of `rules`.
           class Union; end
         end
 
@@ -157,37 +157,37 @@ module Google
         # for production use. It is not subject to any SLA or deprecation policy.
         # @!attribute [rw] name
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The unique name of the snapshot.
         #     Values are of the form
-        #     +projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>+.
+        #     `projects/<project>/instances/<instance>/clusters/<cluster>/snapshots/<snapshot>`.
         # @!attribute [rw] source_table
         #   @return [Google::Bigtable::Admin::V2::Table]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The source table at the time the snapshot was taken.
         # @!attribute [rw] data_size_bytes
         #   @return [Integer]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The size of the data in the source table at the time the snapshot was
         #     taken. In some cases, this value may be computed asynchronously via a
         #     background process and a placeholder of 0 will be used in the meantime.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The time when the snapshot is created.
         # @!attribute [rw] delete_time
         #   @return [Google::Protobuf::Timestamp]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The time when the snapshot will be deleted. The maximum amount of time a
         #     snapshot can stay active is 365 days. If 'ttl' is not specified,
         #     the default maximum of 365 days will be used.
         # @!attribute [rw] state
         #   @return [Google::Bigtable::Admin::V2::Snapshot::State]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     The current state of the snapshot.
         # @!attribute [rw] description
         #   @return [String]
-        #     (+OutputOnly+)
+        #     (`OutputOnly`)
         #     Description of the snapshot.
         class Snapshot
           # Possible states of a snapshot.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/policy.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/longrunning/operations.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/duration.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/admin/v2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/bigtable_client.rb
@@ -245,7 +245,7 @@ module Google
           # @param table_name [String]
           #   The unique name of the table from which to read.
           #   Values are of the form
-          #   +projects/<project>/instances/<instance>/tables/<table>+.
+          #   `projects/<project>/instances/<instance>/tables/<table>`.
           # @param app_profile_id [String]
           #   This value specifies routing for replication. If not specified, the
           #   "default" application profile will be used.
@@ -303,7 +303,7 @@ module Google
           # @param table_name [String]
           #   The unique name of the table from which to sample row keys.
           #   Values are of the form
-          #   +projects/<project>/instances/<instance>/tables/<table>+.
+          #   `projects/<project>/instances/<instance>/tables/<table>`.
           # @param app_profile_id [String]
           #   This value specifies routing for replication. If not specified, the
           #   "default" application profile will be used.
@@ -336,12 +336,12 @@ module Google
           end
 
           # Mutates a row atomically. Cells already present in the row are left
-          # unchanged unless explicitly changed by +mutation+.
+          # unchanged unless explicitly changed by `mutation`.
           #
           # @param table_name [String]
           #   The unique name of the table to which the mutation should be applied.
           #   Values are of the form
-          #   +projects/<project>/instances/<instance>/tables/<table>+.
+          #   `projects/<project>/instances/<instance>/tables/<table>`.
           # @param row_key [String]
           #   The key of the row to which the mutation should be applied.
           # @param mutations [Array<Google::Bigtable::V2::Mutation | Hash>]
@@ -367,10 +367,10 @@ module Google
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
           #
-          #   # TODO: Initialize +row_key+:
+          #   # TODO: Initialize `row_key`:
           #   row_key = ''
           #
-          #   # TODO: Initialize +mutations+:
+          #   # TODO: Initialize `mutations`:
           #   mutations = []
           #   response = bigtable_client.mutate_row(formatted_table_name, row_key, mutations)
 
@@ -421,7 +421,7 @@ module Google
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
           #
-          #   # TODO: Initialize +entries+:
+          #   # TODO: Initialize `entries`:
           #   entries = []
           #   bigtable_client.mutate_rows(formatted_table_name, entries).each do |element|
           #     # Process element.
@@ -447,7 +447,7 @@ module Google
           #   The unique name of the table to which the conditional mutation should be
           #   applied.
           #   Values are of the form
-          #   +projects/<project>/instances/<instance>/tables/<table>+.
+          #   `projects/<project>/instances/<instance>/tables/<table>`.
           # @param row_key [String]
           #   The key of the row to which the conditional mutation should be applied.
           # @param app_profile_id [String]
@@ -455,24 +455,24 @@ module Google
           #   "default" application profile will be used.
           # @param predicate_filter [Google::Bigtable::V2::RowFilter | Hash]
           #   The filter to be applied to the contents of the specified row. Depending
-          #   on whether or not any results are yielded, either +true_mutations+ or
-          #   +false_mutations+ will be executed. If unset, checks that the row contains
+          #   on whether or not any results are yielded, either `true_mutations` or
+          #   `false_mutations` will be executed. If unset, checks that the row contains
           #   any values at all.
           #   A hash of the same form as `Google::Bigtable::V2::RowFilter`
           #   can also be provided.
           # @param true_mutations [Array<Google::Bigtable::V2::Mutation | Hash>]
-          #   Changes to be atomically applied to the specified row if +predicate_filter+
-          #   yields at least one cell when applied to +row_key+. Entries are applied in
+          #   Changes to be atomically applied to the specified row if `predicate_filter`
+          #   yields at least one cell when applied to `row_key`. Entries are applied in
           #   order, meaning that earlier mutations can be masked by later ones.
-          #   Must contain at least one entry if +false_mutations+ is empty, and at most
+          #   Must contain at least one entry if `false_mutations` is empty, and at most
           #   100000.
           #   A hash of the same form as `Google::Bigtable::V2::Mutation`
           #   can also be provided.
           # @param false_mutations [Array<Google::Bigtable::V2::Mutation | Hash>]
-          #   Changes to be atomically applied to the specified row if +predicate_filter+
-          #   does not yield any cells when applied to +row_key+. Entries are applied in
+          #   Changes to be atomically applied to the specified row if `predicate_filter`
+          #   does not yield any cells when applied to `row_key`. Entries are applied in
           #   order, meaning that earlier mutations can be masked by later ones.
-          #   Must contain at least one entry if +true_mutations+ is empty, and at most
+          #   Must contain at least one entry if `true_mutations` is empty, and at most
           #   100000.
           #   A hash of the same form as `Google::Bigtable::V2::Mutation`
           #   can also be provided.
@@ -490,7 +490,7 @@ module Google
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
           #
-          #   # TODO: Initialize +row_key+:
+          #   # TODO: Initialize `row_key`:
           #   row_key = ''
           #   response = bigtable_client.check_and_mutate_row(formatted_table_name, row_key)
 
@@ -525,7 +525,7 @@ module Google
           #   The unique name of the table to which the read/modify/write rules should be
           #   applied.
           #   Values are of the form
-          #   +projects/<project>/instances/<instance>/tables/<table>+.
+          #   `projects/<project>/instances/<instance>/tables/<table>`.
           # @param row_key [String]
           #   The key of the row to which the read/modify/write rules should be applied.
           # @param rules [Array<Google::Bigtable::V2::ReadModifyWriteRule | Hash>]
@@ -551,10 +551,10 @@ module Google
           #   bigtable_client = Google::Cloud::Bigtable::V2.new
           #   formatted_table_name = Google::Cloud::Bigtable::V2::BigtableClient.table_path("[PROJECT]", "[INSTANCE]", "[TABLE]")
           #
-          #   # TODO: Initialize +row_key+:
+          #   # TODO: Initialize `row_key`:
           #   row_key = ''
           #
-          #   # TODO: Initialize +rules+:
+          #   # TODO: Initialize `rules`:
           #   rules = []
           #   response = bigtable_client.read_modify_write_row(formatted_table_name, row_key, rules)
 

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/bigtable.rb
@@ -21,7 +21,7 @@ module Google
       #   @return [String]
       #     The unique name of the table from which to read.
       #     Values are of the form
-      #     +projects/<project>/instances/<instance>/tables/<table>+.
+      #     `projects/<project>/instances/<instance>/tables/<table>`.
       # @!attribute [rw] app_profile_id
       #   @return [String]
       #     This value specifies routing for replication. If not specified, the
@@ -67,14 +67,14 @@ module Google
         #     family as the previous CellChunk.  The empty string can occur as a
         #     column family name in a response so clients must check
         #     explicitly for the presence of this message, not just for
-        #     +family_name.value+ being non-empty.
+        #     `family_name.value` being non-empty.
         # @!attribute [rw] qualifier
         #   @return [Google::Protobuf::BytesValue]
         #     The column qualifier for this chunk of data.  If this message
         #     is not present, this CellChunk is a continuation of the same column
         #     as the previous CellChunk.  Column qualifiers may be empty so
         #     clients must check for the presence of this message, not just
-        #     for +qualifier.value+ being non-empty.
+        #     for `qualifier.value` being non-empty.
         # @!attribute [rw] timestamp_micros
         #   @return [Integer]
         #     The cell's stored timestamp, which also uniquely identifies it
@@ -82,7 +82,7 @@ module Google
         #     microseconds, but individual tables may set a coarser
         #     granularity to further restrict the allowed values. For
         #     example, a table which specifies millisecond granularity will
-        #     only allow values of +timestamp_micros+ which are multiples of
+        #     only allow values of `timestamp_micros` which are multiples of
         #     1000.  Timestamps are only set in the first CellChunk per cell
         #     (for cells split into multiple chunks).
         # @!attribute [rw] labels
@@ -106,11 +106,11 @@ module Google
         # @!attribute [rw] reset_row
         #   @return [true, false]
         #     Indicates that the client should drop all previous chunks for
-        #     +row_key+, as it will be re-read from the beginning.
+        #     `row_key`, as it will be re-read from the beginning.
         # @!attribute [rw] commit_row
         #   @return [true, false]
         #     Indicates that the client can safely process all previous chunks for
-        #     +row_key+, as its data has been fully read.
+        #     `row_key`, as its data has been fully read.
         class CellChunk; end
       end
 
@@ -119,7 +119,7 @@ module Google
       #   @return [String]
       #     The unique name of the table from which to sample row keys.
       #     Values are of the form
-      #     +projects/<project>/instances/<instance>/tables/<table>+.
+      #     `projects/<project>/instances/<instance>/tables/<table>`.
       # @!attribute [rw] app_profile_id
       #   @return [String]
       #     This value specifies routing for replication. If not specified, the
@@ -139,9 +139,9 @@ module Google
       # @!attribute [rw] offset_bytes
       #   @return [Integer]
       #     Approximate total storage space used by all rows in the table which precede
-      #     +row_key+. Buffering the contents of all rows between two subsequent
+      #     `row_key`. Buffering the contents of all rows between two subsequent
       #     samples would require space roughly equal to the difference in their
-      #     +offset_bytes+ fields.
+      #     `offset_bytes` fields.
       class SampleRowKeysResponse; end
 
       # Request message for Bigtable.MutateRow.
@@ -149,7 +149,7 @@ module Google
       #   @return [String]
       #     The unique name of the table to which the mutation should be applied.
       #     Values are of the form
-      #     +projects/<project>/instances/<instance>/tables/<table>+.
+      #     `projects/<project>/instances/<instance>/tables/<table>`.
       # @!attribute [rw] app_profile_id
       #   @return [String]
       #     This value specifies routing for replication. If not specified, the
@@ -185,7 +185,7 @@ module Google
       class MutateRowsRequest
         # @!attribute [rw] row_key
         #   @return [String]
-        #     The key of the row to which the +mutations+ should be applied.
+        #     The key of the row to which the `mutations` should be applied.
         # @!attribute [rw] mutations
         #   @return [Array<Google::Bigtable::V2::Mutation>]
         #     Changes to be atomically applied to the specified row. Mutations are
@@ -202,11 +202,11 @@ module Google
       class MutateRowsResponse
         # @!attribute [rw] index
         #   @return [Integer]
-        #     The index into the original request's +entries+ list of the Entry
+        #     The index into the original request's `entries` list of the Entry
         #     for which a result is being reported.
         # @!attribute [rw] status
         #   @return [Google::Rpc::Status]
-        #     The result of the request Entry identified by +index+.
+        #     The result of the request Entry identified by `index`.
         #     Depending on how requests are batched during execution, it is possible
         #     for one Entry to fail due to an error with another Entry. In the event
         #     that this occurs, the same error will be reported for both entries.
@@ -219,7 +219,7 @@ module Google
       #     The unique name of the table to which the conditional mutation should be
       #     applied.
       #     Values are of the form
-      #     +projects/<project>/instances/<instance>/tables/<table>+.
+      #     `projects/<project>/instances/<instance>/tables/<table>`.
       # @!attribute [rw] app_profile_id
       #   @return [String]
       #     This value specifies routing for replication. If not specified, the
@@ -230,29 +230,29 @@ module Google
       # @!attribute [rw] predicate_filter
       #   @return [Google::Bigtable::V2::RowFilter]
       #     The filter to be applied to the contents of the specified row. Depending
-      #     on whether or not any results are yielded, either +true_mutations+ or
-      #     +false_mutations+ will be executed. If unset, checks that the row contains
+      #     on whether or not any results are yielded, either `true_mutations` or
+      #     `false_mutations` will be executed. If unset, checks that the row contains
       #     any values at all.
       # @!attribute [rw] true_mutations
       #   @return [Array<Google::Bigtable::V2::Mutation>]
-      #     Changes to be atomically applied to the specified row if +predicate_filter+
-      #     yields at least one cell when applied to +row_key+. Entries are applied in
+      #     Changes to be atomically applied to the specified row if `predicate_filter`
+      #     yields at least one cell when applied to `row_key`. Entries are applied in
       #     order, meaning that earlier mutations can be masked by later ones.
-      #     Must contain at least one entry if +false_mutations+ is empty, and at most
+      #     Must contain at least one entry if `false_mutations` is empty, and at most
       #     100000.
       # @!attribute [rw] false_mutations
       #   @return [Array<Google::Bigtable::V2::Mutation>]
-      #     Changes to be atomically applied to the specified row if +predicate_filter+
-      #     does not yield any cells when applied to +row_key+. Entries are applied in
+      #     Changes to be atomically applied to the specified row if `predicate_filter`
+      #     does not yield any cells when applied to `row_key`. Entries are applied in
       #     order, meaning that earlier mutations can be masked by later ones.
-      #     Must contain at least one entry if +true_mutations+ is empty, and at most
+      #     Must contain at least one entry if `true_mutations` is empty, and at most
       #     100000.
       class CheckAndMutateRowRequest; end
 
       # Response message for Bigtable.CheckAndMutateRow.
       # @!attribute [rw] predicate_matched
       #   @return [true, false]
-      #     Whether or not the request's +predicate_filter+ yielded any results for
+      #     Whether or not the request's `predicate_filter` yielded any results for
       #     the specified row.
       class CheckAndMutateRowResponse; end
 
@@ -262,7 +262,7 @@ module Google
       #     The unique name of the table to which the read/modify/write rules should be
       #     applied.
       #     Values are of the form
-      #     +projects/<project>/instances/<instance>/tables/<table>+.
+      #     `projects/<project>/instances/<instance>/tables/<table>`.
       # @!attribute [rw] app_profile_id
       #   @return [String]
       #     This value specifies routing for replication. If not specified, the

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/bigtable/v2/data.rb
@@ -36,7 +36,7 @@ module Google
       #     The unique key which identifies this family within its row. This is the
       #     same key that's used to identify the family in, for example, a RowFilter
       #     which sets its "family_name_regex_filter" field.
-      #     Must match +[-_.a-zA-Z0-9]++, except that AggregatingRowProcessors may
+      #     Must match `[-_.a-zA-Z0-9]+`, except that AggregatingRowProcessors may
       #     produce cells in a sentinel family with an empty name.
       #     Must be no greater than 64 characters in length.
       # @!attribute [rw] columns
@@ -50,7 +50,7 @@ module Google
       #   @return [String]
       #     The unique key which identifies this column within its family. This is the
       #     same key that's used to identify the column in, for example, a RowFilter
-      #     which sets its +column_qualifier_regex_filter+ field.
+      #     which sets its `column_qualifier_regex_filter` field.
       #     May contain any byte string, including the empty string, up to 16kiB in
       #     length.
       # @!attribute [rw] cells
@@ -66,7 +66,7 @@ module Google
       #     Values are always expressed in microseconds, but individual tables may set
       #     a coarser granularity to further restrict the allowed values. For
       #     example, a table which specifies millisecond granularity will only allow
-      #     values of +timestamp_micros+ which are multiples of 1000.
+      #     values of `timestamp_micros` which are multiples of 1000.
       # @!attribute [rw] value
       #   @return [String]
       #     The value stored in the cell.
@@ -159,18 +159,18 @@ module Google
       # (chains and interleaves). They work as follows:
       #
       # * True filters alter the input row by excluding some of its cells wholesale
-      #   from the output row. An example of a true filter is the +value_regex_filter+,
+      #   from the output row. An example of a true filter is the `value_regex_filter`,
       #   which excludes cells whose values don't match the specified pattern. All
       #   regex true filters use RE2 syntax (https://github.com/google/re2/wiki/Syntax)
       #   in raw byte mode (RE2::Latin1), and are evaluated as full matches. An
-      #   important point to keep in mind is that +RE2(.)+ is equivalent by default to
-      #   +RE2([^\n])+, meaning that it does not match newlines. When attempting to
-      #   match an arbitrary byte, you should therefore use the escape sequence +\C+,
-      #   which may need to be further escaped as +\\C+ in your client language.
+      #   important point to keep in mind is that `RE2(.)` is equivalent by default to
+      #   `RE2([^\n])`, meaning that it does not match newlines. When attempting to
+      #   match an arbitrary byte, you should therefore use the escape sequence `\C`,
+      #   which may need to be further escaped as `\\C` in your client language.
       #
       # * Transformers alter the input row by changing the values of some of its
       #   cells in the output, without excluding them completely. Currently, the only
-      #   supported transformer is the +strip_value_transformer+, which replaces every
+      #   supported transformer is the `strip_value_transformer`, which replaces every
       #   cell's value with the empty string.
       #
       # * Chains and interleaves are described in more detail in the
@@ -250,12 +250,12 @@ module Google
       #     passed through the label and sink. Note that one copy has label "foo",
       #     while the other does not.
       #
-      #     Cannot be used within the +predicate_filter+, +true_filter+, or
-      #     +false_filter+ of a {Google::Bigtable::V2::RowFilter::Condition Condition}.
+      #     Cannot be used within the `predicate_filter`, `true_filter`, or
+      #     `false_filter` of a {Google::Bigtable::V2::RowFilter::Condition Condition}.
       # @!attribute [rw] pass_all_filter
       #   @return [true, false]
       #     Matches all cells, regardless of input. Functionally equivalent to
-      #     leaving +filter+ unset, but included for completeness.
+      #     leaving `filter` unset, but included for completeness.
       # @!attribute [rw] block_all_filter
       #   @return [true, false]
       #     Does not match any cells, regardless of input. Useful for temporarily
@@ -265,9 +265,9 @@ module Google
       #     Matches only cells from rows whose keys satisfy the given RE2 regex. In
       #     other words, passes through the entire row when the key matches, and
       #     otherwise produces an empty row.
-      #     Note that, since row keys can contain arbitrary bytes, the +\C+ escape
-      #     sequence must be used if a true wildcard is desired. The +.+ character
-      #     will not match the new line character +\n+, which may be present in a
+      #     Note that, since row keys can contain arbitrary bytes, the `\C` escape
+      #     sequence must be used if a true wildcard is desired. The `.` character
+      #     will not match the new line character `\n`, which may be present in a
       #     binary key.
       # @!attribute [rw] row_sample_filter
       #   @return [Float]
@@ -276,18 +276,18 @@ module Google
       # @!attribute [rw] family_name_regex_filter
       #   @return [String]
       #     Matches only cells from columns whose families satisfy the given RE2
-      #     regex. For technical reasons, the regex must not contain the +:+
+      #     regex. For technical reasons, the regex must not contain the `:`
       #     character, even if it is not being used as a literal.
       #     Note that, since column families cannot contain the new line character
-      #     +\n+, it is sufficient to use +.+ as a full wildcard when matching
+      #     `\n`, it is sufficient to use `.` as a full wildcard when matching
       #     column family names.
       # @!attribute [rw] column_qualifier_regex_filter
       #   @return [String]
       #     Matches only cells from columns whose qualifiers satisfy the given RE2
       #     regex.
-      #     Note that, since column qualifiers can contain arbitrary bytes, the +\C+
-      #     escape sequence must be used if a true wildcard is desired. The +.+
-      #     character will not match the new line character +\n+, which may be
+      #     Note that, since column qualifiers can contain arbitrary bytes, the `\C`
+      #     escape sequence must be used if a true wildcard is desired. The `.`
+      #     character will not match the new line character `\n`, which may be
       #     present in a binary qualifier.
       # @!attribute [rw] column_range_filter
       #   @return [Google::Bigtable::V2::ColumnRange]
@@ -298,9 +298,9 @@ module Google
       # @!attribute [rw] value_regex_filter
       #   @return [String]
       #     Matches only cells with values that satisfy the given regular expression.
-      #     Note that, since cell values can contain arbitrary bytes, the +\C+ escape
-      #     sequence must be used if a true wildcard is desired. The +.+ character
-      #     will not match the new line character +\n+, which may be present in a
+      #     Note that, since cell values can contain arbitrary bytes, the `\C` escape
+      #     sequence must be used if a true wildcard is desired. The `.` character
+      #     will not match the new line character `\n`, which may be present in a
       #     binary value.
       # @!attribute [rw] value_range_filter
       #   @return [Google::Bigtable::V2::ValueRange]
@@ -318,9 +318,9 @@ module Google
       # @!attribute [rw] cells_per_column_limit_filter
       #   @return [Integer]
       #     Matches only the most recent N cells within each column. For example,
-      #     if N=2, this filter would match column +foo:bar+ at timestamps 10 and 9,
-      #     skip all earlier cells in +foo:bar+, and then begin matching again in
-      #     column +foo:bar2+.
+      #     if N=2, this filter would match column `foo:bar` at timestamps 10 and 9,
+      #     skip all earlier cells in `foo:bar`, and then begin matching again in
+      #     column `foo:bar2`.
       #     If duplicate cells are present, as is possible when using an Interleave,
       #     each copy of the cell is counted separately.
       # @!attribute [rw] strip_value_transformer
@@ -333,12 +333,12 @@ module Google
       #     the filter.
       #
       #     Values must be at most 15 characters in length, and match the RE2
-      #     pattern +[a-z0-9\\-]++
+      #     pattern `[a-z0-9\\-]+`
       #
       #     Due to a technical limitation, it is not currently possible to apply
       #     multiple labels to a cell. As a result, a Chain may have no more than
-      #     one sub-filter which contains a +apply_label_transformer+. It is okay for
-      #     an Interleave to contain multiple +apply_label_transformers+, as they
+      #     one sub-filter which contains a `apply_label_transformer`. It is okay for
+      #     an Interleave to contain multiple `apply_label_transformers`, as they
       #     will be applied to separate copies of the input. This may be relaxed in
       #     the future.
       class RowFilter
@@ -390,15 +390,15 @@ module Google
         # when filters are set for the false condition.
         # @!attribute [rw] predicate_filter
         #   @return [Google::Bigtable::V2::RowFilter]
-        #     If +predicate_filter+ outputs any cells, then +true_filter+ will be
-        #     evaluated on the input row. Otherwise, +false_filter+ will be evaluated.
+        #     If `predicate_filter` outputs any cells, then `true_filter` will be
+        #     evaluated on the input row. Otherwise, `false_filter` will be evaluated.
         # @!attribute [rw] true_filter
         #   @return [Google::Bigtable::V2::RowFilter]
-        #     The filter to apply to the input row if +predicate_filter+ returns any
+        #     The filter to apply to the input row if `predicate_filter` returns any
         #     results. If not provided, no results will be returned in the true case.
         # @!attribute [rw] false_filter
         #   @return [Google::Bigtable::V2::RowFilter]
-        #     The filter to apply to the input row if +predicate_filter+ does not
+        #     The filter to apply to the input row if `predicate_filter` does not
         #     return any results. If not provided, no results will be returned in the
         #     false case.
         class Condition; end
@@ -422,7 +422,7 @@ module Google
         # @!attribute [rw] family_name
         #   @return [String]
         #     The name of the family into which new data should be written.
-        #     Must match +[-_.a-zA-Z0-9]++
+        #     Must match `[-_.a-zA-Z0-9]+`
         # @!attribute [rw] column_qualifier
         #   @return [String]
         #     The qualifier of the column into which new data should be written.
@@ -444,7 +444,7 @@ module Google
         # @!attribute [rw] family_name
         #   @return [String]
         #     The name of the family from which cells should be deleted.
-        #     Must match +[-_.a-zA-Z0-9]++
+        #     Must match `[-_.a-zA-Z0-9]+`
         # @!attribute [rw] column_qualifier
         #   @return [String]
         #     The qualifier of the column from which cells should be deleted.
@@ -458,7 +458,7 @@ module Google
         # @!attribute [rw] family_name
         #   @return [String]
         #     The name of the family from which cells should be deleted.
-        #     Must match +[-_.a-zA-Z0-9]++
+        #     Must match `[-_.a-zA-Z0-9]+`
         class DeleteFromFamily; end
 
         # A Mutation which deletes all cells from the containing row.
@@ -470,7 +470,7 @@ module Google
       # @!attribute [rw] family_name
       #   @return [String]
       #     The name of the family to which the read/modify/write should be applied.
-      #     Must match +[-_.a-zA-Z0-9]++
+      #     Must match `[-_.a-zA-Z0-9]+`
       # @!attribute [rw] column_qualifier
       #   @return [String]
       #     The qualifier of the column to which the read/modify/write should be
@@ -478,12 +478,12 @@ module Google
       #     Can be any byte string, including the empty string.
       # @!attribute [rw] append_value
       #   @return [String]
-      #     Rule specifying that +append_value+ be appended to the existing value.
+      #     Rule specifying that `append_value` be appended to the existing value.
       #     If the targeted cell is unset, it will be treated as containing the
       #     empty string.
       # @!attribute [rw] increment_amount
       #   @return [Integer]
-      #     Rule specifying that +increment_amount+ be added to the existing value.
+      #     Rule specifying that `increment_amount` be added to the existing value.
       #     If the targeted cell is unset, it will be treated as containing a zero.
       #     Otherwise, the targeted cell must contain an 8-byte value (interpreted
       #     as a 64-bit big-endian signed integer), or the entire request will fail.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
+++ b/google-cloud-bigtable/lib/google/cloud/bigtable/v2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-bigtable/synth.py
+++ b/google-cloud-bigtable/synth.py
@@ -96,10 +96,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1/cluster_manager_client.rb
@@ -337,10 +337,10 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #   response = cluster_manager_client.list_clusters(project_id, zone)
 
@@ -381,13 +381,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #   response = cluster_manager_client.get_cluster(project_id, zone, cluster_id)
 
@@ -445,13 +445,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster+:
+          #   # TODO: Initialize `cluster`:
           #   cluster = {}
           #   response = cluster_manager_client.create_cluster(project_id, zone, cluster)
 
@@ -498,16 +498,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +update+:
+          #   # TODO: Initialize `update`:
           #   update = {}
           #   response = cluster_manager_client.update_cluster(project_id, zone, cluster_id, update)
 
@@ -543,7 +543,7 @@ module Google
           #   The name of the node pool to upgrade.
           # @param node_version [String]
           #   The Kubernetes version to change the nodes to (typically an
-          #   upgrade). Use +-+ to upgrade to the latest version supported by
+          #   upgrade). Use `-` to upgrade to the latest version supported by
           #   the server.
           # @param image_type [String]
           #   The desired image type for the node pool.
@@ -560,22 +560,22 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #
-          #   # TODO: Initialize +node_version+:
+          #   # TODO: Initialize `node_version`:
           #   node_version = ''
           #
-          #   # TODO: Initialize +image_type+:
+          #   # TODO: Initialize `image_type`:
           #   image_type = ''
           #   response = cluster_manager_client.update_node_pool(project_id, zone, cluster_id, node_pool_id, node_version, image_type)
 
@@ -630,19 +630,19 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #
-          #   # TODO: Initialize +autoscaling+:
+          #   # TODO: Initialize `autoscaling`:
           #   autoscaling = {}
           #   response = cluster_manager_client.set_node_pool_autoscaling(project_id, zone, cluster_id, node_pool_id, autoscaling)
 
@@ -695,16 +695,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +logging_service+:
+          #   # TODO: Initialize `logging_service`:
           #   logging_service = ''
           #   response = cluster_manager_client.set_logging_service(project_id, zone, cluster_id, logging_service)
 
@@ -755,16 +755,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +monitoring_service+:
+          #   # TODO: Initialize `monitoring_service`:
           #   monitoring_service = ''
           #   response = cluster_manager_client.set_monitoring_service(project_id, zone, cluster_id, monitoring_service)
 
@@ -814,16 +814,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +addons_config+:
+          #   # TODO: Initialize `addons_config`:
           #   addons_config = {}
           #   response = cluster_manager_client.set_addons_config(project_id, zone, cluster_id, addons_config)
 
@@ -876,16 +876,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +locations+:
+          #   # TODO: Initialize `locations`:
           #   locations = []
           #   response = cluster_manager_client.set_locations(project_id, zone, cluster_id, locations)
 
@@ -934,16 +934,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +master_version+:
+          #   # TODO: Initialize `master_version`:
           #   master_version = ''
           #   response = cluster_manager_client.update_master(project_id, zone, cluster_id, master_version)
 
@@ -996,19 +996,19 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +action+:
+          #   # TODO: Initialize `action`:
           #   action = :UNKNOWN
           #
-          #   # TODO: Initialize +update+:
+          #   # TODO: Initialize `update`:
           #   update = {}
           #   response = cluster_manager_client.set_master_auth(project_id, zone, cluster_id, action, update)
 
@@ -1063,13 +1063,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #   response = cluster_manager_client.delete_cluster(project_id, zone, cluster_id)
 
@@ -1095,7 +1095,7 @@ module Google
           #   number](https://support.google.com/cloud/answer/6158840).
           # @param zone [String]
           #   The name of the Google Compute Engine [zone](https://cloud.google.com/compute/docs/zones#available)
-          #   to return operations for, or +-+ for all zones.
+          #   to return operations for, or `-` for all zones.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1109,10 +1109,10 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #   response = cluster_manager_client.list_operations(project_id, zone)
 
@@ -1139,7 +1139,7 @@ module Google
           #   [zone](https://cloud.google.com/compute/docs/zones#available) in which the cluster
           #   resides.
           # @param operation_id [String]
-          #   The server-assigned +name+ of the operation.
+          #   The server-assigned `name` of the operation.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1153,13 +1153,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +operation_id+:
+          #   # TODO: Initialize `operation_id`:
           #   operation_id = ''
           #   response = cluster_manager_client.get_operation(project_id, zone, operation_id)
 
@@ -1187,7 +1187,7 @@ module Google
           #   The name of the Google Compute Engine
           #   [zone](https://cloud.google.com/compute/docs/zones#available) in which the operation resides.
           # @param operation_id [String]
-          #   The server-assigned +name+ of the operation.
+          #   The server-assigned `name` of the operation.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1200,13 +1200,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +operation_id+:
+          #   # TODO: Initialize `operation_id`:
           #   operation_id = ''
           #   cluster_manager_client.cancel_operation(project_id, zone, operation_id)
 
@@ -1247,10 +1247,10 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #   response = cluster_manager_client.get_server_config(project_id, zone)
 
@@ -1291,13 +1291,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #   response = cluster_manager_client.list_node_pools(project_id, zone, cluster_id)
 
@@ -1342,16 +1342,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #   response = cluster_manager_client.get_node_pool(project_id, zone, cluster_id, node_pool_id)
 
@@ -1400,16 +1400,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool+:
+          #   # TODO: Initialize `node_pool`:
           #   node_pool = {}
           #   response = cluster_manager_client.create_node_pool(project_id, zone, cluster_id, node_pool)
 
@@ -1456,16 +1456,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #   response = cluster_manager_client.delete_node_pool(project_id, zone, cluster_id, node_pool_id)
 
@@ -1513,16 +1513,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #   response = cluster_manager_client.rollback_node_pool_upgrade(project_id, zone, cluster_id, node_pool_id)
 
@@ -1573,19 +1573,19 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #
-          #   # TODO: Initialize +management+:
+          #   # TODO: Initialize `management`:
           #   management = {}
           #   response = cluster_manager_client.set_node_pool_management(project_id, zone, cluster_id, node_pool_id, management)
 
@@ -1641,19 +1641,19 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +resource_labels+:
+          #   # TODO: Initialize `resource_labels`:
           #   resource_labels = {}
           #
-          #   # TODO: Initialize +label_fingerprint+:
+          #   # TODO: Initialize `label_fingerprint`:
           #   label_fingerprint = ''
           #   response = cluster_manager_client.set_labels(project_id, zone, cluster_id, resource_labels, label_fingerprint)
 
@@ -1702,16 +1702,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +enabled+:
+          #   # TODO: Initialize `enabled`:
           #   enabled = false
           #   response = cluster_manager_client.set_legacy_abac(project_id, zone, cluster_id, enabled)
 
@@ -1756,13 +1756,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #   response = cluster_manager_client.start_ip_rotation(project_id, zone, cluster_id)
 
@@ -1805,13 +1805,13 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #   response = cluster_manager_client.complete_ip_rotation(project_id, zone, cluster_id)
 
@@ -1858,19 +1858,19 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +node_pool_id+:
+          #   # TODO: Initialize `node_pool_id`:
           #   node_pool_id = ''
           #
-          #   # TODO: Initialize +node_count+:
+          #   # TODO: Initialize `node_count`:
           #   node_count = 0
           #   response = cluster_manager_client.set_node_pool_size(project_id, zone, cluster_id, node_pool_id, node_count)
 
@@ -1921,16 +1921,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +network_policy+:
+          #   # TODO: Initialize `network_policy`:
           #   network_policy = {}
           #   response = cluster_manager_client.set_network_policy(project_id, zone, cluster_id, network_policy)
 
@@ -1980,16 +1980,16 @@ module Google
           #
           #   cluster_manager_client = Google::Cloud::Container.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +zone+:
+          #   # TODO: Initialize `zone`:
           #   zone = ''
           #
-          #   # TODO: Initialize +cluster_id+:
+          #   # TODO: Initialize `cluster_id`:
           #   cluster_id = ''
           #
-          #   # TODO: Initialize +maintenance_policy+:
+          #   # TODO: Initialize `maintenance_policy`:
           #   maintenance_policy = {}
           #   response = cluster_manager_client.set_maintenance_policy(project_id, zone, cluster_id, maintenance_policy)
 

--- a/google-cloud-container/lib/google/cloud/container/v1/doc/google/container/v1/cluster_service.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1/doc/google/container/v1/cluster_service.rb
@@ -21,10 +21,10 @@ module Google
       #   @return [String]
       #     The name of a Google Compute Engine [machine
       #     type](/compute/docs/machine-types) (e.g.
-      #     +n1-standard-1+).
+      #     `n1-standard-1`).
       #
       #     If unspecified, the default machine type is
-      #     +n1-standard-1+.
+      #     `n1-standard-1`.
       # @!attribute [rw] disk_size_gb
       #   @return [Integer]
       #     Size of the disk attached to each node, specified in GB.
@@ -39,9 +39,9 @@ module Google
       #     The following scopes are recommended, but not required, and by default are
       #     not included:
       #
-      #     * +https://www.googleapis.com/auth/compute+ is required for mounting
+      #     * `https://www.googleapis.com/auth/compute` is required for mounting
       #       persistent storage on your nodes.
-      #     * +https://www.googleapis.com/auth/devstorage.read_only+ is required for
+      #     * `https://www.googleapis.com/auth/devstorage.read_only` is required for
       #       communicating with **gcr.io**
       #       (the [Google Container Registry](https://cloud.google.com/container-registry/)).
       #
@@ -266,10 +266,10 @@ module Google
       #   @return [true, false]
       #     Whether a new subnetwork will be created automatically for the cluster.
       #
-      #     This field is only applicable when +use_ip_aliases+ is true.
+      #     This field is only applicable when `use_ip_aliases` is true.
       # @!attribute [rw] subnetwork_name
       #   @return [String]
-      #     A custom subnetwork name to be used if +create_subnetwork+ is true.  If
+      #     A custom subnetwork name to be used if `create_subnetwork` is true.  If
       #     this field is empty, then an automatic name will be chosen for the new
       #     subnetwork.
       # @!attribute [rw] cluster_ipv4_cidr
@@ -302,52 +302,52 @@ module Google
       # @!attribute [rw] cluster_ipv4_cidr_block
       #   @return [String]
       #     The IP address range for the cluster pod IPs. If this field is set, then
-      #     +cluster.cluster_ipv4_cidr+ must be left blank.
+      #     `cluster.cluster_ipv4_cidr` must be left blank.
       #
-      #     This field is only applicable when +use_ip_aliases+ is true.
+      #     This field is only applicable when `use_ip_aliases` is true.
       #
       #     Set to blank to have a range chosen with the default size.
       #
-      #     Set to /netmask (e.g. +/14+) to have a range chosen with a specific
+      #     Set to /netmask (e.g. `/14`) to have a range chosen with a specific
       #     netmask.
       #
       #     Set to a
       #     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-      #     notation (e.g. +10.96.0.0/14+) from the RFC-1918 private networks (e.g.
-      #     +10.0.0.0/8+, +172.16.0.0/12+, +192.168.0.0/16+) to pick a specific range
+      #     notation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.
+      #     `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range
       #     to use.
       # @!attribute [rw] node_ipv4_cidr_block
       #   @return [String]
       #     The IP address range of the instance IPs in this cluster.
       #
-      #     This is applicable only if +create_subnetwork+ is true.
+      #     This is applicable only if `create_subnetwork` is true.
       #
       #     Set to blank to have a range chosen with the default size.
       #
-      #     Set to /netmask (e.g. +/14+) to have a range chosen with a specific
+      #     Set to /netmask (e.g. `/14`) to have a range chosen with a specific
       #     netmask.
       #
       #     Set to a
       #     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-      #     notation (e.g. +10.96.0.0/14+) from the RFC-1918 private networks (e.g.
-      #     +10.0.0.0/8+, +172.16.0.0/12+, +192.168.0.0/16+) to pick a specific range
+      #     notation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.
+      #     `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range
       #     to use.
       # @!attribute [rw] services_ipv4_cidr_block
       #   @return [String]
       #     The IP address range of the services IPs in this cluster. If blank, a range
       #     will be automatically chosen with the default size.
       #
-      #     This field is only applicable when +use_ip_aliases+ is true.
+      #     This field is only applicable when `use_ip_aliases` is true.
       #
       #     Set to blank to have a range chosen with the default size.
       #
-      #     Set to /netmask (e.g. +/14+) to have a range chosen with a specific
+      #     Set to /netmask (e.g. `/14`) to have a range chosen with a specific
       #     netmask.
       #
       #     Set to a
       #     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-      #     notation (e.g. +10.96.0.0/14+) from the RFC-1918 private networks (e.g.
-      #     +10.0.0.0/8+, +172.16.0.0/12+, +192.168.0.0/16+) to pick a specific range
+      #     notation (e.g. `10.96.0.0/14`) from the RFC-1918 private networks (e.g.
+      #     `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) to pick a specific range
       #     to use.
       class IPAllocationPolicy; end
 
@@ -376,7 +376,7 @@ module Google
       # @!attribute [rw] node_config
       #   @return [Google::Container::V1::NodeConfig]
       #     Parameters used in creating the cluster's nodes.
-      #     See +nodeConfig+ for the description of its properties.
+      #     See `nodeConfig` for the description of its properties.
       #     For requests, this field should only be used in lieu of a
       #     "node_pool" object, since this configuration (along with the
       #     "initial_node_count") will be used to create a "NodePool" object with an
@@ -393,29 +393,29 @@ module Google
       #     The logging service the cluster should use to write logs.
       #     Currently available options:
       #
-      #     * +logging.googleapis.com+ - the Google Cloud Logging service.
-      #     * +none+ - no logs will be exported from the cluster.
-      #     * if left as an empty string,+logging.googleapis.com+ will be used.
+      #     * `logging.googleapis.com` - the Google Cloud Logging service.
+      #     * `none` - no logs will be exported from the cluster.
+      #     * if left as an empty string,`logging.googleapis.com` will be used.
       # @!attribute [rw] monitoring_service
       #   @return [String]
       #     The monitoring service the cluster should use to write metrics.
       #     Currently available options:
       #
-      #     * +monitoring.googleapis.com+ - the Google Cloud Monitoring service.
-      #     * +none+ - no metrics will be exported from the cluster.
-      #     * if left as an empty string, +monitoring.googleapis.com+ will be used.
+      #     * `monitoring.googleapis.com` - the Google Cloud Monitoring service.
+      #     * `none` - no metrics will be exported from the cluster.
+      #     * if left as an empty string, `monitoring.googleapis.com` will be used.
       # @!attribute [rw] network
       #   @return [String]
       #     The name of the Google Compute Engine
       #     [network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks) to which the
-      #     cluster is connected. If left unspecified, the +default+ network
+      #     cluster is connected. If left unspecified, the `default` network
       #     will be used.
       # @!attribute [rw] cluster_ipv4_cidr
       #   @return [String]
       #     The IP address range of the container pods in this cluster, in
       #     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-      #     notation (e.g. +10.96.0.0/14+). Leave blank to have
-      #     one automatically chosen or specify a +/14+ block in +10.0.0.0/8+.
+      #     notation (e.g. `10.96.0.0/14`). Leave blank to have
+      #     one automatically chosen or specify a `/14` block in `10.0.0.0/8`.
       # @!attribute [rw] addons_config
       #   @return [Google::Container::V1::AddonsConfig]
       #     Configurations for the various addons available to run in the cluster.
@@ -477,9 +477,9 @@ module Google
       #   @return [String]
       #     [Output only] The IP address of this cluster's master endpoint.
       #     The endpoint can be accessed from the internet at
-      #     +https://username:password@endpoint/+.
+      #     `https://username:password@endpoint/`.
       #
-      #     See the +masterAuth+ property of this resource for username and
+      #     See the `masterAuth` property of this resource for username and
       #     password information.
       # @!attribute [rw] initial_cluster_version
       #   @return [String]
@@ -509,15 +509,15 @@ module Google
       # @!attribute [rw] node_ipv4_cidr_size
       #   @return [Integer]
       #     [Output only] The size of the address space on each node for hosting
-      #     containers. This is provisioned from within the +container_ipv4_cidr+
+      #     containers. This is provisioned from within the `container_ipv4_cidr`
       #     range.
       # @!attribute [rw] services_ipv4_cidr
       #   @return [String]
       #     [Output only] The IP address range of the Kubernetes services in
       #     this cluster, in
       #     [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
-      #     notation (e.g. +1.2.3.4/29+). Service addresses are
-      #     typically put in the last +/16+ from the container CIDR.
+      #     notation (e.g. `1.2.3.4/29`). Service addresses are
+      #     typically put in the last `/16` from the container CIDR.
       # @!attribute [rw] instance_group_urls
       #   @return [Array<String>]
       #     Deprecated. Use node_pools.instance_group_urls.
@@ -543,14 +543,14 @@ module Google
 
           # The RECONCILING state indicates that some work is actively being done on
           # the cluster, such as upgrading the master or node software. Details can
-          # be found in the +statusMessage+ field.
+          # be found in the `statusMessage` field.
           RECONCILING = 3
 
           # The STOPPING state indicates the cluster is being deleted.
           STOPPING = 4
 
           # The ERROR state indicates the cluster may be unusable. Details
-          # can be found in the +statusMessage+ field.
+          # can be found in the `statusMessage` field.
           ERROR = 5
         end
       end
@@ -561,7 +561,7 @@ module Google
       # @!attribute [rw] desired_node_version
       #   @return [String]
       #     The Kubernetes version to change the nodes to (typically an
-      #     upgrade). Use +-+ to upgrade to the latest version supported by
+      #     upgrade). Use `-` to upgrade to the latest version supported by
       #     the server.
       # @!attribute [rw] desired_monitoring_service
       #   @return [String]
@@ -787,7 +787,7 @@ module Google
       # @!attribute [rw] node_version
       #   @return [String]
       #     The Kubernetes version to change the nodes to (typically an
-      #     upgrade). Use +-+ to upgrade to the latest version supported by
+      #     upgrade). Use `-` to upgrade to the latest version supported by
       #     the server.
       # @!attribute [rw] image_type
       #   @return [String]
@@ -1011,7 +1011,7 @@ module Google
       #     resides.
       # @!attribute [rw] operation_id
       #   @return [String]
-      #     The server-assigned +name+ of the operation.
+      #     The server-assigned `name` of the operation.
       class GetOperationRequest; end
 
       # ListOperationsRequest lists operations.
@@ -1022,7 +1022,7 @@ module Google
       # @!attribute [rw] zone
       #   @return [String]
       #     The name of the Google Compute Engine [zone](https://cloud.google.com/compute/docs/zones#available)
-      #     to return operations for, or +-+ for all zones.
+      #     to return operations for, or `-` for all zones.
       class ListOperationsRequest; end
 
       # CancelOperationRequest cancels a single operation.
@@ -1036,7 +1036,7 @@ module Google
       #     [zone](https://cloud.google.com/compute/docs/zones#available) in which the operation resides.
       # @!attribute [rw] operation_id
       #   @return [String]
-      #     The server-assigned +name+ of the operation.
+      #     The server-assigned `name` of the operation.
       class CancelOperationRequest; end
 
       # ListOperationsResponse is the result of ListOperationsRequest.
@@ -1211,14 +1211,14 @@ module Google
 
           # The RECONCILING state indicates that some work is actively being done on
           # the node pool, such as upgrading node software. Details can
-          # be found in the +statusMessage+ field.
+          # be found in the `statusMessage` field.
           RECONCILING = 4
 
           # The STOPPING state indicates the node pool is being deleted.
           STOPPING = 5
 
           # The ERROR state indicates the node pool may be unusable. Details
-          # can be found in the +statusMessage+ field.
+          # can be found in the `statusMessage` field.
           ERROR = 6
         end
       end

--- a/google-cloud-container/lib/google/cloud/container/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-container/lib/google/cloud/container/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/cluster_controller_client.rb
@@ -242,13 +242,13 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +cluster+:
+          #   # TODO: Initialize `cluster`:
           #   cluster = {}
           #
           #   # Register a callback during the method call.
@@ -314,11 +314,11 @@ module Google
           #   A hash of the same form as `Google::Cloud::Dataproc::V1::Cluster`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #   Required. Specifies the path, relative to +Cluster+, of
+          #   Required. Specifies the path, relative to `Cluster`, of
           #   the field to update. For example, to change the number of workers
-          #   in a cluster to 5, the +update_mask+ parameter would be
-          #   specified as +config.worker_config.num_instances+,
-          #   and the +PATCH+ request body would specify the new value, as follows:
+          #   in a cluster to 5, the `update_mask` parameter would be
+          #   specified as `config.worker_config.num_instances`,
+          #   and the `PATCH` request body would specify the new value, as follows:
           #
           #       {
           #         "config":{
@@ -328,8 +328,8 @@ module Google
           #         }
           #       }
           #   Similarly, to change the number of preemptible workers in a cluster to 5,
-          #   the +update_mask+ parameter would be
-          #   +config.secondary_worker_config.num_instances+, and the +PATCH+ request
+          #   the `update_mask` parameter would be
+          #   `config.secondary_worker_config.num_instances`, and the `PATCH` request
           #   body would be set as follows:
           #
           #       {
@@ -373,19 +373,19 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +cluster_name+:
+          #   # TODO: Initialize `cluster_name`:
           #   cluster_name = ''
           #
-          #   # TODO: Initialize +cluster+:
+          #   # TODO: Initialize `cluster`:
           #   cluster = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #
           #   # Register a callback during the method call.
@@ -460,13 +460,13 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +cluster_name+:
+          #   # TODO: Initialize `cluster_name`:
           #   cluster_name = ''
           #
           #   # Register a callback during the method call.
@@ -540,13 +540,13 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +cluster_name+:
+          #   # TODO: Initialize `cluster_name`:
           #   cluster_name = ''
           #   response = cluster_controller_client.get_cluster(project_id, region, cluster_name)
 
@@ -578,15 +578,15 @@ module Google
           #
           #   field = value [AND [field = value]] ...
           #
-          #   where **field** is one of +status.state+, +clusterName+, or +labels.[KEY]+,
-          #   and +[KEY]+ is a label key. **value** can be +*+ to match all values.
-          #   +status.state+ can be one of the following: +ACTIVE+, +INACTIVE+,
-          #   +CREATING+, +RUNNING+, +ERROR+, +DELETING+, or +UPDATING+. +ACTIVE+
-          #   contains the +CREATING+, +UPDATING+, and +RUNNING+ states. +INACTIVE+
-          #   contains the +DELETING+ and +ERROR+ states.
-          #   +clusterName+ is the name of the cluster provided at creation time.
-          #   Only the logical +AND+ operator is supported; space-separated items are
-          #   treated as having an implicit +AND+ operator.
+          #   where **field** is one of `status.state`, `clusterName`, or `labels.[KEY]`,
+          #   and `[KEY]` is a label key. **value** can be `*` to match all values.
+          #   `status.state` can be one of the following: `ACTIVE`, `INACTIVE`,
+          #   `CREATING`, `RUNNING`, `ERROR`, `DELETING`, or `UPDATING`. `ACTIVE`
+          #   contains the `CREATING`, `UPDATING`, and `RUNNING` states. `INACTIVE`
+          #   contains the `DELETING` and `ERROR` states.
+          #   `clusterName` is the name of the cluster provided at creation time.
+          #   Only the logical `AND` operator is supported; space-separated items are
+          #   treated as having an implicit `AND` operator.
           #
           #   Example filter:
           #
@@ -615,10 +615,10 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
           #   # Iterate over all results.
@@ -653,7 +653,7 @@ module Google
 
           # Gets cluster diagnostic information.
           # After the operation completes, the Operation.response field
-          # contains +DiagnoseClusterOutputLocation+.
+          # contains `DiagnoseClusterOutputLocation`.
           #
           # @param project_id [String]
           #   Required. The ID of the Google Cloud Platform project that the cluster
@@ -672,13 +672,13 @@ module Google
           #
           #   cluster_controller_client = Google::Cloud::Dataproc::ClusterController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +cluster_name+:
+          #   # TODO: Initialize `cluster_name`:
           #   cluster_name = ''
           #
           #   # Register a callback during the method call.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/clusters.rb
@@ -88,8 +88,8 @@ module Google
         #   @return [Array<Google::Cloud::Dataproc::V1::NodeInitializationAction>]
         #     Optional. Commands to execute on each node after config is
         #     completed. By default, executables are run on master and all worker nodes.
-        #     You can test a node's +role+ metadata to run an executable on
-        #     a master or worker node, as shown below using +curl+ (you can also use +wget+):
+        #     You can test a node's `role` metadata to run an executable on
+        #     a master or worker node, as shown below using `curl` (you can also use `wget`):
         #
         #         ROLE=$(curl -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
         #         if [[ "${ROLE}" == 'Master' ]]; then
@@ -111,22 +111,22 @@ module Google
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * +https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]+
-        #     * +projects/[project_id]/zones/[zone]+
-        #     * +us-central1-f+
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/[zone]`
+        #     * `projects/[project_id]/zones/[zone]`
+        #     * `us-central1-f`
         # @!attribute [rw] network_uri
         #   @return [String]
         #     Optional. The Google Compute Engine network to be used for machine
         #     communications. Cannot be specified with subnetwork_uri. If neither
-        #     +network_uri+ nor +subnetwork_uri+ is specified, the "default" network of
+        #     `network_uri` nor `subnetwork_uri` is specified, the "default" network of
         #     the project is used, if it exists. Cannot be a "Custom Subnet Network" (see
         #     [Using Subnetworks](https://cloud.google.com/compute/docs/subnetworks) for more information).
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * +https://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default+
-        #     * +projects/[project_id]/regions/global/default+
-        #     * +default+
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/global/default`
+        #     * `projects/[project_id]/regions/global/default`
+        #     * `default`
         # @!attribute [rw] subnetwork_uri
         #   @return [String]
         #     Optional. The Google Compute Engine subnetwork to be used for machine
@@ -134,15 +134,15 @@ module Google
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * +https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0+
-        #     * +projects/[project_id]/regions/us-east1/sub0+
-        #     * +sub0+
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/regions/us-east1/sub0`
+        #     * `projects/[project_id]/regions/us-east1/sub0`
+        #     * `sub0`
         # @!attribute [rw] internal_ip_only
         #   @return [true, false]
         #     Optional. If true, all instances in the cluster will only have internal IP
         #     addresses. By default, clusters are not restricted to internal IP addresses,
         #     and will have ephemeral external IP addresses assigned to each instance.
-        #     This +internal_ip_only+ restriction can only be enabled for subnetwork
+        #     This `internal_ip_only` restriction can only be enabled for subnetwork
         #     enabled networks, and all off-cluster dependencies must be configured to be
         #     accessible without external IP addresses.
         # @!attribute [rw] service_account
@@ -156,7 +156,7 @@ module Google
         #
         #     (see https://cloud.google.com/compute/docs/access/service-accounts#custom_service_accounts
         #     for more information).
-        #     Example: +[account_id]@[project_id].iam.gserviceaccount.com+
+        #     Example: `[account_id]@[project_id].iam.gserviceaccount.com`
         # @!attribute [rw] service_account_scopes
         #   @return [Array<String>]
         #     Optional. The URIs of service account scopes to be included in Google
@@ -192,21 +192,21 @@ module Google
         # @!attribute [rw] instance_names
         #   @return [Array<String>]
         #     Optional. The list of instance names. Cloud Dataproc derives the names from
-        #     +cluster_name+, +num_instances+, and the instance group if not set by user
+        #     `cluster_name`, `num_instances`, and the instance group if not set by user
         #     (recommended practice is to let Cloud Dataproc derive the name).
         # @!attribute [rw] image_uri
         #   @return [String]
         #     Output-only. The Google Compute Engine image resource used for cluster
-        #     instances. Inferred from +SoftwareConfig.image_version+.
+        #     instances. Inferred from `SoftwareConfig.image_version`.
         # @!attribute [rw] machine_type_uri
         #   @return [String]
         #     Optional. The Google Compute Engine machine type used for cluster instances.
         #
         #     A full URL, partial URI, or short name are valid. Examples:
         #
-        #     * +https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2+
-        #     * +projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2+
-        #     * +n1-standard-2+
+        #     * `https://www.googleapis.com/compute/v1/projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+        #     * `projects/[project_id]/zones/us-east1-a/machineTypes/n1-standard-2`
+        #     * `n1-standard-2`
         # @!attribute [rw] disk_config
         #   @return [Google::Cloud::Dataproc::V1::DiskConfig]
         #     Optional. Disk option config settings.
@@ -246,9 +246,9 @@ module Google
         #     /compute/docs/reference/beta/acceleratorTypes)
         #
         #     Examples
-        #     * +https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80+
-        #     * +projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80+
-        #     * +nvidia-tesla-k80+
+        #     * `https://www.googleapis.com/compute/beta/projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+        #     * `projects/[project_id]/zones/us-east1-a/acceleratorTypes/nvidia-tesla-k80`
+        #     * `nvidia-tesla-k80`
         # @!attribute [rw] accelerator_count
         #   @return [Integer]
         #     The number of the accelerator cards of this type exposed to this instance.
@@ -339,25 +339,25 @@ module Google
         # @!attribute [rw] image_version
         #   @return [String]
         #     Optional. The version of software inside the cluster. It must match the
-        #     regular expression +[0-9]+\.[0-9]++. If unspecified, it defaults to the
+        #     regular expression `[0-9]+\.[0-9]+`. If unspecified, it defaults to the
         #     latest version (see [Cloud Dataproc Versioning](https://cloud.google.com/dataproc/versioning)).
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. The properties to set on daemon config files.
         #
-        #     Property keys are specified in +prefix:property+ format, such as
-        #     +core:fs.defaultFS+. The following are supported prefixes
+        #     Property keys are specified in `prefix:property` format, such as
+        #     `core:fs.defaultFS`. The following are supported prefixes
         #     and their mappings:
         #
-        #     * capacity-scheduler: +capacity-scheduler.xml+
-        #     * core:   +core-site.xml+
-        #     * distcp: +distcp-default.xml+
-        #     * hdfs:   +hdfs-site.xml+
-        #     * hive:   +hive-site.xml+
-        #     * mapred: +mapred-site.xml+
-        #     * pig:    +pig.properties+
-        #     * spark:  +spark-defaults.conf+
-        #     * yarn:   +yarn-site.xml+
+        #     * capacity-scheduler: `capacity-scheduler.xml`
+        #     * core:   `core-site.xml`
+        #     * distcp: `distcp-default.xml`
+        #     * hdfs:   `hdfs-site.xml`
+        #     * hive:   `hive-site.xml`
+        #     * mapred: `mapred-site.xml`
+        #     * pig:    `pig.properties`
+        #     * spark:  `spark-defaults.conf`
+        #     * yarn:   `yarn-site.xml`
         #
         #     For more information, see
         #     [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties).
@@ -404,11 +404,11 @@ module Google
         #     Required. The changes to the cluster.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
-        #     Required. Specifies the path, relative to +Cluster+, of
+        #     Required. Specifies the path, relative to `Cluster`, of
         #     the field to update. For example, to change the number of workers
-        #     in a cluster to 5, the +update_mask+ parameter would be
-        #     specified as +config.worker_config.num_instances+,
-        #     and the +PATCH+ request body would specify the new value, as follows:
+        #     in a cluster to 5, the `update_mask` parameter would be
+        #     specified as `config.worker_config.num_instances`,
+        #     and the `PATCH` request body would specify the new value, as follows:
         #
         #         {
         #           "config":{
@@ -418,8 +418,8 @@ module Google
         #           }
         #         }
         #     Similarly, to change the number of preemptible workers in a cluster to 5,
-        #     the +update_mask+ parameter would be
-        #     +config.secondary_worker_config.num_instances+, and the +PATCH+ request
+        #     the `update_mask` parameter would be
+        #     `config.secondary_worker_config.num_instances`, and the `PATCH` request
         #     body would be set as follows:
         #
         #         {
@@ -494,15 +494,15 @@ module Google
         #
         #     field = value [AND [field = value]] ...
         #
-        #     where **field** is one of +status.state+, +clusterName+, or +labels.[KEY]+,
-        #     and +[KEY]+ is a label key. **value** can be +*+ to match all values.
-        #     +status.state+ can be one of the following: +ACTIVE+, +INACTIVE+,
-        #     +CREATING+, +RUNNING+, +ERROR+, +DELETING+, or +UPDATING+. +ACTIVE+
-        #     contains the +CREATING+, +UPDATING+, and +RUNNING+ states. +INACTIVE+
-        #     contains the +DELETING+ and +ERROR+ states.
-        #     +clusterName+ is the name of the cluster provided at creation time.
-        #     Only the logical +AND+ operator is supported; space-separated items are
-        #     treated as having an implicit +AND+ operator.
+        #     where **field** is one of `status.state`, `clusterName`, or `labels.[KEY]`,
+        #     and `[KEY]` is a label key. **value** can be `*` to match all values.
+        #     `status.state` can be one of the following: `ACTIVE`, `INACTIVE`,
+        #     `CREATING`, `RUNNING`, `ERROR`, `DELETING`, or `UPDATING`. `ACTIVE`
+        #     contains the `CREATING`, `UPDATING`, and `RUNNING` states. `INACTIVE`
+        #     contains the `DELETING` and `ERROR` states.
+        #     `clusterName` is the name of the cluster provided at creation time.
+        #     Only the logical `AND` operator is supported; space-separated items are
+        #     treated as having an implicit `AND` operator.
         #
         #     Example filter:
         #
@@ -524,7 +524,7 @@ module Google
         #   @return [String]
         #     Output-only. This token is included in the response if there are more
         #     results to fetch. To fetch additional results, provide this value as the
-        #     +page_token+ in a subsequent +ListClustersRequest+.
+        #     `page_token` in a subsequent `ListClustersRequest`.
         class ListClustersResponse; end
 
         # A request to collect cluster diagnostic information.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/cloud/dataproc/v1/jobs.rb
@@ -71,11 +71,11 @@ module Google
         # @!attribute [rw] main_class
         #   @return [String]
         #     The name of the driver's main class. The jar file containing the class
-        #     must be in the default CLASSPATH or specified in +jar_file_uris+.
+        #     must be in the default CLASSPATH or specified in `jar_file_uris`.
         # @!attribute [rw] args
         #   @return [Array<String>]
         #     Optional. The arguments to pass to the driver. Do not
-        #     include arguments, such as +-libjars+ or +-Dfoo=bar+, that can be set as job
+        #     include arguments, such as `-libjars` or `-Dfoo=bar`, that can be set as job
         #     properties, since a collision may occur that causes an incorrect job
         #     submission.
         # @!attribute [rw] jar_file_uris
@@ -111,11 +111,11 @@ module Google
         # @!attribute [rw] main_class
         #   @return [String]
         #     The name of the driver's main class. The jar file that contains the class
-        #     must be in the default CLASSPATH or specified in +jar_file_uris+.
+        #     must be in the default CLASSPATH or specified in `jar_file_uris`.
         # @!attribute [rw] args
         #   @return [Array<String>]
         #     Optional. The arguments to pass to the driver. Do not include arguments,
-        #     such as +--conf+, that can be set as job properties, since a collision may
+        #     such as `--conf`, that can be set as job properties, since a collision may
         #     occur that causes an incorrect job submission.
         # @!attribute [rw] jar_file_uris
         #   @return [Array<String>]
@@ -151,7 +151,7 @@ module Google
         # @!attribute [rw] args
         #   @return [Array<String>]
         #     Optional. The arguments to pass to the driver.  Do not include arguments,
-        #     such as +--conf+, that can be set as job properties, since a collision may
+        #     such as `--conf`, that can be set as job properties, since a collision may
         #     occur that causes an incorrect job submission.
         # @!attribute [rw] python_file_uris
         #   @return [Array<String>]
@@ -210,12 +210,12 @@ module Google
         # @!attribute [rw] continue_on_failure
         #   @return [true, false]
         #     Optional. Whether to continue executing queries if a query fails.
-        #     The default value is +false+. Setting to +true+ can be useful when executing
+        #     The default value is `false`. Setting to `true` can be useful when executing
         #     independent parallel queries.
         # @!attribute [rw] script_variables
         #   @return [Hash{String => String}]
         #     Optional. Mapping of query variable names to values (equivalent to the
-        #     Hive command: +SET name="value";+).
+        #     Hive command: `SET name="value";`).
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. A mapping of property names and values, used to configure Hive.
@@ -240,7 +240,7 @@ module Google
         # @!attribute [rw] script_variables
         #   @return [Hash{String => String}]
         #     Optional. Mapping of query variable names to values (equivalent to the
-        #     Spark SQL command: SET +name="value";+).
+        #     Spark SQL command: SET `name="value";`).
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. A mapping of property names to values, used to configure
@@ -265,12 +265,12 @@ module Google
         # @!attribute [rw] continue_on_failure
         #   @return [true, false]
         #     Optional. Whether to continue executing queries if a query fails.
-        #     The default value is +false+. Setting to +true+ can be useful when executing
+        #     The default value is `false`. Setting to `true` can be useful when executing
         #     independent parallel queries.
         # @!attribute [rw] script_variables
         #   @return [Hash{String => String}]
         #     Optional. Mapping of query variable names to values (equivalent to the Pig
-        #     command: +name=[value]+).
+        #     command: `name=[value]`).
         # @!attribute [rw] properties
         #   @return [Hash{String => String}]
         #     Optional. A mapping of property names to values, used to configure Pig.
@@ -492,7 +492,7 @@ module Google
         #   @return [String]
         #     Output-only. If present, the location of miscellaneous control files
         #     which may be used as part of job setup and handling. If not present,
-        #     control files may be placed in the same location as +driver_output_uri+.
+        #     control files may be placed in the same location as `driver_output_uri`.
         # @!attribute [rw] labels
         #   @return [Hash{String => String}]
         #     Optional. The labels to associate with this job.
@@ -572,7 +572,7 @@ module Google
         #     Optional. Specifies enumerated categories of jobs to list.
         #     (default = match ALL jobs).
         #
-        #     If +filter+ is provided, +jobStateMatcher+ will be ignored.
+        #     If `filter` is provided, `jobStateMatcher` will be ignored.
         # @!attribute [rw] filter
         #   @return [String]
         #     Optional. A filter constraining the jobs to list. Filters are
@@ -580,11 +580,11 @@ module Google
         #
         #     [field = value] AND [field [= value]] ...
         #
-        #     where **field** is +status.state+ or +labels.[KEY]+, and +[KEY]+ is a label
-        #     key. **value** can be +*+ to match all values.
-        #     +status.state+ can be either +ACTIVE+ or +NON_ACTIVE+.
-        #     Only the logical +AND+ operator is supported; space-separated items are
-        #     treated as having an implicit +AND+ operator.
+        #     where **field** is `status.state` or `labels.[KEY]`, and `[KEY]` is a label
+        #     key. **value** can be `*` to match all values.
+        #     `status.state` can be either `ACTIVE` or `NON_ACTIVE`.
+        #     Only the logical `AND` operator is supported; space-separated items are
+        #     treated as having an implicit `AND` operator.
         #
         #     Example filter:
         #
@@ -623,7 +623,7 @@ module Google
         #     Required. Specifies the path, relative to <code>Job</code>, of
         #     the field to update. For example, to update the labels of a Job the
         #     <code>update_mask</code> parameter would be specified as
-        #     <code>labels</code>, and the +PATCH+ request body would specify the new
+        #     <code>labels</code>, and the `PATCH` request body would specify the new
         #     value. <strong>Note:</strong> Currently, <code>labels</code> is the only
         #     field that can be updated.
         class UpdateJobRequest; end
@@ -636,7 +636,7 @@ module Google
         #   @return [String]
         #     Optional. This token is included in the response if there are more results
         #     to fetch. To fetch additional results, provide this value as the
-        #     +page_token+ in a subsequent <code>ListJobsRequest</code>.
+        #     `page_token` in a subsequent <code>ListJobsRequest</code>.
         class ListJobsResponse; end
 
         # A request to cancel a job.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/rpc/status.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
+++ b/google-cloud-dataproc/lib/google/cloud/dataproc/v1/job_controller_client.rb
@@ -228,13 +228,13 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +job+:
+          #   # TODO: Initialize `job`:
           #   job = {}
           #   response = job_controller_client.submit_job(project_id, region, job)
 
@@ -275,13 +275,13 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +job_id+:
+          #   # TODO: Initialize `job_id`:
           #   job_id = ''
           #   response = job_controller_client.get_job(project_id, region, job_id)
 
@@ -320,18 +320,18 @@ module Google
           #   Optional. Specifies enumerated categories of jobs to list.
           #   (default = match ALL jobs).
           #
-          #   If +filter+ is provided, +jobStateMatcher+ will be ignored.
+          #   If `filter` is provided, `jobStateMatcher` will be ignored.
           # @param filter [String]
           #   Optional. A filter constraining the jobs to list. Filters are
           #   case-sensitive and have the following syntax:
           #
           #   [field = value] AND [field [= value]] ...
           #
-          #   where **field** is +status.state+ or +labels.[KEY]+, and +[KEY]+ is a label
-          #   key. **value** can be +*+ to match all values.
-          #   +status.state+ can be either +ACTIVE+ or +NON_ACTIVE+.
-          #   Only the logical +AND+ operator is supported; space-separated items are
-          #   treated as having an implicit +AND+ operator.
+          #   where **field** is `status.state` or `labels.[KEY]`, and `[KEY]` is a label
+          #   key. **value** can be `*` to match all values.
+          #   `status.state` can be either `ACTIVE` or `NON_ACTIVE`.
+          #   Only the logical `AND` operator is supported; space-separated items are
+          #   treated as having an implicit `AND` operator.
           #
           #   Example filter:
           #
@@ -353,10 +353,10 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
           #   # Iterate over all results.
@@ -410,7 +410,7 @@ module Google
           #   Required. Specifies the path, relative to <code>Job</code>, of
           #   the field to update. For example, to update the labels of a Job the
           #   <code>update_mask</code> parameter would be specified as
-          #   <code>labels</code>, and the +PATCH+ request body would specify the new
+          #   <code>labels</code>, and the `PATCH` request body would specify the new
           #   value. <strong>Note:</strong> Currently, <code>labels</code> is the only
           #   field that can be updated.
           #   A hash of the same form as `Google::Protobuf::FieldMask`
@@ -428,19 +428,19 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +job_id+:
+          #   # TODO: Initialize `job_id`:
           #   job_id = ''
           #
-          #   # TODO: Initialize +job+:
+          #   # TODO: Initialize `job`:
           #   job = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = job_controller_client.update_job(project_id, region, job_id, job, update_mask)
 
@@ -488,13 +488,13 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +job_id+:
+          #   # TODO: Initialize `job_id`:
           #   job_id = ''
           #   response = job_controller_client.cancel_job(project_id, region, job_id)
 
@@ -514,7 +514,7 @@ module Google
           end
 
           # Deletes the job from the project. If the job is active, the delete fails,
-          # and the response returns +FAILED_PRECONDITION+.
+          # and the response returns `FAILED_PRECONDITION`.
           #
           # @param project_id [String]
           #   Required. The ID of the Google Cloud Platform project that the job
@@ -535,13 +535,13 @@ module Google
           #
           #   job_controller_client = Google::Cloud::Dataproc::JobController.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +region+:
+          #   # TODO: Initialize `region`:
           #   region = ''
           #
-          #   # TODO: Initialize +job_id+:
+          #   # TODO: Initialize `job_id`:
           #   job_id = ''
           #   job_controller_client.delete_job(project_id, region, job_id)
 

--- a/google-cloud-dataproc/synth.py
+++ b/google-cloud-dataproc/synth.py
@@ -46,10 +46,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/datastore_client.rb
@@ -230,10 +230,10 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +keys+:
+          #   # TODO: Initialize `keys`:
           #   keys = []
           #   response = datastore_client.lookup(project_id, keys)
 
@@ -288,10 +288,10 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +partition_id+:
+          #   # TODO: Initialize `partition_id`:
           #   partition_id = {}
           #   response = datastore_client.run_query(project_id, partition_id)
 
@@ -335,7 +335,7 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #   response = datastore_client.begin_transaction(project_id)
 
@@ -358,20 +358,20 @@ module Google
           # @param project_id [String]
           #   The ID of the project against which to make the request.
           # @param mode [Google::Datastore::V1::CommitRequest::Mode]
-          #   The type of commit to perform. Defaults to +TRANSACTIONAL+.
+          #   The type of commit to perform. Defaults to `TRANSACTIONAL`.
           # @param mutations [Array<Google::Datastore::V1::Mutation | Hash>]
           #   The mutations to perform.
           #
-          #   When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+          #   When mode is `TRANSACTIONAL`, mutations affecting a single entity are
           #   applied in order. The following sequences of mutations affecting a single
-          #   entity are not permitted in a single +Commit+ request:
+          #   entity are not permitted in a single `Commit` request:
           #
-          #   * +insert+ followed by +insert+
-          #   * +update+ followed by +insert+
-          #   * +upsert+ followed by +insert+
-          #   * +delete+ followed by +update+
+          #   * `insert` followed by `insert`
+          #   * `update` followed by `insert`
+          #   * `upsert` followed by `insert`
+          #   * `delete` followed by `update`
           #
-          #   When mode is +NON_TRANSACTIONAL+, no two mutations may affect a single
+          #   When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
           #   entity.
           #   A hash of the same form as `Google::Datastore::V1::Mutation`
           #   can also be provided.
@@ -392,13 +392,13 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +mode+:
+          #   # TODO: Initialize `mode`:
           #   mode = :MODE_UNSPECIFIED
           #
-          #   # TODO: Initialize +mutations+:
+          #   # TODO: Initialize `mutations`:
           #   mutations = []
           #   response = datastore_client.commit(project_id, mode, mutations)
 
@@ -439,10 +439,10 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +transaction+:
+          #   # TODO: Initialize `transaction`:
           #   transaction = ''
           #   response = datastore_client.rollback(project_id, transaction)
 
@@ -482,10 +482,10 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +keys+:
+          #   # TODO: Initialize `keys`:
           #   keys = []
           #   response = datastore_client.allocate_ids(project_id, keys)
 
@@ -527,10 +527,10 @@ module Google
           #
           #   datastore_client = Google::Cloud::Datastore.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +keys+:
+          #   # TODO: Initialize `keys`:
           #   keys = []
           #   response = datastore_client.reserve_ids(project_id, keys)
 

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/datastore.rb
@@ -31,12 +31,12 @@ module Google
       # The response for {Google::Datastore::V1::Datastore::Lookup Datastore::Lookup}.
       # @!attribute [rw] found
       #   @return [Array<Google::Datastore::V1::EntityResult>]
-      #     Entities found as +ResultType.FULL+ entities. The order of results in this
+      #     Entities found as `ResultType.FULL` entities. The order of results in this
       #     field is undefined and has no relation to the order of the keys in the
       #     input.
       # @!attribute [rw] missing
       #   @return [Array<Google::Datastore::V1::EntityResult>]
-      #     Entities not found as +ResultType.KEY_ONLY+ entities. The order of results
+      #     Entities not found as `ResultType.KEY_ONLY` entities. The order of results
       #     in this field is undefined and has no relation to the order of the keys
       #     in the input.
       # @!attribute [rw] deferred
@@ -73,7 +73,7 @@ module Google
       #     A batch of query results (always present).
       # @!attribute [rw] query
       #   @return [Google::Datastore::V1::Query]
-      #     The parsed form of the +GqlQuery+ from the request, if it was set.
+      #     The parsed form of the `GqlQuery` from the request, if it was set.
       class RunQueryResponse; end
 
       # The request for {Google::Datastore::V1::Datastore::BeginTransaction Datastore::BeginTransaction}.
@@ -111,7 +111,7 @@ module Google
       #     The ID of the project against which to make the request.
       # @!attribute [rw] mode
       #   @return [Google::Datastore::V1::CommitRequest::Mode]
-      #     The type of commit to perform. Defaults to +TRANSACTIONAL+.
+      #     The type of commit to perform. Defaults to `TRANSACTIONAL`.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The identifier of the transaction associated with the commit. A
@@ -121,16 +121,16 @@ module Google
       #   @return [Array<Google::Datastore::V1::Mutation>]
       #     The mutations to perform.
       #
-      #     When mode is +TRANSACTIONAL+, mutations affecting a single entity are
+      #     When mode is `TRANSACTIONAL`, mutations affecting a single entity are
       #     applied in order. The following sequences of mutations affecting a single
-      #     entity are not permitted in a single +Commit+ request:
+      #     entity are not permitted in a single `Commit` request:
       #
-      #     * +insert+ followed by +insert+
-      #     * +update+ followed by +insert+
-      #     * +upsert+ followed by +insert+
-      #     * +delete+ followed by +update+
+      #     * `insert` followed by `insert`
+      #     * `update` followed by `insert`
+      #     * `upsert` followed by `insert`
+      #     * `delete` followed by `update`
       #
-      #     When mode is +NON_TRANSACTIONAL+, no two mutations may affect a single
+      #     When mode is `NON_TRANSACTIONAL`, no two mutations may affect a single
       #     entity.
       class CommitRequest
         # The modes available for commits.
@@ -236,7 +236,7 @@ module Google
       # @!attribute [rw] read_consistency
       #   @return [Google::Datastore::V1::ReadOptions::ReadConsistency]
       #     The non-transactional read consistency to use.
-      #     Cannot be set to +STRONG+ for global queries.
+      #     Cannot be set to `STRONG` for global queries.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The identifier of the transaction in which to read. A

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/entity.rb
@@ -24,10 +24,10 @@ module Google
       #
       # Partition dimensions:
       #
-      # * May be +""+.
+      # * May be `""`.
       # * Must be valid UTF-8 bytes.
-      # * Must have values that match regex +[A-Za-z\d\.\-_]{1,100}+
-      #   If the value of any dimension matches regex +__.*__+, the partition is
+      # * Must have values that match regex `[A-Za-z\d\.\-_]{1,100}`
+      #   If the value of any dimension matches regex `__.*__`, the partition is
       #   reserved/read-only.
       #   A reserved/read-only partition ID is forbidden in certain documented
       #   contexts.
@@ -66,7 +66,7 @@ module Google
       #     are required to be in the path along with the entity identifier itself.
       #     The only exception is that in some documented cases, the identifier in the
       #     last path element (for the entity) itself may be omitted. For example,
-      #     the last path element of the key of +Mutation.insert+ may have no
+      #     the last path element of the key of `Mutation.insert` may have no
       #     identifier.
       #
       #     A path can never be empty, and a path can have at most 100 elements.
@@ -78,9 +78,9 @@ module Google
         # @!attribute [rw] kind
         #   @return [String]
         #     The kind of the entity.
-        #     A kind matching regex +__.*__+ is reserved/read-only.
+        #     A kind matching regex `__.*__` is reserved/read-only.
         #     A kind must not contain more than 1500 bytes when UTF-8 encoded.
-        #     Cannot be +""+.
+        #     Cannot be `""`.
         # @!attribute [rw] id
         #   @return [Integer]
         #     The auto-allocated ID of the entity.
@@ -89,9 +89,9 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     The name of the entity.
-        #     A name matching regex +__.*__+ is reserved/read-only.
+        #     A name matching regex `__.*__` is reserved/read-only.
         #     A name must not be more than 1500 bytes when UTF-8 encoded.
-        #     Cannot be +""+.
+        #     Cannot be `""`.
         class PathElement; end
       end
 
@@ -128,13 +128,13 @@ module Google
       # @!attribute [rw] string_value
       #   @return [String]
       #     A UTF-8 encoded string value.
-      #     When +exclude_from_indexes+ is false (it is indexed) , may have at most 1500 bytes.
+      #     When `exclude_from_indexes` is false (it is indexed) , may have at most 1500 bytes.
       #     Otherwise, may be set to at least 1,000,000 bytes.
       # @!attribute [rw] blob_value
       #   @return [String]
       #     A blob value.
       #     May have at most 1,000,000 bytes.
-      #     When +exclude_from_indexes+ is false, may have at most 1500 bytes.
+      #     When `exclude_from_indexes` is false, may have at most 1500 bytes.
       #     In JSON requests, must be base64-encoded.
       # @!attribute [rw] geo_point_value
       #   @return [Google::Type::LatLng]
@@ -150,11 +150,11 @@ module Google
       #   @return [Google::Datastore::V1::ArrayValue]
       #     An array value.
       #     Cannot contain another array value.
-      #     A +Value+ instance that sets field +array_value+ must not set fields
-      #     +meaning+ or +exclude_from_indexes+.
+      #     A `Value` instance that sets field `array_value` must not set fields
+      #     `meaning` or `exclude_from_indexes`.
       # @!attribute [rw] meaning
       #   @return [Integer]
-      #     The +meaning+ field should only be populated for backwards compatibility.
+      #     The `meaning` field should only be populated for backwards compatibility.
       # @!attribute [rw] exclude_from_indexes
       #   @return [true, false]
       #     If the value should be excluded from all indexes including those defined
@@ -171,17 +171,17 @@ module Google
       #     The entity's key.
       #
       #     An entity must have a key, unless otherwise documented (for example,
-      #     an entity in +Value.entity_value+ may have no key).
+      #     an entity in `Value.entity_value` may have no key).
       #     An entity's kind is its key path's last element's kind,
       #     or null if it has no key.
       # @!attribute [rw] properties
       #   @return [Hash{String => Google::Datastore::V1::Value}]
       #     The entity's properties.
       #     The map's keys are property names.
-      #     A property name matching regex +__.*__+ is reserved.
+      #     A property name matching regex `__.*__` is reserved.
       #     A reserved property name is forbidden in certain documented contexts.
       #     The name must not contain more than 500 characters.
-      #     The name cannot be +""+.
+      #     The name cannot be `""`.
       class Entity; end
     end
   end

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/datastore/v1/query.rb
@@ -25,22 +25,22 @@ module Google
       #     The version of the entity, a strictly positive number that monotonically
       #     increases with changes to the entity.
       #
-      #     This field is set for {Google::Datastore::V1::EntityResult::ResultType::FULL +FULL+} entity
+      #     This field is set for {Google::Datastore::V1::EntityResult::ResultType::FULL `FULL`} entity
       #     results.
       #
-      #     For {Google::Datastore::V1::LookupResponse#missing missing} entities in +LookupResponse+, this
+      #     For {Google::Datastore::V1::LookupResponse#missing missing} entities in `LookupResponse`, this
       #     is the version of the snapshot that was used to look up the entity, and it
       #     is always set except for eventually consistent reads.
       # @!attribute [rw] cursor
       #   @return [String]
       #     A cursor that points to the position after the result entity.
-      #     Set only when the +EntityResult+ is part of a +QueryResultBatch+ message.
+      #     Set only when the `EntityResult` is part of a `QueryResultBatch` message.
       class EntityResult
         # Specifies what data the 'entity' field contains.
-        # A +ResultType+ is either implied (for example, in +LookupResponse.missing+
-        # from +datastore.proto+, it is always +KEY_ONLY+) or specified by context
-        # (for example, in message +QueryResultBatch+, field +entity_result_type+
-        # specifies a +ResultType+ for all the values in field +entity_results+).
+        # A `ResultType` is either implied (for example, in `LookupResponse.missing`
+        # from `datastore.proto`, it is always `KEY_ONLY`) or specified by context
+        # (for example, in message `QueryResultBatch`, field `entity_result_type`
+        # specifies a `ResultType` for all the values in field `entity_results`).
         module ResultType
           # Unspecified. This value is never used.
           RESULT_TYPE_UNSPECIFIED = 0
@@ -122,7 +122,7 @@ module Google
       #     The property to order by.
       # @!attribute [rw] direction
       #   @return [Google::Datastore::V1::PropertyOrder::Direction]
-      #     The direction to order by. Defaults to +ASCENDING+.
+      #     The direction to order by. Defaults to `ASCENDING`.
       class PropertyOrder
         # The sort direction.
         module Direction
@@ -210,21 +210,21 @@ module Google
       #   @return [true, false]
       #     When false, the query string must not contain any literals and instead must
       #     bind all values. For example,
-      #     +SELECT * FROM Kind WHERE a = 'string literal'+ is not allowed, while
-      #     +SELECT * FROM Kind WHERE a = @value+ is.
+      #     `SELECT * FROM Kind WHERE a = 'string literal'` is not allowed, while
+      #     `SELECT * FROM Kind WHERE a = @value` is.
       # @!attribute [rw] named_bindings
       #   @return [Hash{String => Google::Datastore::V1::GqlQueryParameter}]
       #     For each non-reserved named binding site in the query string, there must be
       #     a named parameter with that name, but not necessarily the inverse.
       #
-      #     Key must match regex +[A-Za-z_$][A-Za-z_$0-9]*+, must not match regex
-      #     +__.*__+, and must not be +""+.
+      #     Key must match regex `[A-Za-z_$][A-Za-z_$0-9]*`, must not match regex
+      #     `__.*__`, and must not be `""`.
       # @!attribute [rw] positional_bindings
       #   @return [Array<Google::Datastore::V1::GqlQueryParameter>]
       #     Numbered binding site @1 references the first numbered parameter,
       #     effectively using 1-based indexing, rather than the usual 0.
       #
-      #     For each binding site numbered i in +query_string+, there must be an i-th
+      #     For each binding site numbered i in `query_string`, there must be an i-th
       #     numbered parameter. The inverse must also be true.
       class GqlQuery; end
 
@@ -245,10 +245,10 @@ module Google
       # @!attribute [rw] skipped_cursor
       #   @return [String]
       #     A cursor that points to the position after the last skipped result.
-      #     Will be set when +skipped_results+ != 0.
+      #     Will be set when `skipped_results` != 0.
       # @!attribute [rw] entity_result_type
       #   @return [Google::Datastore::V1::EntityResult::ResultType]
-      #     The result type for every entity in +entity_results+.
+      #     The result type for every entity in `entity_results`.
       # @!attribute [rw] entity_results
       #   @return [Array<Google::Datastore::V1::EntityResult>]
       #     The results for this batch.
@@ -261,16 +261,16 @@ module Google
       # @!attribute [rw] snapshot_version
       #   @return [Integer]
       #     The version number of the snapshot this batch was returned from.
-      #     This applies to the range of results from the query's +start_cursor+ (or
+      #     This applies to the range of results from the query's `start_cursor` (or
       #     the beginning of the query if no cursor was given) to this batch's
-      #     +end_cursor+ (not the query's +end_cursor+).
+      #     `end_cursor` (not the query's `end_cursor`).
       #
       #     In a single transaction, subsequent query result batches for the same query
       #     can have a greater snapshot version number. Each batch's snapshot version
       #     is valid for all preceding batches.
       #     The value will be zero for eventually consistent queries.
       class QueryResultBatch
-        # The possible values for the +more_results+ field.
+        # The possible values for the `more_results` field.
         module MoreResultsType
           # Unspecified. This value is never used.
           MORE_RESULTS_TYPE_UNSPECIFIED = 0

--- a/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-datastore/lib/google/cloud/datastore/v1/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2.rb
@@ -155,10 +155,10 @@ module Google
           #
           # The debugger agents register with the Controller to identify the application
           # being debugged, the Debuggee. All agents that register with the same data,
-          # represent the same Debuggee, and are assigned the same +debuggee_id+.
+          # represent the same Debuggee, and are assigned the same `debuggee_id`.
           #
           # The debugger agents call the Controller to retrieve  the list of active
-          # Breakpoints. Agents with the same +debuggee_id+ get the same breakpoints
+          # Breakpoints. Agents with the same `debuggee_id` get the same breakpoints
           # list. An agent that can fulfill the breakpoint request updates the
           # Controller with the breakpoint result. The controller selects the first
           # result received and discards the rest of the results.

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/controller2_client.rb
@@ -38,10 +38,10 @@ module Google
         #
         # The debugger agents register with the Controller to identify the application
         # being debugged, the Debuggee. All agents that register with the same data,
-        # represent the same Debuggee, and are assigned the same +debuggee_id+.
+        # represent the same Debuggee, and are assigned the same `debuggee_id`.
         #
         # The debugger agents call the Controller to retrieve  the list of active
-        # Breakpoints. Agents with the same +debuggee_id+ get the same breakpoints
+        # Breakpoints. Agents with the same `debuggee_id` get the same breakpoints
         # list. An agent that can fulfill the breakpoint request updates the
         # Controller with the breakpoint result. The controller selects the first
         # result received and discards the rest of the results.
@@ -202,17 +202,17 @@ module Google
           # Registers the debuggee with the controller service.
           #
           # All agents attached to the same application must call this method with
-          # exactly the same request content to get back the same stable +debuggee_id+.
-          # Agents should call this method again whenever +google.rpc.Code.NOT_FOUND+
+          # exactly the same request content to get back the same stable `debuggee_id`.
+          # Agents should call this method again whenever `google.rpc.Code.NOT_FOUND`
           # is returned from any controller method.
           #
           # This protocol allows the controller service to disable debuggees, recover
-          # from data loss, or change the +debuggee_id+ format. Agents must handle
-          # +debuggee_id+ value changing upon re-registration.
+          # from data loss, or change the `debuggee_id` format. Agents must handle
+          # `debuggee_id` value changing upon re-registration.
           #
           # @param debuggee [Google::Devtools::Clouddebugger::V2::Debuggee | Hash]
           #   Debuggee information to register.
-          #   The fields +project+, +uniquifier+, +description+ and +agent_version+
+          #   The fields `project`, `uniquifier`, `description` and `agent_version`
           #   of the debuggee must be set.
           #   A hash of the same form as `Google::Devtools::Clouddebugger::V2::Debuggee`
           #   can also be provided.
@@ -229,7 +229,7 @@ module Google
           #
           #   controller2_client = Google::Cloud::Debugger::V2::Controller2.new
           #
-          #   # TODO: Initialize +debuggee+:
+          #   # TODO: Initialize `debuggee`:
           #   debuggee = {}
           #   response = controller2_client.register_debuggee(debuggee)
 
@@ -246,7 +246,7 @@ module Google
 
           # Returns the list of all active breakpoints for the debuggee.
           #
-          # The breakpoint specification (+location+, +condition+, and +expressions+
+          # The breakpoint specification (`location`, `condition`, and `expressions`
           # fields) is semantically immutable, although the field values may
           # change. For example, an agent may update the location line number
           # to reflect the actual line where the breakpoint was set, but this
@@ -263,14 +263,14 @@ module Google
           # @param wait_token [String]
           #   A token that, if specified, blocks the method call until the list
           #   of active breakpoints has changed, or a server-selected timeout has
-          #   expired. The value should be set from the +next_wait_token+ field in
-          #   the last response. The initial value should be set to +"init"+.
+          #   expired. The value should be set from the `next_wait_token` field in
+          #   the last response. The initial value should be set to `"init"`.
           # @param success_on_timeout [true, false]
-          #   If set to +true+ (recommended), returns +google.rpc.Code.OK+ status and
-          #   sets the +wait_expired+ response field to +true+ when the server-selected
+          #   If set to `true` (recommended), returns `google.rpc.Code.OK` status and
+          #   sets the `wait_expired` response field to `true` when the server-selected
           #   timeout has expired.
           #
-          #   If set to +false+ (deprecated), returns +google.rpc.Code.ABORTED+ status
+          #   If set to `false` (deprecated), returns `google.rpc.Code.ABORTED` status
           #   when the server-selected timeout has expired.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -285,7 +285,7 @@ module Google
           #
           #   controller2_client = Google::Cloud::Debugger::V2::Controller2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #   response = controller2_client.list_active_breakpoints(debuggee_id)
 
@@ -308,8 +308,8 @@ module Google
           # The entire Breakpoint message must be sent back to the controller service.
           #
           # Updates to active breakpoint fields are only allowed if the new value
-          # does not change the breakpoint specification. Updates to the +location+,
-          # +condition+ and +expressions+ fields should not alter the breakpoint
+          # does not change the breakpoint specification. Updates to the `location`,
+          # `condition` and `expressions` fields should not alter the breakpoint
           # semantics. These may only make changes such as canonicalizing a value
           # or snapping the location to the correct line of code.
           #
@@ -317,7 +317,7 @@ module Google
           #   Identifies the debuggee being debugged.
           # @param breakpoint [Google::Devtools::Clouddebugger::V2::Breakpoint | Hash]
           #   Updated breakpoint information.
-          #   The field +id+ must be set.
+          #   The field `id` must be set.
           #   The agent must echo all Breakpoint specification fields in the update.
           #   A hash of the same form as `Google::Devtools::Clouddebugger::V2::Breakpoint`
           #   can also be provided.
@@ -334,10 +334,10 @@ module Google
           #
           #   controller2_client = Google::Cloud::Debugger::V2::Controller2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #
-          #   # TODO: Initialize +breakpoint+:
+          #   # TODO: Initialize `breakpoint`:
           #   breakpoint = {}
           #   response = controller2_client.update_active_breakpoint(debuggee_id, breakpoint)
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/debugger2_client.rb
@@ -207,12 +207,12 @@ module Google
           #   ID of the debuggee where the breakpoint is to be set.
           # @param breakpoint [Google::Devtools::Clouddebugger::V2::Breakpoint | Hash]
           #   Breakpoint specification to set.
-          #   The field +location+ of the breakpoint must be set.
+          #   The field `location` of the breakpoint must be set.
           #   A hash of the same form as `Google::Devtools::Clouddebugger::V2::Breakpoint`
           #   can also be provided.
           # @param client_version [String]
           #   The client version making the call.
-          #   Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+          #   Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -226,13 +226,13 @@ module Google
           #
           #   debugger2_client = Google::Cloud::Debugger::V2::Debugger2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #
-          #   # TODO: Initialize +breakpoint+:
+          #   # TODO: Initialize `breakpoint`:
           #   breakpoint = {}
           #
-          #   # TODO: Initialize +client_version+:
+          #   # TODO: Initialize `client_version`:
           #   client_version = ''
           #   response = debugger2_client.set_breakpoint(debuggee_id, breakpoint, client_version)
 
@@ -259,7 +259,7 @@ module Google
           #   ID of the breakpoint to get.
           # @param client_version [String]
           #   The client version making the call.
-          #   Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+          #   Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -273,13 +273,13 @@ module Google
           #
           #   debugger2_client = Google::Cloud::Debugger::V2::Debugger2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #
-          #   # TODO: Initialize +breakpoint_id+:
+          #   # TODO: Initialize `breakpoint_id`:
           #   breakpoint_id = ''
           #
-          #   # TODO: Initialize +client_version+:
+          #   # TODO: Initialize `client_version`:
           #   client_version = ''
           #   response = debugger2_client.get_breakpoint(debuggee_id, breakpoint_id, client_version)
 
@@ -306,7 +306,7 @@ module Google
           #   ID of the breakpoint to delete.
           # @param client_version [String]
           #   The client version making the call.
-          #   Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+          #   Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -319,13 +319,13 @@ module Google
           #
           #   debugger2_client = Google::Cloud::Debugger::V2::Debugger2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #
-          #   # TODO: Initialize +breakpoint_id+:
+          #   # TODO: Initialize `breakpoint_id`:
           #   breakpoint_id = ''
           #
-          #   # TODO: Initialize +client_version+:
+          #   # TODO: Initialize `client_version`:
           #   client_version = ''
           #   debugger2_client.delete_breakpoint(debuggee_id, breakpoint_id, client_version)
 
@@ -351,12 +351,12 @@ module Google
           #   ID of the debuggee whose breakpoints to list.
           # @param client_version [String]
           #   The client version making the call.
-          #   Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+          #   Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
           # @param include_all_users [true, false]
-          #   When set to +true+, the response includes the list of breakpoints set by
+          #   When set to `true`, the response includes the list of breakpoints set by
           #   any user. Otherwise, it includes only breakpoints set by the caller.
           # @param include_inactive [true, false]
-          #   When set to +true+, the response includes active and inactive
+          #   When set to `true`, the response includes active and inactive
           #   breakpoints. Otherwise, it includes only active breakpoints.
           # @param action [Google::Devtools::Clouddebugger::V2::ListBreakpointsRequest::BreakpointActionValue | Hash]
           #   When set, the response includes only breakpoints with the specified action.
@@ -364,13 +364,13 @@ module Google
           #   can also be provided.
           # @param strip_results [true, false]
           #   This field is deprecated. The following fields are always stripped out of
-          #   the result: +stack_frames+, +evaluated_expressions+ and +variable_table+.
+          #   the result: `stack_frames`, `evaluated_expressions` and `variable_table`.
           # @param wait_token [String]
           #   A wait token that, if specified, blocks the call until the breakpoints
           #   list has changed, or a server selected timeout has expired.  The value
           #   should be set from the last response. The error code
-          #   +google.rpc.Code.ABORTED+ (RPC) is returned on wait timeout, which
-          #   should be called again with the same +wait_token+.
+          #   `google.rpc.Code.ABORTED` (RPC) is returned on wait timeout, which
+          #   should be called again with the same `wait_token`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -384,10 +384,10 @@ module Google
           #
           #   debugger2_client = Google::Cloud::Debugger::V2::Debugger2.new
           #
-          #   # TODO: Initialize +debuggee_id+:
+          #   # TODO: Initialize `debuggee_id`:
           #   debuggee_id = ''
           #
-          #   # TODO: Initialize +client_version+:
+          #   # TODO: Initialize `client_version`:
           #   client_version = ''
           #   response = debugger2_client.list_breakpoints(debuggee_id, client_version)
 
@@ -420,9 +420,9 @@ module Google
           #   Project number of a Google Cloud project whose debuggees to list.
           # @param client_version [String]
           #   The client version making the call.
-          #   Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+          #   Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
           # @param include_inactive [true, false]
-          #   When set to +true+, the result includes all debuggees. Otherwise, the
+          #   When set to `true`, the result includes all debuggees. Otherwise, the
           #   result includes only debuggees that are active.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -437,10 +437,10 @@ module Google
           #
           #   debugger2_client = Google::Cloud::Debugger::V2::Debugger2.new
           #
-          #   # TODO: Initialize +project+:
+          #   # TODO: Initialize `project`:
           #   project = ''
           #
-          #   # TODO: Initialize +client_version+:
+          #   # TODO: Initialize `client_version`:
           #   client_version = ''
           #   response = debugger2_client.list_debuggees(project, client_version)
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/controller.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/controller.rb
@@ -21,7 +21,7 @@ module Google
         # @!attribute [rw] debuggee
         #   @return [Google::Devtools::Clouddebugger::V2::Debuggee]
         #     Debuggee information to register.
-        #     The fields +project+, +uniquifier+, +description+ and +agent_version+
+        #     The fields `project`, `uniquifier`, `description` and `agent_version`
         #     of the debuggee must be set.
         class RegisterDebuggeeRequest; end
 
@@ -29,10 +29,10 @@ module Google
         # @!attribute [rw] debuggee
         #   @return [Google::Devtools::Clouddebugger::V2::Debuggee]
         #     Debuggee resource.
-        #     The field +id+ is guranteed to be set (in addition to the echoed fields).
-        #     If the field +is_disabled+ is set to +true+, the agent should disable
+        #     The field `id` is guranteed to be set (in addition to the echoed fields).
+        #     If the field `is_disabled` is set to `true`, the agent should disable
         #     itself by removing all breakpoints and detaching from the application.
-        #     It should however continue to poll +RegisterDebuggee+ until reenabled.
+        #     It should however continue to poll `RegisterDebuggee` until reenabled.
         class RegisterDebuggeeResponse; end
 
         # Request to list active breakpoints.
@@ -43,15 +43,15 @@ module Google
         #   @return [String]
         #     A token that, if specified, blocks the method call until the list
         #     of active breakpoints has changed, or a server-selected timeout has
-        #     expired. The value should be set from the +next_wait_token+ field in
-        #     the last response. The initial value should be set to +"init"+.
+        #     expired. The value should be set from the `next_wait_token` field in
+        #     the last response. The initial value should be set to `"init"`.
         # @!attribute [rw] success_on_timeout
         #   @return [true, false]
-        #     If set to +true+ (recommended), returns +google.rpc.Code.OK+ status and
-        #     sets the +wait_expired+ response field to +true+ when the server-selected
+        #     If set to `true` (recommended), returns `google.rpc.Code.OK` status and
+        #     sets the `wait_expired` response field to `true` when the server-selected
         #     timeout has expired.
         #
-        #     If set to +false+ (deprecated), returns +google.rpc.Code.ABORTED+ status
+        #     If set to `false` (deprecated), returns `google.rpc.Code.ABORTED` status
         #     when the server-selected timeout has expired.
         class ListActiveBreakpointsRequest; end
 
@@ -59,16 +59,16 @@ module Google
         # @!attribute [rw] breakpoints
         #   @return [Array<Google::Devtools::Clouddebugger::V2::Breakpoint>]
         #     List of all active breakpoints.
-        #     The fields +id+ and +location+ are guaranteed to be set on each breakpoint.
+        #     The fields `id` and `location` are guaranteed to be set on each breakpoint.
         # @!attribute [rw] next_wait_token
         #   @return [String]
         #     A token that can be used in the next method call to block until
         #     the list of breakpoints changes.
         # @!attribute [rw] wait_expired
         #   @return [true, false]
-        #     If set to +true+, indicates that there is no change to the
+        #     If set to `true`, indicates that there is no change to the
         #     list of active breakpoints and the server-selected timeout has expired.
-        #     The +breakpoints+ field would be empty and should be ignored.
+        #     The `breakpoints` field would be empty and should be ignored.
         class ListActiveBreakpointsResponse; end
 
         # Request to update an active breakpoint.
@@ -78,7 +78,7 @@ module Google
         # @!attribute [rw] breakpoint
         #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint]
         #     Updated breakpoint information.
-        #     The field +id+ must be set.
+        #     The field `id` must be set.
         #     The agent must echo all Breakpoint specification fields in the update.
         class UpdateActiveBreakpointRequest; end
 

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/data.rb
@@ -20,15 +20,15 @@ module Google
         # Represents a message with parameters.
         # @!attribute [rw] format
         #   @return [String]
-        #     Format template for the message. The +format+ uses placeholders +$0+,
-        #     +$1+, etc. to reference parameters. +$$+ can be used to denote the +$+
+        #     Format template for the message. The `format` uses placeholders `$0`,
+        #     `$1`, etc. to reference parameters. `$$` can be used to denote the `$`
         #     character.
         #
         #     Examples:
         #
-        #     * +Failed to load '$0' which helps debug $1 the first time it
-        #       is loaded.  Again, $0 is very important.+
-        #     * +Please pay $$10 to use $0 instead of $1.+
+        #     * `Failed to load '$0' which helps debug $1 the first time it
+        #       is loaded.  Again, $0 is very important.`
+        #     * `Please pay $$10 to use $0 instead of $1.`
         # @!attribute [rw] parameters
         #   @return [Array<String>]
         #     Optional parameters to be embedded into the message.
@@ -37,8 +37,8 @@ module Google
         # Represents a contextual status message.
         # The message can indicate an error or informational status, and refer to
         # specific parts of the containing object.
-        # For example, the +Breakpoint.status+ field can indicate an error referring
-        # to the +BREAKPOINT_SOURCE_LOCATION+ with the message +Location not found+.
+        # For example, the `Breakpoint.status` field can indicate an error referring
+        # to the `BREAKPOINT_SOURCE_LOCATION` with the message `Location not found`.
         # @!attribute [rw] is_error
         #   @return [true, false]
         #     Distinguishes errors from informational messages.
@@ -80,7 +80,7 @@ module Google
         #     Path to the source file within the source context of the target binary.
         # @!attribute [rw] line
         #   @return [Integer]
-        #     Line inside the file. The first line in the file has the value +1+.
+        #     Line inside the file. The first line in the file has the value `1`.
         class SourceLocation; end
 
         # Represents a variable or an argument possibly of a compound object type.
@@ -132,7 +132,7 @@ module Google
         #     }
         #
         # The status should describe the reason for the missing value,
-        # such as +<optimized out>+, +<inaccessible>+, +<pointers limit reached>+.
+        # such as `<optimized out>`, `<inaccessible>`, `<pointers limit reached>`.
         #
         # Note that a null pointer should not have members.
         #
@@ -167,7 +167,7 @@ module Google
         #
         # To optimize computation, memory and network traffic, variables that
         # repeat in the output multiple times can be stored once in a shared
-        # variable table and be referenced using the +var_table_index+ field.  The
+        # variable table and be referenced using the `var_table_index` field.  The
         # variables stored in the shared table are nameless and are essentially
         # a partition of the complete variable. To reconstruct the complete
         # variable, merge the referencing variable with the referenced variable.
@@ -200,8 +200,8 @@ module Google
         #     Simple value of the variable.
         # @!attribute [rw] type
         #   @return [String]
-        #     Variable type (e.g. +MyClass+). If the variable is split with
-        #     +var_table_index+, +type+ goes next to +value+. The interpretation of
+        #     Variable type (e.g. `MyClass`). If the variable is split with
+        #     `var_table_index`, `type` goes next to `value`. The interpretation of
         #     a type is agent specific. It is recommended to include the dynamic type
         #     rather than a static type of an object.
         # @!attribute [rw] members
@@ -211,7 +211,7 @@ module Google
         #   @return [Google::Protobuf::Int32Value]
         #     Reference to a variable in the shared variable table. More than
         #     one variable can reference the same variable in the table. The
-        #     +var_table_index+ field is an index into +variable_table+ in Breakpoint.
+        #     `var_table_index` field is an index into `variable_table` in Breakpoint.
         # @!attribute [rw] status
         #   @return [Google::Devtools::Clouddebugger::V2::StatusMessage]
         #     Status associated with the variable. This field will usually stay
@@ -220,19 +220,19 @@ module Google
         #     might be reported in error state even when breakpoint is not in final
         #     state.
         #
-        #     The message may refer to variable name with +refers_to+ set to
-        #     +VARIABLE_NAME+. Alternatively +refers_to+ will be set to +VARIABLE_VALUE+.
+        #     The message may refer to variable name with `refers_to` set to
+        #     `VARIABLE_NAME`. Alternatively `refers_to` will be set to `VARIABLE_VALUE`.
         #     In either case variable value and members will be unset.
         #
-        #     Example of error message applied to name: +Invalid expression syntax+.
+        #     Example of error message applied to name: `Invalid expression syntax`.
         #
-        #     Example of information message applied to value: +Not captured+.
+        #     Example of information message applied to value: `Not captured`.
         #
         #     Examples of error message applied to value:
         #
-        #     * +Malformed string+,
-        #     * +Field f not found in class C+
-        #     * +Null pointer dereference+
+        #     * `Malformed string`,
+        #     * `Field f not found in class C`
+        #     * `Null pointer dereference`
         class Variable; end
 
         # Represents a stack frame context.
@@ -272,21 +272,21 @@ module Google
         #   @return [Array<String>]
         #     List of read-only expressions to evaluate at the breakpoint location.
         #     The expressions are composed using expressions in the programming language
-        #     at the source location. If the breakpoint action is +LOG+, the evaluated
+        #     at the source location. If the breakpoint action is `LOG`, the evaluated
         #     expressions are included in log statements.
         # @!attribute [rw] log_message_format
         #   @return [String]
-        #     Only relevant when action is +LOG+. Defines the message to log when
-        #     the breakpoint hits. The message may include parameter placeholders +$0+,
-        #     +$1+, etc. These placeholders are replaced with the evaluated value
+        #     Only relevant when action is `LOG`. Defines the message to log when
+        #     the breakpoint hits. The message may include parameter placeholders `$0`,
+        #     `$1`, etc. These placeholders are replaced with the evaluated value
         #     of the appropriate expression. Expressions not referenced in
-        #     +log_message_format+ are not logged.
+        #     `log_message_format` are not logged.
         #
-        #     Example: +Message received, id = $0, count = $1+ with
-        #     +expressions+ = +[ message.id, message.count ]+.
+        #     Example: `Message received, id = $0, count = $1` with
+        #     `expressions` = `[ message.id, message.count ]`.
         # @!attribute [rw] log_level
         #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint::LogLevel]
-        #     Indicates the severity of the log. Only relevant when action is +LOG+.
+        #     Indicates the severity of the log. Only relevant when action is `LOG`.
         # @!attribute [rw] is_final_state
         #   @return [true, false]
         #     When true, indicates that this is a final result and the
@@ -312,12 +312,12 @@ module Google
         #
         #     Error status indicates complete failure of the breakpoint.
         #
-        #     Example (non-final state): +Still loading symbols...+
+        #     Example (non-final state): `Still loading symbols...`
         #
         #     Examples (final state):
         #
-        #     * +Invalid line number+ referring to location
-        #     * +Field f not found in class C+ referring to condition
+        #     * `Invalid line number` referring to location
+        #     * `Field f not found in class C` referring to condition
         # @!attribute [rw] stack_frames
         #   @return [Array<Google::Devtools::Clouddebugger::V2::StackFrame>]
         #     The stack at breakpoint time.
@@ -325,22 +325,22 @@ module Google
         #   @return [Array<Google::Devtools::Clouddebugger::V2::Variable>]
         #     Values of evaluated expressions at breakpoint time.
         #     The evaluated expressions appear in exactly the same order they
-        #     are listed in the +expressions+ field.
-        #     The +name+ field holds the original expression text, the +value+ or
-        #     +members+ field holds the result of the evaluated expression.
-        #     If the expression cannot be evaluated, the +status+ inside the +Variable+
+        #     are listed in the `expressions` field.
+        #     The `name` field holds the original expression text, the `value` or
+        #     `members` field holds the result of the evaluated expression.
+        #     If the expression cannot be evaluated, the `status` inside the `Variable`
         #     will indicate an error and contain the error text.
         # @!attribute [rw] variable_table
         #   @return [Array<Google::Devtools::Clouddebugger::V2::Variable>]
-        #     The +variable_table+ exists to aid with computation, memory and network
+        #     The `variable_table` exists to aid with computation, memory and network
         #     traffic optimization.  It enables storing a variable once and reference
         #     it from multiple variables, including variables stored in the
-        #     +variable_table+ itself.
-        #     For example, the same +this+ object, which may appear at many levels of
+        #     `variable_table` itself.
+        #     For example, the same `this` object, which may appear at many levels of
         #     the stack, can have all of its data stored once in this table.  The
         #     stack frame variables then would hold only a reference to it.
         #
-        #     The variable +var_table_index+ field is an index into this repeated field.
+        #     The variable `var_table_index` field is an index into this repeated field.
         #     The stored objects are nameless and get their name from the referencing
         #     variable. The effective variable is a merge of the referencing variable
         #     and the referenced variable.
@@ -402,16 +402,16 @@ module Google
         #     information is recommended.
         # @!attribute [rw] is_inactive
         #   @return [true, false]
-        #     If set to +true+, indicates that Controller service does not detect any
+        #     If set to `true`, indicates that Controller service does not detect any
         #     activity from the debuggee agents and the application is possibly stopped.
         # @!attribute [rw] agent_version
         #   @return [String]
         #     Version ID of the agent.
-        #     Schema: +domain/language-platform/vmajor.minor+ (for example
-        #     +google.com/java-gcp/v1.1+).
+        #     Schema: `domain/language-platform/vmajor.minor` (for example
+        #     `google.com/java-gcp/v1.1`).
         # @!attribute [rw] is_disabled
         #   @return [true, false]
-        #     If set to +true+, indicates that the agent should disable itself and
+        #     If set to `true`, indicates that the agent should disable itself and
         #     detach from the debuggee.
         # @!attribute [rw] status
         #   @return [Google::Devtools::Clouddebugger::V2::StatusMessage]

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/devtools/clouddebugger/v2/debugger.rb
@@ -24,18 +24,18 @@ module Google
         # @!attribute [rw] breakpoint
         #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint]
         #     Breakpoint specification to set.
-        #     The field +location+ of the breakpoint must be set.
+        #     The field `location` of the breakpoint must be set.
         # @!attribute [rw] client_version
         #   @return [String]
         #     The client version making the call.
-        #     Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+        #     Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
         class SetBreakpointRequest; end
 
         # Response for setting a breakpoint.
         # @!attribute [rw] breakpoint
         #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint]
         #     Breakpoint resource.
-        #     The field +id+ is guaranteed to be set (in addition to the echoed fileds).
+        #     The field `id` is guaranteed to be set (in addition to the echoed fileds).
         class SetBreakpointResponse; end
 
         # Request to get breakpoint information.
@@ -48,14 +48,14 @@ module Google
         # @!attribute [rw] client_version
         #   @return [String]
         #     The client version making the call.
-        #     Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+        #     Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
         class GetBreakpointRequest; end
 
         # Response for getting breakpoint information.
         # @!attribute [rw] breakpoint
         #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint]
         #     Complete breakpoint state.
-        #     The fields +id+ and +location+ are guaranteed to be set.
+        #     The fields `id` and `location` are guaranteed to be set.
         class GetBreakpointResponse; end
 
         # Request to delete a breakpoint.
@@ -68,7 +68,7 @@ module Google
         # @!attribute [rw] client_version
         #   @return [String]
         #     The client version making the call.
-        #     Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+        #     Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
         class DeleteBreakpointRequest; end
 
         # Request to list breakpoints.
@@ -77,11 +77,11 @@ module Google
         #     ID of the debuggee whose breakpoints to list.
         # @!attribute [rw] include_all_users
         #   @return [true, false]
-        #     When set to +true+, the response includes the list of breakpoints set by
+        #     When set to `true`, the response includes the list of breakpoints set by
         #     any user. Otherwise, it includes only breakpoints set by the caller.
         # @!attribute [rw] include_inactive
         #   @return [true, false]
-        #     When set to +true+, the response includes active and inactive
+        #     When set to `true`, the response includes active and inactive
         #     breakpoints. Otherwise, it includes only active breakpoints.
         # @!attribute [rw] action
         #   @return [Google::Devtools::Clouddebugger::V2::ListBreakpointsRequest::BreakpointActionValue]
@@ -89,20 +89,20 @@ module Google
         # @!attribute [rw] strip_results
         #   @return [true, false]
         #     This field is deprecated. The following fields are always stripped out of
-        #     the result: +stack_frames+, +evaluated_expressions+ and +variable_table+.
+        #     the result: `stack_frames`, `evaluated_expressions` and `variable_table`.
         # @!attribute [rw] wait_token
         #   @return [String]
         #     A wait token that, if specified, blocks the call until the breakpoints
         #     list has changed, or a server selected timeout has expired.  The value
         #     should be set from the last response. The error code
-        #     +google.rpc.Code.ABORTED+ (RPC) is returned on wait timeout, which
-        #     should be called again with the same +wait_token+.
+        #     `google.rpc.Code.ABORTED` (RPC) is returned on wait timeout, which
+        #     should be called again with the same `wait_token`.
         # @!attribute [rw] client_version
         #   @return [String]
         #     The client version making the call.
-        #     Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+        #     Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
         class ListBreakpointsRequest
-          # Wrapper message for +Breakpoint.Action+. Defines a filter on the action
+          # Wrapper message for `Breakpoint.Action`. Defines a filter on the action
           # field of breakpoints.
           # @!attribute [rw] value
           #   @return [Google::Devtools::Clouddebugger::V2::Breakpoint::Action]
@@ -114,13 +114,13 @@ module Google
         # @!attribute [rw] breakpoints
         #   @return [Array<Google::Devtools::Clouddebugger::V2::Breakpoint>]
         #     List of breakpoints matching the request.
-        #     The fields +id+ and +location+ are guaranteed to be set on each breakpoint.
-        #     The fields: +stack_frames+, +evaluated_expressions+ and +variable_table+
+        #     The fields `id` and `location` are guaranteed to be set on each breakpoint.
+        #     The fields: `stack_frames`, `evaluated_expressions` and `variable_table`
         #     are cleared on each breakpoint regardless of its status.
         # @!attribute [rw] next_wait_token
         #   @return [String]
-        #     A wait token that can be used in the next call to +list+ (REST) or
-        #     +ListBreakpoints+ (RPC) to block until the list of breakpoints has changes.
+        #     A wait token that can be used in the next call to `list` (REST) or
+        #     `ListBreakpoints` (RPC) to block until the list of breakpoints has changes.
         class ListBreakpointsResponse; end
 
         # Request to list debuggees.
@@ -129,20 +129,20 @@ module Google
         #     Project number of a Google Cloud project whose debuggees to list.
         # @!attribute [rw] include_inactive
         #   @return [true, false]
-        #     When set to +true+, the result includes all debuggees. Otherwise, the
+        #     When set to `true`, the result includes all debuggees. Otherwise, the
         #     result includes only debuggees that are active.
         # @!attribute [rw] client_version
         #   @return [String]
         #     The client version making the call.
-        #     Schema: +domain/type/version+ (e.g., +google.com/intellij/v1+).
+        #     Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
         class ListDebuggeesRequest; end
 
         # Response for listing debuggees.
         # @!attribute [rw] debuggees
         #   @return [Array<Google::Devtools::Clouddebugger::V2::Debuggee>]
         #     List of debuggees accessible to the calling user.
-        #     The fields +debuggee.id+ and +description+ are guaranteed to be set.
-        #     The +description+ field is a human readable field provided by agents and
+        #     The fields `debuggee.id` and `description` are guaranteed to be set.
+        #     The `description` field is a human readable field provided by agents and
         #     can be displayed to users.
         class ListDebuggeesResponse; end
       end

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-debugger/lib/google/cloud/debugger/v2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-debugger/synth.py
+++ b/google-cloud-debugger/synth.py
@@ -67,10 +67,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow.rb
@@ -176,9 +176,9 @@ module Google
         # {Google::Cloud::Dialogflow::V2::Sessions::DetectIntent DetectIntent} (or
         # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) request,
         # or as output contexts included in the returned intent.
-        # Contexts expire when an intent is matched, after the number of +DetectIntent+
-        # requests specified by the +lifespan_count+ parameter, or after 10 minutes
-        # if no intents are matched for a +DetectIntent+ request.
+        # Contexts expire when an intent is matched, after the number of `DetectIntent`
+        # requests specified by the `lifespan_count` parameter, or after 10 minutes
+        # if no intents are matched for a `DetectIntent` request.
         #
         # For more information about contexts, see the
         # [Dialogflow documentation](https://dialogflow.com/docs/contexts).
@@ -245,14 +245,14 @@ module Google
         #
         # * **System** - entities that are defined by the Dialogflow API for common
         #   data types such as date, time, currency, and so on. A system entity is
-        #   represented by the +EntityType+ type.
+        #   represented by the `EntityType` type.
         #
         # * **Developer** - entities that are defined by you that represent
         #   actionable data that is meaningful to your application. For example,
-        #   you could define a +pizza.sauce+ entity for red or white pizza sauce,
-        #   a +pizza.cheese+ entity for the different types of cheese on a pizza,
-        #   a +pizza.topping+ entity for different toppings, and so on. A developer
-        #   entity is represented by the +EntityType+ type.
+        #   you could define a `pizza.sauce` entity for red or white pizza sauce,
+        #   a `pizza.cheese` entity for the different types of cheese on a pizza,
+        #   a `pizza.topping` entity for different toppings, and so on. A developer
+        #   entity is represented by the `EntityType` type.
         #
         # * **User** - entities that are built for an individual user such as
         #   favorites, preferences, playlists, and so on. A user entity is
@@ -317,7 +317,7 @@ module Google
         # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) method, the
         # Dialogflow API analyzes the input and searches
         # for a matching intent. If no match is found, the Dialogflow API returns a
-        # fallback intent (+is_fallback+ = true).
+        # fallback intent (`is_fallback` = true).
         #
         # You can provide additional information for the Dialogflow API to use to
         # match user input to an intent by adding the following to your intent.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2.rb
@@ -181,9 +181,9 @@ module Google
           # {Google::Cloud::Dialogflow::V2::Sessions::DetectIntent DetectIntent} (or
           # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) request,
           # or as output contexts included in the returned intent.
-          # Contexts expire when an intent is matched, after the number of +DetectIntent+
-          # requests specified by the +lifespan_count+ parameter, or after 10 minutes
-          # if no intents are matched for a +DetectIntent+ request.
+          # Contexts expire when an intent is matched, after the number of `DetectIntent`
+          # requests specified by the `lifespan_count` parameter, or after 10 minutes
+          # if no intents are matched for a `DetectIntent` request.
           #
           # For more information about contexts, see the
           # [Dialogflow documentation](https://dialogflow.com/docs/contexts).
@@ -254,14 +254,14 @@ module Google
           #
           # * **System** - entities that are defined by the Dialogflow API for common
           #   data types such as date, time, currency, and so on. A system entity is
-          #   represented by the +EntityType+ type.
+          #   represented by the `EntityType` type.
           #
           # * **Developer** - entities that are defined by you that represent
           #   actionable data that is meaningful to your application. For example,
-          #   you could define a +pizza.sauce+ entity for red or white pizza sauce,
-          #   a +pizza.cheese+ entity for the different types of cheese on a pizza,
-          #   a +pizza.topping+ entity for different toppings, and so on. A developer
-          #   entity is represented by the +EntityType+ type.
+          #   you could define a `pizza.sauce` entity for red or white pizza sauce,
+          #   a `pizza.cheese` entity for the different types of cheese on a pizza,
+          #   a `pizza.topping` entity for different toppings, and so on. A developer
+          #   entity is represented by the `EntityType` type.
           #
           # * **User** - entities that are built for an individual user such as
           #   favorites, preferences, playlists, and so on. A user entity is
@@ -330,7 +330,7 @@ module Google
           # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) method, the
           # Dialogflow API analyzes the input and searches
           # for a matching intent. If no match is found, the Dialogflow API returns a
-          # fallback intent (+is_fallback+ = true).
+          # fallback intent (`is_fallback` = true).
           #
           # You can provide additional information for the Dialogflow API to use to
           # match user input to an intent by adding the following to your intent.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/agents_client.rb
@@ -263,7 +263,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project that the agent to fetch is associated with.
-          #   Format: +projects/<Project ID>+.
+          #   Format: `projects/<Project ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -300,7 +300,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project to list agents from.
-          #   Format: +projects/<Project ID or '-'>+.
+          #   Format: `projects/<Project ID or '-'>`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -358,7 +358,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project that the agent to train is associated with.
-          #   Format: +projects/<Project ID>+.
+          #   Format: `projects/<Project ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -422,7 +422,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project that the agent to export is associated with.
-          #   Format: +projects/<Project ID>+.
+          #   Format: `projects/<Project ID>`.
           # @param agent_uri [String]
           #   Optional. The Google Cloud Storage URI to export the agent to.
           #   Note: The URI must start with
@@ -496,7 +496,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project that the agent to import is associated with.
-          #   Format: +projects/<Project ID>+.
+          #   Format: `projects/<Project ID>`.
           # @param agent_uri [String]
           #   The URI to a Google Cloud Storage file containing the agent to import.
           #   Note: The URI must start with "gs://".
@@ -585,7 +585,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The project that the agent to restore is associated with.
-          #   Format: +projects/<Project ID>+.
+          #   Format: `projects/<Project ID>`.
           # @param agent_uri [String]
           #   The URI to a Google Cloud Storage file containing the agent to restore.
           #   Note: The URI must start with "gs://".

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/contexts_client.rb
@@ -43,9 +43,9 @@ module Google
         # {Google::Cloud::Dialogflow::V2::Sessions::DetectIntent DetectIntent} (or
         # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) request,
         # or as output contexts included in the returned intent.
-        # Contexts expire when an intent is matched, after the number of +DetectIntent+
-        # requests specified by the +lifespan_count+ parameter, or after 10 minutes
-        # if no intents are matched for a +DetectIntent+ request.
+        # Contexts expire when an intent is matched, after the number of `DetectIntent`
+        # requests specified by the `lifespan_count` parameter, or after 10 minutes
+        # if no intents are matched for a `DetectIntent` request.
         #
         # For more information about contexts, see the
         # [Dialogflow documentation](https://dialogflow.com/docs/contexts).
@@ -260,7 +260,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The session to list all contexts from.
-          #   Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+          #   Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -315,7 +315,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the context. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -346,7 +346,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The session to create a context for.
-          #   Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+          #   Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
           # @param context [Google::Cloud::Dialogflow::V2::Context | Hash]
           #   Required. The context to create.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::Context`
@@ -365,7 +365,7 @@ module Google
           #   contexts_client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::ContextsClient.session_path("[PROJECT]", "[SESSION]")
           #
-          #   # TODO: Initialize +context+:
+          #   # TODO: Initialize `context`:
           #   context = {}
           #   response = contexts_client.create_context(formatted_parent, context)
 
@@ -405,7 +405,7 @@ module Google
           #
           #   contexts_client = Google::Cloud::Dialogflow::Contexts.new(version: :v2)
           #
-          #   # TODO: Initialize +context+:
+          #   # TODO: Initialize `context`:
           #   context = {}
           #   response = contexts_client.update_context(context)
 
@@ -426,7 +426,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the context to delete. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -457,7 +457,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the session to delete all contexts from. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/agent.rb
@@ -21,7 +21,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project of this agent.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         # @!attribute [rw] display_name
         #   @return [String]
         #     Required. The name of this agent.
@@ -30,11 +30,11 @@ module Google
         #     Required. The default language of the agent as a language tag. See
         #     [Language Support](https://dialogflow.com/docs/reference/language) for a
         #     list of the currently supported language codes.
-        #     This field cannot be set by the +Update+ method.
+        #     This field cannot be set by the `Update` method.
         # @!attribute [rw] supported_language_codes
         #   @return [Array<String>]
         #     Optional. The list of all languages supported by this agent (except for the
-        #     +default_language_code+).
+        #     `default_language_code`).
         # @!attribute [rw] time_zone
         #   @return [String]
         #     Required. The time zone of this agent from the
@@ -84,14 +84,14 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project that the agent to fetch is associated with.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         class GetAgentRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Agents::SearchAgents Agents::SearchAgents}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project to list agents from.
-        #     Format: +projects/<Project ID or '-'>+.
+        #     Format: `projects/<Project ID or '-'>`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional. The maximum number of items to return in a single page. By
@@ -116,14 +116,14 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project that the agent to train is associated with.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         class TrainAgentRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Agents::ExportAgent Agents::ExportAgent}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project that the agent to export is associated with.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         # @!attribute [rw] agent_uri
         #   @return [String]
         #     Optional. The Google Cloud Storage URI to export the agent to.
@@ -135,7 +135,7 @@ module Google
         # @!attribute [rw] agent_uri
         #   @return [String]
         #     The URI to a file containing the exported agent. This field is populated
-        #     only if +agent_uri+ is specified in +ExportAgentRequest+.
+        #     only if `agent_uri` is specified in `ExportAgentRequest`.
         # @!attribute [rw] agent_content
         #   @return [String]
         #     The exported agent.
@@ -158,7 +158,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project that the agent to import is associated with.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         # @!attribute [rw] agent_uri
         #   @return [String]
         #     The URI to a Google Cloud Storage file containing the agent to import.
@@ -185,7 +185,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The project that the agent to restore is associated with.
-        #     Format: +projects/<Project ID>+.
+        #     Format: `projects/<Project ID>`.
         # @!attribute [rw] agent_uri
         #   @return [String]
         #     The URI to a Google Cloud Storage file containing the agent to restore.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/context.rb
@@ -21,11 +21,11 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The unique identifier of the context. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`.
         # @!attribute [rw] lifespan_count
         #   @return [Integer]
         #     Optional. The number of conversational query requests after which the
-        #     context expires. If set to +0+ (the default) the context expires
+        #     context expires. If set to `0` (the default) the context expires
         #     immediately. Contexts expire automatically after 10 minutes even if there
         #     are no matching queries.
         # @!attribute [rw] parameters
@@ -39,7 +39,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The session to list all contexts from.
-        #     Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional. The maximum number of items to return in a single page. By
@@ -64,14 +64,14 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the context. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`.
         class GetContextRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Contexts::CreateContext Contexts::CreateContext}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The session to create a context for.
-        #     Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
         # @!attribute [rw] context
         #   @return [Google::Cloud::Dialogflow::V2::Context]
         #     Required. The context to create.
@@ -90,14 +90,14 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the context to delete. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/contexts/<Context ID>`.
         class DeleteContextRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Contexts::DeleteAllContexts Contexts::DeleteAllContexts}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the session to delete all contexts from. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>`.
         class DeleteAllContextsRequest; end
       end
     end

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/entity_type.rb
@@ -22,10 +22,10 @@ module Google
         # language queries.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required for all methods except +create+ (+create+ populates the name
+        #     Required for all methods except `create` (`create` populates the name
         #     automatically.
         #     The unique identifier of the entity type. Format:
-        #     +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+        #     `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
         # @!attribute [rw] display_name
         #   @return [String]
         #     Required. The name of the entity.
@@ -44,15 +44,15 @@ module Google
           # @!attribute [rw] value
           #   @return [String]
           #     Required.
-          #     For +KIND_MAP+ entity types:
+          #     For `KIND_MAP` entity types:
           #       A canonical name to be used in place of synonyms.
-          #     For +KIND_LIST+ entity types:
+          #     For `KIND_LIST` entity types:
           #       A string that can contain references to other entity types (with or
           #       without aliases).
           # @!attribute [rw] synonyms
           #   @return [Array<String>]
-          #     Required. A collection of synonyms. For +KIND_LIST+ entity types this
-          #     must contain exactly one synonym equal to +value+.
+          #     Required. A collection of synonyms. For `KIND_LIST` entity types this
+          #     must contain exactly one synonym equal to `value`.
           class Entity; end
 
           # Represents kinds of entities.
@@ -87,7 +87,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The agent to list all entity types from.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language to list entity synonyms for. If not specified,
@@ -119,7 +119,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the entity type.
-        #     Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+        #     Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language to retrieve entity synonyms for. If not specified,
@@ -133,13 +133,13 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The agent to create a entity type for.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] entity_type
         #   @return [Google::Cloud::Dialogflow::V2::EntityType]
         #     Required. The entity type to create.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entity_type+. If not
+        #     Optional. The language of entity synonyms defined in `entity_type`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -150,10 +150,10 @@ module Google
         # @!attribute [rw] entity_type
         #   @return [Google::Cloud::Dialogflow::V2::EntityType]
         #     Required. The entity type to update.
-        #     Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+        #     Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entity_type+. If not
+        #     Optional. The language of entity synonyms defined in `entity_type`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -167,14 +167,14 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the entity type to delete.
-        #     Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+        #     Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
         class DeleteEntityTypeRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::EntityTypes::BatchUpdateEntityTypes EntityTypes::BatchUpdateEntityTypes}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the agent to update or create entity types in.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] entity_type_batch_uri
         #   @return [String]
         #     The URI to a Google Cloud Storage file containing entity types to update
@@ -186,7 +186,7 @@ module Google
         #     The collection of entity type to update or create.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entity_types+. If not
+        #     Optional. The language of entity synonyms defined in `entity_types`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -206,24 +206,24 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the agent to delete all entities types for. Format:
-        #     +projects/<Project ID>/agent+.
+        #     `projects/<Project ID>/agent`.
         # @!attribute [rw] entity_type_names
         #   @return [Array<String>]
         #     Required. The names entity types to delete. All names must point to the
-        #     same agent as +parent+.
+        #     same agent as `parent`.
         class BatchDeleteEntityTypesRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::EntityTypes::BatchCreateEntities EntityTypes::BatchCreateEntities}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the entity type to create entities in. Format:
-        #     +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+        #     `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
         # @!attribute [rw] entities
         #   @return [Array<Google::Cloud::Dialogflow::V2::EntityType::Entity>]
         #     Required. The collection of entities to create.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entities+. If not
+        #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -234,13 +234,13 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the entity type to update the entities in. Format:
-        #     +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+        #     `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
         # @!attribute [rw] entities
         #   @return [Array<Google::Cloud::Dialogflow::V2::EntityType::Entity>]
         #     Required. The collection of new entities to replace the existing entities.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entities+. If not
+        #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -254,15 +254,15 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the entity type to delete entries for. Format:
-        #     +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+        #     `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
         # @!attribute [rw] entity_values
         #   @return [Array<String>]
-        #     Required. The canonical +values+ of the entities to delete. Note that
+        #     Required. The canonical `values` of the entities to delete. Note that
         #     these are not fully-qualified names, i.e. they don't start with
-        #     +projects/<Project ID>+.
+        #     `projects/<Project ID>`.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Optional. The language of entity synonyms defined in +entities+. If not
+        #     Optional. The language of entity synonyms defined in `entities`. If not
         #     specified, the agent's default language is used.
         #     [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/intent.rb
@@ -22,10 +22,10 @@ module Google
         # action is an extraction of a user command or sentence semantics.
         # @!attribute [rw] name
         #   @return [String]
-        #     Required for all methods except +create+ (+create+ populates the name
+        #     Required for all methods except `create` (`create` populates the name
         #     automatically.
         #     The unique identifier of this intent.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         # @!attribute [rw] display_name
         #   @return [String]
         #     Required. The name of this intent.
@@ -42,14 +42,14 @@ module Google
         # @!attribute [rw] ml_disabled
         #   @return [true, false]
         #     Optional. Indicates whether Machine Learning is disabled for the intent.
-        #     Note: If +ml_diabled+ setting is set to true, then this intent is not
-        #     taken into account during inference in +ML ONLY+ match mode. Also,
+        #     Note: If `ml_diabled` setting is set to true, then this intent is not
+        #     taken into account during inference in `ML ONLY` match mode. Also,
         #     auto-markup in the UI is turned off.
         # @!attribute [rw] input_context_names
         #   @return [Array<String>]
         #     Optional. The list of context names required for this intent to be
         #     triggered.
-        #     Format: +projects/<Project ID>/agent/sessions/-/contexts/<Context ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/-/contexts/<Context ID>`.
         # @!attribute [rw] events
         #   @return [Array<String>]
         #     Optional. The collection of event names that trigger the intent.
@@ -66,9 +66,9 @@ module Google
         #   @return [Array<Google::Cloud::Dialogflow::V2::Context>]
         #     Optional. The collection of contexts that are activated when the intent
         #     is matched. Context messages in this collection should not set the
-        #     parameters field. Setting the +lifespan_count+ to 0 will reset the context
+        #     parameters field. Setting the `lifespan_count` to 0 will reset the context
         #     when the intent is matched.
-        #     Format: +projects/<Project ID>/agent/sessions/-/contexts/<Context ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/-/contexts/<Context ID>`.
         # @!attribute [rw] reset_contexts
         #   @return [true, false]
         #     Optional. Indicates whether to delete all contexts in the current
@@ -79,7 +79,7 @@ module Google
         # @!attribute [rw] messages
         #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::Message>]
         #     Optional. The collection of rich messages corresponding to the
-        #     +Response+ field in the Dialogflow console.
+        #     `Response` field in the Dialogflow console.
         # @!attribute [rw] default_response_platforms
         #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::Message::Platform>]
         #     Optional. The list of platforms for which the first response will be
@@ -88,13 +88,13 @@ module Google
         #   @return [String]
         #     The unique identifier of the root intent in the chain of followup intents.
         #     It identifies the correct followup intents chain for this intent.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         # @!attribute [rw] parent_followup_intent_name
         #   @return [String]
         #     The unique identifier of the parent intent in the chain of followup
         #     intents.
         #     It identifies the parent followup intent.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         # @!attribute [rw] followup_intent_info
         #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::FollowupIntentInfo>]
         #     Optional. Collection of information about all followup intents that have
@@ -110,7 +110,7 @@ module Google
           # @!attribute [rw] parts
           #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::TrainingPhrase::Part>]
           #     Required. The collection of training phrase parts (can be annotated).
-          #     Fields: +entity_type+, +alias+ and +user_defined+ should be populated
+          #     Fields: `entity_type`, `alias` and `user_defined` should be populated
           #     only for the annotated parts of the training phrase.
           # @!attribute [rw] times_added_count
           #   @return [Integer]
@@ -126,7 +126,7 @@ module Google
             #     annotated examples, it is the text for one of the example's parts.
             # @!attribute [rw] entity_type
             #   @return [String]
-            #     Optional. The entity type name prefixed with +@+. This field is
+            #     Optional. The entity type name prefixed with `@`. This field is
             #     required for the annotated part of the text and applies only to
             #     examples.
             # @!attribute [rw] alias
@@ -165,19 +165,19 @@ module Google
           #   @return [String]
           #     Optional. The definition of the parameter value. It can be:
           #     * a constant string,
-          #     * a parameter value defined as +$parameter_name+,
-          #     * an original parameter value defined as +$parameter_name.original+,
+          #     * a parameter value defined as `$parameter_name`,
+          #     * an original parameter value defined as `$parameter_name.original`,
           #     * a parameter value from some context defined as
-          #       +#context_name.parameter_name+.
+          #       `#context_name.parameter_name`.
           # @!attribute [rw] default_value
           #   @return [String]
-          #     Optional. The default value to use when the +value+ yields an empty
+          #     Optional. The default value to use when the `value` yields an empty
           #     result.
           #     Default values can be extracted from contexts by using the following
-          #     syntax: +#context_name.parameter_name+.
+          #     syntax: `#context_name.parameter_name`.
           # @!attribute [rw] entity_type_display_name
           #   @return [String]
-          #     Optional. The name of the entity type, prefixed with +@+, that
+          #     Optional. The name of the entity type, prefixed with `@`, that
           #     describes values of the parameter. If the parameter is
           #     required, this must be provided.
           # @!attribute [rw] mandatory
@@ -194,7 +194,7 @@ module Google
           #     Optional. Indicates whether the parameter represents a list of values.
           class Parameter; end
 
-          # Corresponds to the +Response+ field in the Dialogflow console.
+          # Corresponds to the `Response` field in the Dialogflow console.
           # @!attribute [rw] text
           #   @return [Google::Cloud::Dialogflow::V2::Intent::Message::Text]
           #     The text response.
@@ -300,9 +300,9 @@ module Google
             class SimpleResponse; end
 
             # The collection of simple response candidates.
-            # This message in +QueryResult.fulfillment_messages+ and
-            # +WebhookResponse.fulfillment_messages+ should contain only one
-            # +SimpleResponse+.
+            # This message in `QueryResult.fulfillment_messages` and
+            # `WebhookResponse.fulfillment_messages` should contain only one
+            # `SimpleResponse`.
             # @!attribute [rw] simple_responses
             #   @return [Array<Google::Cloud::Dialogflow::V2::Intent::Message::SimpleResponse>]
             #     Required. The list of simple responses.
@@ -517,11 +517,11 @@ module Google
           # @!attribute [rw] followup_intent_name
           #   @return [String]
           #     The unique identifier of the followup intent.
-          #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+          #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
           # @!attribute [rw] parent_followup_intent_name
           #   @return [String]
           #     The unique identifier of the followup intent parent.
-          #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+          #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
           class FollowupIntentInfo; end
 
           # Represents the different states that webhooks can be in.
@@ -542,7 +542,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The agent to list all intents from.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language to list training phrases, parameters and rich
@@ -577,7 +577,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the intent.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language to retrieve training phrases, parameters and rich
@@ -594,14 +594,14 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The agent to create a intent for.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] intent
         #   @return [Google::Cloud::Dialogflow::V2::Intent]
         #     Required. The intent to create.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language of training phrases, parameters and rich messages
-        #     defined in +intent+. If not specified, the agent's default language is
+        #     defined in `intent`. If not specified, the agent's default language is
         #     used. [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
         #     Note: languages must be enabled in the agent, before they can be used.
@@ -614,11 +614,11 @@ module Google
         # @!attribute [rw] intent
         #   @return [Google::Cloud::Dialogflow::V2::Intent]
         #     Required. The intent to update.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language of training phrases, parameters and rich messages
-        #     defined in +intent+. If not specified, the agent's default language is
+        #     defined in `intent`. If not specified, the agent's default language is
         #     used. [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
         #     Note: languages must be enabled in the agent, before they can be used.
@@ -634,14 +634,14 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the intent to delete.
-        #     Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+        #     Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
         class DeleteIntentRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::Intents::BatchUpdateIntents Intents::BatchUpdateIntents}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the agent to update or create intents in.
-        #     Format: +projects/<Project ID>/agent+.
+        #     Format: `projects/<Project ID>/agent`.
         # @!attribute [rw] intent_batch_uri
         #   @return [String]
         #     The URI to a Google Cloud Storage file containing intents to update or
@@ -653,7 +653,7 @@ module Google
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional. The language of training phrases, parameters and rich messages
-        #     defined in +intents+. If not specified, the agent's default language is
+        #     defined in `intents`. If not specified, the agent's default language is
         #     used. [More than a dozen
         #     languages](https://dialogflow.com/docs/reference/language) are supported.
         #     Note: languages must be enabled in the agent, before they can be used.
@@ -675,10 +675,10 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The name of the agent to delete all entities types for. Format:
-        #     +projects/<Project ID>/agent+.
+        #     `projects/<Project ID>/agent`.
         # @!attribute [rw] intents
         #   @return [Array<Google::Cloud::Dialogflow::V2::Intent>]
-        #     Required. The collection of intents to delete. Only intent +name+ must be
+        #     Required. The collection of intents to delete. Only intent `name` must be
         #     filled in.
         class BatchDeleteIntentsRequest; end
 

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session.rb
@@ -21,7 +21,7 @@ module Google
         # @!attribute [rw] session
         #   @return [String]
         #     Required. The name of the session this query is sent to. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>+. It's up to the API
+        #     `projects/<Project ID>/agent/sessions/<Session ID>`. It's up to the API
         #     caller to choose an appropriate session ID. It can be a random number or
         #     some type of user identifier (preferably hashed). The length of the session
         #     ID must not exceed 36 bytes.
@@ -41,7 +41,7 @@ module Google
         # @!attribute [rw] input_audio
         #   @return [String]
         #     Optional. The natural language speech audio to be processed. This field
-        #     should be populated iff +query_input+ is set to an input audio config.
+        #     should be populated iff `query_input` is set to an input audio config.
         #     A single request can contain up to 1 minute of speech audio data.
         class DetectIntentRequest; end
 
@@ -55,7 +55,7 @@ module Google
         #     The results of the conversational query or event processing.
         # @!attribute [rw] webhook_status
         #   @return [Google::Rpc::Status]
-        #     Specifies the status of the webhook request. +webhook_status+
+        #     Specifies the status of the webhook request. `webhook_status`
         #     is never populated in webhook requests.
         class DetectIntentResponse; end
 
@@ -111,12 +111,12 @@ module Google
         # @!attribute [rw] query_text
         #   @return [String]
         #     The original conversational query text:
-        #     * If natural language text was provided as input, +query_text+ contains
+        #     * If natural language text was provided as input, `query_text` contains
         #       a copy of the input.
-        #     * If natural language speech audio was provided as input, +query_text+
+        #     * If natural language speech audio was provided as input, `query_text`
         #       contains the speech recognition result. If speech recognizer produced
         #       multiple alternatives, a particular one is picked.
-        #     * If an event was provided as input, +query_text+ is not set.
+        #     * If an event was provided as input, `query_text` is not set.
         # @!attribute [rw] language_code
         #   @return [String]
         #     The language that was triggered during intent detection.
@@ -142,9 +142,9 @@ module Google
         # @!attribute [rw] all_required_params_present
         #   @return [true, false]
         #     This field is set to:
-        #     * +false+ if the matched intent has required parameters and not all of
+        #     * `false` if the matched intent has required parameters and not all of
         #       the required parameter values have been collected.
-        #     * +true+ if all required parameter values have been collected, or if the
+        #     * `true` if all required parameter values have been collected, or if the
         #       matched intent doesn't contain any required parameters.
         # @!attribute [rw] fulfillment_text
         #   @return [String]
@@ -155,22 +155,22 @@ module Google
         # @!attribute [rw] webhook_source
         #   @return [String]
         #     If the query was fulfilled by a webhook call, this field is set to the
-        #     value of the +source+ field returned in the webhook response.
+        #     value of the `source` field returned in the webhook response.
         # @!attribute [rw] webhook_payload
         #   @return [Google::Protobuf::Struct]
         #     If the query was fulfilled by a webhook call, this field is set to the
-        #     value of the +payload+ field returned in the webhook response.
+        #     value of the `payload` field returned in the webhook response.
         # @!attribute [rw] output_contexts
         #   @return [Array<Google::Cloud::Dialogflow::V2::Context>]
         #     The collection of output contexts. If applicable,
-        #     +output_contexts.parameters+ contains entries with name
-        #     +<parameter name>.original+ containing the original parameter values
+        #     `output_contexts.parameters` contains entries with name
+        #     `<parameter name>.original` containing the original parameter values
         #     before the query.
         # @!attribute [rw] intent
         #   @return [Google::Cloud::Dialogflow::V2::Intent]
         #     The intent that matched the conversational query. Some, not
         #     all fields are filled in this message, including but not limited to:
-        #     +name+, +display_name+ and +webhook_state+.
+        #     `name`, `display_name` and `webhook_state`.
         # @!attribute [rw] intent_detection_confidence
         #   @return [Float]
         #     The intent detection confidence. Values range from 0.0
@@ -182,21 +182,21 @@ module Google
         class QueryResult; end
 
         # The top-level message sent by the client to the
-        # +StreamingDetectIntent+ method.
+        # `StreamingDetectIntent` method.
         #
         # Multiple request messages should be sent in order:
         #
-        # 1.  The first message must contain +session+, +query_input+ plus optionally
-        #     +query_params+ and/or +single_utterance+. The message must not contain +input_audio+.
+        # 1.  The first message must contain `session`, `query_input` plus optionally
+        #     `query_params` and/or `single_utterance`. The message must not contain `input_audio`.
         #
-        # 2.  If +query_input+ was set to a streaming input audio config,
-        #     all subsequent messages must contain only +input_audio+.
+        # 2.  If `query_input` was set to a streaming input audio config,
+        #     all subsequent messages must contain only `input_audio`.
         #     Otherwise, finish the request stream.
         # @!attribute [rw] session
         #   @return [String]
         #     Required. The name of the session the query is sent to.
         #     Format of the session name:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>+. It’s up to the API
+        #     `projects/<Project ID>/agent/sessions/<Session ID>`. It’s up to the API
         #     caller to choose an appropriate <Session ID>. It can be a random number or
         #     some type of user identifier (preferably hashed). The length of the session
         #     ID must not exceed 36 characters.
@@ -215,33 +215,33 @@ module Google
         #     3.  an event that specifies which intent to trigger.
         # @!attribute [rw] single_utterance
         #   @return [true, false]
-        #     Optional. If +false+ (default), recognition does not cease until the
+        #     Optional. If `false` (default), recognition does not cease until the
         #     client closes the stream.
-        #     If +true+, the recognizer will detect a single spoken utterance in input
+        #     If `true`, the recognizer will detect a single spoken utterance in input
         #     audio. Recognition ceases when it detects the audio's voice has
         #     stopped or paused. In this case, once a detected intent is received, the
         #     client should close the stream and start a new request with a new stream as
         #     needed.
-        #     This setting is ignored when +query_input+ is a piece of text or an event.
+        #     This setting is ignored when `query_input` is a piece of text or an event.
         # @!attribute [rw] input_audio
         #   @return [String]
         #     Optional. The input audio content to be recognized. Must be sent if
-        #     +query_input+ was set to a streaming input audio config. The complete audio
+        #     `query_input` was set to a streaming input audio config. The complete audio
         #     over all streaming messages must not exceed 1 minute.
         class StreamingDetectIntentRequest; end
 
         # The top-level message returned from the
-        # +StreamingDetectIntent+ method.
+        # `StreamingDetectIntent` method.
         #
         # Multiple response messages can be returned in order:
         #
         # 1.  If the input was set to streaming audio, the first one or more messages
-        #     contain +recognition_result+. Each +recognition_result+ represents a more
-        #     complete transcript of what the user said. The last +recognition_result+
-        #     has +is_final+ set to +true+.
+        #     contain `recognition_result`. Each `recognition_result` represents a more
+        #     complete transcript of what the user said. The last `recognition_result`
+        #     has `is_final` set to `true`.
         #
-        # 2.  The next message contains +response_id+, +query_result+
-        #     and optionally +webhook_status+ if a WebHook was called.
+        # 2.  The next message contains `response_id`, `query_result`
+        #     and optionally `webhook_status` if a WebHook was called.
         # @!attribute [rw] response_id
         #   @return [String]
         #     The unique identifier of the response. It can be used to
@@ -276,34 +276,34 @@ module Google
         #
         # 6.  transcript: " that is"
         #
-        # 7.  recognition_event_type: +RECOGNITION_EVENT_END_OF_SINGLE_UTTERANCE+
+        # 7.  recognition_event_type: `RECOGNITION_EVENT_END_OF_SINGLE_UTTERANCE`
         #
         # 8.  transcript: " that is the question"
         #     is_final: true
         #
         # Only two of the responses contain final results (#4 and #8 indicated by
-        # +is_final: true+). Concatenating these generates the full transcript: "to be
+        # `is_final: true`). Concatenating these generates the full transcript: "to be
         # or not to be that is the question".
         #
         # In each response we populate:
         #
-        # * for +MESSAGE_TYPE_TRANSCRIPT+: +transcript+ and possibly +is_final+.
+        # * for `MESSAGE_TYPE_TRANSCRIPT`: `transcript` and possibly `is_final`.
         #
-        # * for +MESSAGE_TYPE_END_OF_SINGLE_UTTERANCE+: only +event_type+.
+        # * for `MESSAGE_TYPE_END_OF_SINGLE_UTTERANCE`: only `event_type`.
         # @!attribute [rw] message_type
         #   @return [Google::Cloud::Dialogflow::V2::StreamingRecognitionResult::MessageType]
         #     Type of the result message.
         # @!attribute [rw] transcript
         #   @return [String]
         #     Transcript text representing the words that the user spoke.
-        #     Populated if and only if +event_type+ = +RECOGNITION_EVENT_TRANSCRIPT+.
+        #     Populated if and only if `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`.
         # @!attribute [rw] is_final
         #   @return [true, false]
-        #     The default of 0.0 is a sentinel value indicating +confidence+ was not set.
-        #     If +false+, the +StreamingRecognitionResult+ represents an
-        #     interim result that may change. If +true+, the recognizer will not return
+        #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
+        #     If `false`, the `StreamingRecognitionResult` represents an
+        #     interim result that may change. If `true`, the recognizer will not return
         #     any further hypotheses about this piece of the audio. May only be populated
-        #     for +event_type+ = +RECOGNITION_EVENT_TRANSCRIPT+.
+        #     for `event_type` = `RECOGNITION_EVENT_TRANSCRIPT`.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     The Speech confidence between 0.0 and 1.0 for the current portion of audio.
@@ -311,7 +311,7 @@ module Google
         #     recognized words are correct. The default of 0.0 is a sentinel value
         #     indicating that confidence was not set.
         #
-        #     This field is typically only provided if +is_final+ is true and you should
+        #     This field is typically only provided if `is_final` is true and you should
         #     not rely on it being accurate or even set.
         class StreamingRecognitionResult
           # Type of the response message.
@@ -328,7 +328,7 @@ module Google
             # additional results). The client should stop sending additional audio
             # data, half-close the gRPC connection, and wait for any additional results
             # until the server closes the gRPC connection. This message is only sent if
-            # +single_utterance+ was set to +true+, and is not used otherwise.
+            # `single_utterance` was set to `true`, and is not used otherwise.
             END_OF_SINGLE_UTTERANCE = 2
           end
         end
@@ -371,10 +371,10 @@ module Google
         class TextInput; end
 
         # Events allow for matching intents by event name instead of the natural
-        # language input. For instance, input +<event: { name: “welcome_event”,
-        # parameters: { name: “Sam” } }>+ can trigger a personalized welcome response.
-        # The parameter +name+ may be used by the agent in the response:
-        # +“Hello #welcome_event.name! What can I do for you today?”+.
+        # language input. For instance, input `<event: { name: “welcome_event”,
+        # parameters: { name: “Sam” } }>` can trigger a personalized welcome response.
+        # The parameter `name` may be used by the agent in the response:
+        # `“Hello #welcome_event.name! What can I do for you today?”`.
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The unique identifier of the event.
@@ -399,32 +399,32 @@ module Google
           # Uncompressed 16-bit signed little-endian samples (Linear PCM).
           AUDIO_ENCODING_LINEAR_16 = 1
 
-          # [+FLAC+](https://xiph.org/flac/documentation.html) (Free Lossless Audio
+          # [`FLAC`](https://xiph.org/flac/documentation.html) (Free Lossless Audio
           # Codec) is the recommended encoding because it is lossless (therefore
           # recognition is not compromised) and requires only about half the
-          # bandwidth of +LINEAR16+. +FLAC+ stream encoding supports 16-bit and
-          # 24-bit samples, however, not all fields in +STREAMINFO+ are supported.
+          # bandwidth of `LINEAR16`. `FLAC` stream encoding supports 16-bit and
+          # 24-bit samples, however, not all fields in `STREAMINFO` are supported.
           AUDIO_ENCODING_FLAC = 2
 
           # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
           AUDIO_ENCODING_MULAW = 3
 
-          # Adaptive Multi-Rate Narrowband codec. +sample_rate_hertz+ must be 8000.
+          # Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
           AUDIO_ENCODING_AMR = 4
 
-          # Adaptive Multi-Rate Wideband codec. +sample_rate_hertz+ must be 16000.
+          # Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
           AUDIO_ENCODING_AMR_WB = 5
 
           # Opus encoded audio frames in Ogg container
           # ([OggOpus](https://wiki.xiph.org/OggOpus)).
-          # +sample_rate_hertz+ must be 16000.
+          # `sample_rate_hertz` must be 16000.
           AUDIO_ENCODING_OGG_OPUS = 6
 
           # Although the use of lossy encodings is not recommended, if a very low
-          # bitrate encoding is required, +OGG_OPUS+ is highly preferred over
+          # bitrate encoding is required, `OGG_OPUS` is highly preferred over
           # Speex encoding. The [Speex](https://speex.org/) encoding supported by
           # Dialogflow API has a header byte in each block, as in MIME type
-          # +audio/x-speex-with-header-byte+.
+          # `audio/x-speex-with-header-byte`.
           # It is a variant of the RTP Speex encoding defined in
           # [RFC 5574](https://tools.ietf.org/html/rfc5574).
           # The stream is a sequence of blocks, one block per RTP packet. Each block
@@ -432,7 +432,7 @@ module Google
           # by one or more frames of Speex data, padded to an integral number of
           # bytes (octets) as specified in RFC 5574. In other words, each RTP header
           # is replaced with a single byte containing the block length. Only Speex
-          # wideband is supported. +sample_rate_hertz+ must be 16000.
+          # wideband is supported. `sample_rate_hertz` must be 16000.
           AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE = 7
         end
       end

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session_entity_type.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/cloud/dialogflow/v2/session_entity_type.rb
@@ -27,8 +27,8 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The unique identifier of this session entity type. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-        #     Display Name>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+        #     Display Name>`.
         # @!attribute [rw] entity_override_mode
         #   @return [Google::Cloud::Dialogflow::V2::SessionEntityType::EntityOverrideMode]
         #     Required. Indicates whether the additional data should override or
@@ -49,8 +49,8 @@ module Google
 
             # The collection of session entities extends the collection of entities in
             # the corresponding developer entity type.
-            # Calls to +ListSessionEntityTypes+, +GetSessionEntityType+,
-            # +CreateSessionEntityType+ and +UpdateSessionEntityType+ return the full
+            # Calls to `ListSessionEntityTypes`, `GetSessionEntityType`,
+            # `CreateSessionEntityType` and `UpdateSessionEntityType` return the full
             # collection of entities from the developer entity type in the agent's
             # default language and the session entity type.
             ENTITY_OVERRIDE_MODE_SUPPLEMENT = 2
@@ -61,7 +61,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The session to list all session entity types from.
-        #     Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional. The maximum number of items to return in a single page. By
@@ -86,15 +86,15 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the session entity type. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-        #     Display Name>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+        #     Display Name>`.
         class GetSessionEntityTypeRequest; end
 
         # The request message for {Google::Cloud::Dialogflow::V2::SessionEntityTypes::CreateSessionEntityType SessionEntityTypes::CreateSessionEntityType}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The session to create a session entity type for.
-        #     Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+        #     Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
         # @!attribute [rw] session_entity_type
         #   @return [Google::Cloud::Dialogflow::V2::SessionEntityType]
         #     Required. The session entity type to create.
@@ -104,8 +104,8 @@ module Google
         # @!attribute [rw] session_entity_type
         #   @return [Google::Cloud::Dialogflow::V2::SessionEntityType]
         #     Required. The entity type to update. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-        #     Display Name>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+        #     Display Name>`.
         # @!attribute [rw] update_mask
         #   @return [Google::Protobuf::FieldMask]
         #     Optional. The mask to control which fields get updated.
@@ -115,8 +115,8 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the entity type to delete. Format:
-        #     +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-        #     Display Name>+.
+        #     `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+        #     Display Name>`.
         class DeleteSessionEntityTypeRequest; end
       end
     end

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/longrunning/operations.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/struct.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/rpc/status.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/entity_types_client.rb
@@ -46,14 +46,14 @@ module Google
         #
         # * **System** - entities that are defined by the Dialogflow API for common
         #   data types such as date, time, currency, and so on. A system entity is
-        #   represented by the +EntityType+ type.
+        #   represented by the `EntityType` type.
         #
         # * **Developer** - entities that are defined by you that represent
         #   actionable data that is meaningful to your application. For example,
-        #   you could define a +pizza.sauce+ entity for red or white pizza sauce,
-        #   a +pizza.cheese+ entity for the different types of cheese on a pizza,
-        #   a +pizza.topping+ entity for different toppings, and so on. A developer
-        #   entity is represented by the +EntityType+ type.
+        #   you could define a `pizza.sauce` entity for red or white pizza sauce,
+        #   a `pizza.cheese` entity for the different types of cheese on a pizza,
+        #   a `pizza.topping` entity for different toppings, and so on. A developer
+        #   entity is represented by the `EntityType` type.
         #
         # * **User** - entities that are built for an individual user such as
         #   favorites, preferences, playlists, and so on. A user entity is
@@ -302,7 +302,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The agent to list all entity types from.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param language_code [String]
           #   Optional. The language to list entity synonyms for. If not specified,
           #   the agent's default language is used.
@@ -365,7 +365,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the entity type.
-          #   Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+          #   Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
           # @param language_code [String]
           #   Optional. The language to retrieve entity synonyms for. If not specified,
           #   the agent's default language is used.
@@ -404,13 +404,13 @@ module Google
           #
           # @param parent [String]
           #   Required. The agent to create a entity type for.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param entity_type [Google::Cloud::Dialogflow::V2::EntityType | Hash]
           #   Required. The entity type to create.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::EntityType`
           #   can also be provided.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entity_type+. If not
+          #   Optional. The language of entity synonyms defined in `entity_type`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -429,7 +429,7 @@ module Google
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::EntityTypesClient.project_agent_path("[PROJECT]")
           #
-          #   # TODO: Initialize +entity_type+:
+          #   # TODO: Initialize `entity_type`:
           #   entity_type = {}
           #   response = entity_types_client.create_entity_type(formatted_parent, entity_type)
 
@@ -452,11 +452,11 @@ module Google
           #
           # @param entity_type [Google::Cloud::Dialogflow::V2::EntityType | Hash]
           #   Required. The entity type to update.
-          #   Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+          #   Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::EntityType`
           #   can also be provided.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entity_type+. If not
+          #   Optional. The language of entity synonyms defined in `entity_type`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -478,7 +478,7 @@ module Google
           #
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #
-          #   # TODO: Initialize +entity_type+:
+          #   # TODO: Initialize `entity_type`:
           #   entity_type = {}
           #   response = entity_types_client.update_entity_type(entity_type)
 
@@ -501,7 +501,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the entity type to delete.
-          #   Format: +projects/<Project ID>/agent/entityTypes/<EntityType ID>+.
+          #   Format: `projects/<Project ID>/agent/entityTypes/<EntityType ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -535,7 +535,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the agent to update or create entity types in.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param entity_type_batch_uri [String]
           #   The URI to a Google Cloud Storage file containing entity types to update
           #   or create. The file format can either be a serialized proto (of
@@ -546,7 +546,7 @@ module Google
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::EntityTypeBatch`
           #   can also be provided.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entity_types+. If not
+          #   Optional. The language of entity synonyms defined in `entity_types`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -626,10 +626,10 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the agent to delete all entities types for. Format:
-          #   +projects/<Project ID>/agent+.
+          #   `projects/<Project ID>/agent`.
           # @param entity_type_names [Array<String>]
           #   Required. The names entity types to delete. All names must point to the
-          #   same agent as +parent+.
+          #   same agent as `parent`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -641,7 +641,7 @@ module Google
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::EntityTypesClient.project_agent_path("[PROJECT]")
           #
-          #   # TODO: Initialize +entity_type_names+:
+          #   # TODO: Initialize `entity_type_names`:
           #   entity_type_names = []
           #
           #   # Register a callback during the method call.
@@ -698,13 +698,13 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the entity type to create entities in. Format:
-          #   +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+          #   `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
           # @param entities [Array<Google::Cloud::Dialogflow::V2::EntityType::Entity | Hash>]
           #   Required. The collection of entities to create.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::EntityType::Entity`
           #   can also be provided.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entities+. If not
+          #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -720,7 +720,7 @@ module Google
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::EntityTypesClient.entity_type_path("[PROJECT]", "[ENTITY_TYPE]")
           #
-          #   # TODO: Initialize +entities+:
+          #   # TODO: Initialize `entities`:
           #   entities = []
           #
           #   # Register a callback during the method call.
@@ -780,13 +780,13 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the entity type to update the entities in. Format:
-          #   +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+          #   `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
           # @param entities [Array<Google::Cloud::Dialogflow::V2::EntityType::Entity | Hash>]
           #   Required. The collection of new entities to replace the existing entities.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::EntityType::Entity`
           #   can also be provided.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entities+. If not
+          #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -806,7 +806,7 @@ module Google
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::EntityTypesClient.entity_type_path("[PROJECT]", "[ENTITY_TYPE]")
           #
-          #   # TODO: Initialize +entities+:
+          #   # TODO: Initialize `entities`:
           #   entities = []
           #
           #   # Register a callback during the method call.
@@ -867,13 +867,13 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the entity type to delete entries for. Format:
-          #   +projects/<Project ID>/agent/entityTypes/<Entity Type ID>+.
+          #   `projects/<Project ID>/agent/entityTypes/<Entity Type ID>`.
           # @param entity_values [Array<String>]
-          #   Required. The canonical +values+ of the entities to delete. Note that
+          #   Required. The canonical `values` of the entities to delete. Note that
           #   these are not fully-qualified names, i.e. they don't start with
-          #   +projects/<Project ID>+.
+          #   `projects/<Project ID>`.
           # @param language_code [String]
-          #   Optional. The language of entity synonyms defined in +entities+. If not
+          #   Optional. The language of entity synonyms defined in `entities`. If not
           #   specified, the agent's default language is used.
           #   [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
@@ -889,7 +889,7 @@ module Google
           #   entity_types_client = Google::Cloud::Dialogflow::EntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::EntityTypesClient.entity_type_path("[PROJECT]", "[ENTITY_TYPE]")
           #
-          #   # TODO: Initialize +entity_values+:
+          #   # TODO: Initialize `entity_values`:
           #   entity_values = []
           #
           #   # Register a callback during the method call.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/intents_client.rb
@@ -40,7 +40,7 @@ module Google
         # {Google::Cloud::Dialogflow::V2::Sessions::StreamingDetectIntent StreamingDetectIntent}) method, the
         # Dialogflow API analyzes the input and searches
         # for a matching intent. If no match is found, the Dialogflow API returns a
-        # fallback intent (+is_fallback+ = true).
+        # fallback intent (`is_fallback` = true).
         #
         # You can provide additional information for the Dialogflow API to use to
         # match user input to an intent by adding the following to your intent.
@@ -308,7 +308,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The agent to list all intents from.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param language_code [String]
           #   Optional. The language to list training phrases, parameters and rich
           #   messages for. If not specified, the agent's default language is used.
@@ -375,7 +375,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the intent.
-          #   Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+          #   Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
           # @param language_code [String]
           #   Optional. The language to retrieve training phrases, parameters and rich
           #   messages for. If not specified, the agent's default language is used.
@@ -418,14 +418,14 @@ module Google
           #
           # @param parent [String]
           #   Required. The agent to create a intent for.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param intent [Google::Cloud::Dialogflow::V2::Intent | Hash]
           #   Required. The intent to create.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::Intent`
           #   can also be provided.
           # @param language_code [String]
           #   Optional. The language of training phrases, parameters and rich messages
-          #   defined in +intent+. If not specified, the agent's default language is
+          #   defined in `intent`. If not specified, the agent's default language is
           #   used. [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
           #   Note: languages must be enabled in the agent, before they can be used.
@@ -445,7 +445,7 @@ module Google
           #   intents_client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::IntentsClient.project_agent_path("[PROJECT]")
           #
-          #   # TODO: Initialize +intent+:
+          #   # TODO: Initialize `intent`:
           #   intent = {}
           #   response = intents_client.create_intent(formatted_parent, intent)
 
@@ -470,12 +470,12 @@ module Google
           #
           # @param intent [Google::Cloud::Dialogflow::V2::Intent | Hash]
           #   Required. The intent to update.
-          #   Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+          #   Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::Intent`
           #   can also be provided.
           # @param language_code [String]
           #   Optional. The language of training phrases, parameters and rich messages
-          #   defined in +intent+. If not specified, the agent's default language is
+          #   defined in `intent`. If not specified, the agent's default language is
           #   used. [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
           #   Note: languages must be enabled in the agent, before they can be used.
@@ -498,10 +498,10 @@ module Google
           #
           #   intents_client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
           #
-          #   # TODO: Initialize +intent+:
+          #   # TODO: Initialize `intent`:
           #   intent = {}
           #
-          #   # TODO: Initialize +language_code+:
+          #   # TODO: Initialize `language_code`:
           #   language_code = ''
           #   response = intents_client.update_intent(intent, language_code)
 
@@ -526,7 +526,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the intent to delete.
-          #   Format: +projects/<Project ID>/agent/intents/<Intent ID>+.
+          #   Format: `projects/<Project ID>/agent/intents/<Intent ID>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -559,10 +559,10 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the agent to update or create intents in.
-          #   Format: +projects/<Project ID>/agent+.
+          #   Format: `projects/<Project ID>/agent`.
           # @param language_code [String]
           #   Optional. The language of training phrases, parameters and rich messages
-          #   defined in +intents+. If not specified, the agent's default language is
+          #   defined in `intents`. If not specified, the agent's default language is
           #   used. [More than a dozen
           #   languages](https://dialogflow.com/docs/reference/language) are supported.
           #   Note: languages must be enabled in the agent, before they can be used.
@@ -591,7 +591,7 @@ module Google
           #   intents_client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::IntentsClient.project_agent_path("[PROJECT]")
           #
-          #   # TODO: Initialize +language_code+:
+          #   # TODO: Initialize `language_code`:
           #   language_code = ''
           #
           #   # Register a callback during the method call.
@@ -655,9 +655,9 @@ module Google
           #
           # @param parent [String]
           #   Required. The name of the agent to delete all entities types for. Format:
-          #   +projects/<Project ID>/agent+.
+          #   `projects/<Project ID>/agent`.
           # @param intents [Array<Google::Cloud::Dialogflow::V2::Intent | Hash>]
-          #   Required. The collection of intents to delete. Only intent +name+ must be
+          #   Required. The collection of intents to delete. Only intent `name` must be
           #   filled in.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::Intent`
           #   can also be provided.
@@ -672,7 +672,7 @@ module Google
           #   intents_client = Google::Cloud::Dialogflow::Intents.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::IntentsClient.project_agent_path("[PROJECT]")
           #
-          #   # TODO: Initialize +intents+:
+          #   # TODO: Initialize `intents`:
           #   intents = []
           #
           #   # Register a callback during the method call.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/session_entity_types_client.rb
@@ -250,7 +250,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The session to list all session entity types from.
-          #   Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+          #   Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -305,8 +305,8 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the session entity type. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-          #   Display Name>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+          #   Display Name>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -337,7 +337,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The session to create a session entity type for.
-          #   Format: +projects/<Project ID>/agent/sessions/<Session ID>+.
+          #   Format: `projects/<Project ID>/agent/sessions/<Session ID>`.
           # @param session_entity_type [Google::Cloud::Dialogflow::V2::SessionEntityType | Hash]
           #   Required. The session entity type to create.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::SessionEntityType`
@@ -356,7 +356,7 @@ module Google
           #   session_entity_types_client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
           #   formatted_parent = Google::Cloud::Dialogflow::V2::SessionEntityTypesClient.session_path("[PROJECT]", "[SESSION]")
           #
-          #   # TODO: Initialize +session_entity_type+:
+          #   # TODO: Initialize `session_entity_type`:
           #   session_entity_type = {}
           #   response = session_entity_types_client.create_session_entity_type(formatted_parent, session_entity_type)
 
@@ -377,8 +377,8 @@ module Google
           #
           # @param session_entity_type [Google::Cloud::Dialogflow::V2::SessionEntityType | Hash]
           #   Required. The entity type to update. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-          #   Display Name>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+          #   Display Name>`.
           #   A hash of the same form as `Google::Cloud::Dialogflow::V2::SessionEntityType`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -398,7 +398,7 @@ module Google
           #
           #   session_entity_types_client = Google::Cloud::Dialogflow::SessionEntityTypes.new(version: :v2)
           #
-          #   # TODO: Initialize +session_entity_type+:
+          #   # TODO: Initialize `session_entity_type`:
           #   session_entity_type = {}
           #   response = session_entity_types_client.update_session_entity_type(session_entity_type)
 
@@ -419,8 +419,8 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the entity type to delete. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
-          #   Display Name>+.
+          #   `projects/<Project ID>/agent/sessions/<Session ID>/entityTypes/<Entity Type
+          #   Display Name>`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
+++ b/google-cloud-dialogflow/lib/google/cloud/dialogflow/v2/sessions_client.rb
@@ -201,7 +201,7 @@ module Google
           #
           # @param session [String]
           #   Required. The name of the session this query is sent to. Format:
-          #   +projects/<Project ID>/agent/sessions/<Session ID>+. It's up to the API
+          #   `projects/<Project ID>/agent/sessions/<Session ID>`. It's up to the API
           #   caller to choose an appropriate session ID. It can be a random number or
           #   some type of user identifier (preferably hashed). The length of the session
           #   ID must not exceed 36 bytes.
@@ -222,7 +222,7 @@ module Google
           #   can also be provided.
           # @param input_audio [String]
           #   Optional. The natural language speech audio to be processed. This field
-          #   should be populated iff +query_input+ is set to an input audio config.
+          #   should be populated iff `query_input` is set to an input audio config.
           #   A single request can contain up to 1 minute of speech audio data.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -238,7 +238,7 @@ module Google
           #   sessions_client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
           #   formatted_session = Google::Cloud::Dialogflow::V2::SessionsClient.session_path("[PROJECT]", "[SESSION]")
           #
-          #   # TODO: Initialize +query_input+:
+          #   # TODO: Initialize `query_input`:
           #   query_input = {}
           #   response = sessions_client.detect_intent(formatted_session, query_input)
 
@@ -283,10 +283,10 @@ module Google
           #
           #   sessions_client = Google::Cloud::Dialogflow::Sessions.new(version: :v2)
           #
-          #   # TODO: Initialize +session+:
+          #   # TODO: Initialize `session`:
           #   session = ''
           #
-          #   # TODO: Initialize +query_input+:
+          #   # TODO: Initialize `query_input`:
           #   query_input = {}
           #   request = { session: session, query_input: query_input }
           #   requests = [request]

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/dlp_service_client.rb
@@ -661,7 +661,7 @@ module Google
           #   reverse. This requires that only reversible transformations
           #   be provided here. The reversible transformations are:
           #
-          #   * +CryptoReplaceFfxFpeConfig+
+          #   * `CryptoReplaceFfxFpeConfig`
           #   A hash of the same form as `Google::Privacy::Dlp::V2::DeidentifyConfig`
           #   can also be provided.
           # @param inspect_config [Google::Privacy::Dlp::V2::InspectConfig | Hash]
@@ -674,14 +674,14 @@ module Google
           #   can also be provided.
           # @param inspect_template_name [String]
           #   Optional template to use. Any configuration directly specified in
-          #   +inspect_config+ will override those set in the template. Singular fields
+          #   `inspect_config` will override those set in the template. Singular fields
           #   that are set in this request will replace their corresponding fields in the
           #   template. Repeated fields are appended. Singular sub-messages and groups
           #   are recursively merged.
           # @param reidentify_template_name [String]
-          #   Optional template to use. References an instance of +DeidentifyTemplate+.
-          #   Any configuration directly specified in +reidentify_config+ or
-          #   +inspect_config+ will override those set in the template. Singular fields
+          #   Optional template to use. References an instance of `DeidentifyTemplate`.
+          #   Any configuration directly specified in `reidentify_config` or
+          #   `inspect_config` will override those set in the template. Singular fields
           #   that are set in this request will replace their corresponding fields in the
           #   template. Repeated fields are appended. Singular sub-messages and groups
           #   are recursively merged.
@@ -773,7 +773,7 @@ module Google
           # @param template_id [String]
           #   The template id can contain uppercase and lowercase letters,
           #   numbers, and hyphens; that is, it must match the regular
-          #   expression: +[a-zA-Z\\d-]++. The maximum length is 100
+          #   expression: `[a-zA-Z\\d-]+`. The maximum length is 100
           #   characters. Can be empty to allow the system to generate one.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -810,7 +810,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of organization and inspectTemplate to be updated, for
-          #   example +organizations/433245324/inspectTemplates/432452342+ or
+          #   example `organizations/433245324/inspectTemplates/432452342` or
           #   projects/project-id/inspectTemplates/432452342.
           # @param inspect_template [Google::Privacy::Dlp::V2::InspectTemplate | Hash]
           #   New InspectTemplate value.
@@ -855,7 +855,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the organization and inspectTemplate to be read, for
-          #   example +organizations/433245324/inspectTemplates/432452342+ or
+          #   example `organizations/433245324/inspectTemplates/432452342` or
           #   projects/project-id/inspectTemplates/432452342.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -943,7 +943,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the organization and inspectTemplate to be deleted, for
-          #   example +organizations/433245324/inspectTemplates/432452342+ or
+          #   example `organizations/433245324/inspectTemplates/432452342` or
           #   projects/project-id/inspectTemplates/432452342.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -986,7 +986,7 @@ module Google
           # @param template_id [String]
           #   The template id can contain uppercase and lowercase letters,
           #   numbers, and hyphens; that is, it must match the regular
-          #   expression: +[a-zA-Z\\d-]++. The maximum length is 100
+          #   expression: `[a-zA-Z\\d-]+`. The maximum length is 100
           #   characters. Can be empty to allow the system to generate one.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1024,7 +1024,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of organization and deidentify template to be updated, for
-          #   example +organizations/433245324/deidentifyTemplates/432452342+ or
+          #   example `organizations/433245324/deidentifyTemplates/432452342` or
           #   projects/project-id/deidentifyTemplates/432452342.
           # @param deidentify_template [Google::Privacy::Dlp::V2::DeidentifyTemplate | Hash]
           #   New DeidentifyTemplate value.
@@ -1070,7 +1070,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the organization and deidentify template to be read, for
-          #   example +organizations/433245324/deidentifyTemplates/432452342+ or
+          #   example `organizations/433245324/deidentifyTemplates/432452342` or
           #   projects/project-id/deidentifyTemplates/432452342.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1161,7 +1161,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the organization and deidentify template to be deleted,
-          #   for example +organizations/433245324/deidentifyTemplates/432452342+ or
+          #   for example `organizations/433245324/deidentifyTemplates/432452342` or
           #   projects/project-id/deidentifyTemplates/432452342.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1208,7 +1208,7 @@ module Google
           # @param job_id [String]
           #   The job id can contain uppercase and lowercase letters,
           #   numbers, and hyphens; that is, it must match the regular
-          #   expression: +[a-zA-Z\\d-]++. The maximum length is 100
+          #   expression: `[a-zA-Z\\d-]+`. The maximum length is 100
           #   characters. Can be empty to allow the system to generate one.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1254,16 +1254,16 @@ module Google
           #   Supported syntax:
           #
           #   * Filter expressions are made up of one or more restrictions.
-          #   * Restrictions can be combined by +AND+ or +OR+ logical operators. A
-          #     sequence of restrictions implicitly uses +AND+.
-          #   * A restriction has the form of +<field> <operator> <value>+.
+          #   * Restrictions can be combined by `AND` or `OR` logical operators. A
+          #     sequence of restrictions implicitly uses `AND`.
+          #   * A restriction has the form of `<field> <operator> <value>`.
           #   * Supported fields/values for inspect jobs:
-          #     * +state+ - PENDING|RUNNING|CANCELED|FINISHED|FAILED
-          #       * +inspected_storage+ - DATASTORE|CLOUD_STORAGE|BIGQUERY
-          #       * +trigger_name+ - The resource name of the trigger that created job.
+          #     * `state` - PENDING|RUNNING|CANCELED|FINISHED|FAILED
+          #       * `inspected_storage` - DATASTORE|CLOUD_STORAGE|BIGQUERY
+          #       * `trigger_name` - The resource name of the trigger that created job.
           #     * Supported fields for risk analysis jobs:
-          #       * +state+ - RUNNING|CANCELED|FINISHED|FAILED
-          #     * The operator must be +=+ or +!=+.
+          #       * `state` - RUNNING|CANCELED|FINISHED|FAILED
+          #     * The operator must be `=` or `!=`.
           #
           #     Examples:
           #
@@ -1279,7 +1279,7 @@ module Google
           #   performed per-page, this determines the maximum number of
           #   resources in a page.
           # @param type [Google::Privacy::Dlp::V2::DlpJobType]
-          #   The type of job. Defaults to +DlpJobType.INSPECT+
+          #   The type of job. Defaults to `DlpJobType.INSPECT`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1432,7 +1432,7 @@ module Google
           # See https://cloud.google.com/dlp/docs/creating-job-triggers to learn more.
           #
           # @param parent [String]
-          #   The parent resource name, for example +projects/my-project-id+.
+          #   The parent resource name, for example `projects/my-project-id`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -1441,17 +1441,17 @@ module Google
           #   resources in a page.
           # @param order_by [String]
           #   Optional comma separated list of triggeredJob fields to order by,
-          #   followed by +asc+ or +desc+ postfix. This list is case-insensitive,
+          #   followed by `asc` or `desc` postfix. This list is case-insensitive,
           #   default sorting order is ascending, redundant space characters are
           #   insignificant.
           #
-          #   Example: +name asc,update_time, create_time desc+
+          #   Example: `name asc,update_time, create_time desc`
           #
           #   Supported fields are:
           #
-          #   * +create_time+: corresponds to time the triggeredJob was created.
-          #   * +update_time+: corresponds to time the triggeredJob was last updated.
-          #   * +name+: corresponds to JobTrigger's name.
+          #   * `create_time`: corresponds to time the triggeredJob was created.
+          #   * `update_time`: corresponds to time the triggeredJob was last updated.
+          #   * `name`: corresponds to JobTrigger's name.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1503,7 +1503,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the project and the triggeredJob, for example
-          #   +projects/dlp-test-project/jobTriggers/53234423+.
+          #   `projects/dlp-test-project/jobTriggers/53234423`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1535,7 +1535,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the project and the triggeredJob, for example
-          #   +projects/dlp-test-project/jobTriggers/53234423+.
+          #   `projects/dlp-test-project/jobTriggers/53234423`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1548,7 +1548,7 @@ module Google
           #
           #   dlp_service_client = Google::Cloud::Dlp.new(version: :v2)
           #
-          #   # TODO: Initialize +name+:
+          #   # TODO: Initialize `name`:
           #   name = ''
           #   dlp_service_client.delete_job_trigger(name)
 
@@ -1569,7 +1569,7 @@ module Google
           #
           # @param name [String]
           #   Resource name of the project and the triggeredJob, for example
-          #   +projects/dlp-test-project/jobTriggers/53234423+.
+          #   `projects/dlp-test-project/jobTriggers/53234423`.
           # @param job_trigger [Google::Privacy::Dlp::V2::JobTrigger | Hash]
           #   New JobTrigger value.
           #   A hash of the same form as `Google::Privacy::Dlp::V2::JobTrigger`
@@ -1621,7 +1621,7 @@ module Google
           # @param trigger_id [String]
           #   The trigger id can contain uppercase and lowercase letters,
           #   numbers, and hyphens; that is, it must match the regular
-          #   expression: +[a-zA-Z\\d-]++. The maximum length is 100
+          #   expression: `[a-zA-Z\\d-]+`. The maximum length is 100
           #   characters. Can be empty to allow the system to generate one.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/dlp.rb
@@ -60,13 +60,13 @@ module Google
           # @!attribute [rw] max_findings_per_item
           #   @return [Integer]
           #     Max number of findings that will be returned for each item scanned.
-          #     When set within +InspectDataSourceRequest+,
+          #     When set within `InspectDataSourceRequest`,
           #     the maximum returned is 1000 regardless if this is set higher.
-          #     When set within +InspectContentRequest+, this field is ignored.
+          #     When set within `InspectContentRequest`, this field is ignored.
           # @!attribute [rw] max_findings_per_request
           #   @return [Integer]
           #     Max number of findings that will be returned per request/job.
-          #     When set within +InspectContentRequest+, the maximum returned is 1000
+          #     When set within `InspectContentRequest`, the maximum returned is 1000
           #     regardless if this is set higher.
           # @!attribute [rw] max_findings_per_info_type
           #   @return [Array<Google::Privacy::Dlp::V2::InspectConfig::FindingLimits::InfoTypeLimit>]
@@ -123,10 +123,10 @@ module Google
         #     learn more.
         # @!attribute [rw] byte_item
         #   @return [Google::Privacy::Dlp::V2::ByteContentItem]
-        #     Content data to inspect or redact. Replaces +type+ and +data+.
+        #     Content data to inspect or redact. Replaces `type` and `data`.
         class ContentItem; end
 
-        # Structured content to inspect. Up to 50,000 +Value+s per request allowed.
+        # Structured content to inspect. Up to 50,000 `Value`s per request allowed.
         # See https://cloud.google.com/dlp/docs/inspecting-text#inspecting_a_table to
         # learn more.
         # @!attribute [rw] headers
@@ -158,16 +158,16 @@ module Google
         #   @return [String]
         #     The content that was found. Even if the content is not textual, it
         #     may be converted to a textual representation here.
-        #     Provided if +include_quote+ is true and the finding is
+        #     Provided if `include_quote` is true and the finding is
         #     less than or equal to 4096 bytes long. If the finding exceeds 4096 bytes
         #     in length, the quote may be omitted.
         # @!attribute [rw] info_type
         #   @return [Google::Privacy::Dlp::V2::InfoType]
         #     The type of content that might have been found.
-        #     Provided if +excluded_types+ is false.
+        #     Provided if `excluded_types` is false.
         # @!attribute [rw] likelihood
         #   @return [Google::Privacy::Dlp::V2::Likelihood]
-        #     Confidence of how likely it is that the +info_type+ is correct.
+        #     Confidence of how likely it is that the `info_type` is correct.
         # @!attribute [rw] location
         #   @return [Google::Privacy::Dlp::V2::Location]
         #     Where the content was found.
@@ -244,7 +244,7 @@ module Google
         #     Field id of the field containing the finding.
         # @!attribute [rw] table_location
         #   @return [Google::Privacy::Dlp::V2::TableLocation]
-        #     Location within a +ContentItem.Table+.
+        #     Location within a `ContentItem.Table`.
         class RecordLocation; end
 
         # Location of a finding within a table.
@@ -385,7 +385,7 @@ module Google
         #     The de-identified item.
         # @!attribute [rw] overview
         #   @return [Google::Privacy::Dlp::V2::TransformationOverview]
-        #     An overview of the changes that were made on the +item+.
+        #     An overview of the changes that were made on the `item`.
         class DeidentifyContentResponse; end
 
         # Request to re-identify an item.
@@ -402,7 +402,7 @@ module Google
         #     reverse. This requires that only reversible transformations
         #     be provided here. The reversible transformations are:
         #
-        #     * +CryptoReplaceFfxFpeConfig+
+        #     * `CryptoReplaceFfxFpeConfig`
         # @!attribute [rw] inspect_config
         #   @return [Google::Privacy::Dlp::V2::InspectConfig]
         #     Configuration for the inspector.
@@ -412,15 +412,15 @@ module Google
         # @!attribute [rw] inspect_template_name
         #   @return [String]
         #     Optional template to use. Any configuration directly specified in
-        #     +inspect_config+ will override those set in the template. Singular fields
+        #     `inspect_config` will override those set in the template. Singular fields
         #     that are set in this request will replace their corresponding fields in the
         #     template. Repeated fields are appended. Singular sub-messages and groups
         #     are recursively merged.
         # @!attribute [rw] reidentify_template_name
         #   @return [String]
-        #     Optional template to use. References an instance of +DeidentifyTemplate+.
-        #     Any configuration directly specified in +reidentify_config+ or
-        #     +inspect_config+ will override those set in the template. Singular fields
+        #     Optional template to use. References an instance of `DeidentifyTemplate`.
+        #     Any configuration directly specified in `reidentify_config` or
+        #     `inspect_config` will override those set in the template. Singular fields
         #     that are set in this request will replace their corresponding fields in the
         #     template. Repeated fields are appended. Singular sub-messages and groups
         #     are recursively merged.
@@ -432,7 +432,7 @@ module Google
         #     The re-identified item.
         # @!attribute [rw] overview
         #   @return [Google::Privacy::Dlp::V2::TransformationOverview]
-        #     An overview of the changes that were made to the +item+.
+        #     An overview of the changes that were made to the `item`.
         class ReidentifyContentResponse; end
 
         # Request to search for potentially sensitive info in a ContentItem.
@@ -471,7 +471,7 @@ module Google
         #     generating the date details.
         #
         #     For Inspect, each column in an existing output table must have the same
-        #     name, type, and mode of a field in the +Finding+ object.
+        #     name, type, and mode of a field in the `Finding` object.
         #
         #     For Risk, an existing output table should be the output of a previous
         #     Risk analysis job run on the same source table, with the same privacy
@@ -482,7 +482,7 @@ module Google
         #   @return [Google::Privacy::Dlp::V2::OutputStorageConfig::OutputSchema]
         #     Schema used for writing the findings for Inspect jobs. This field is only
         #     used for Inspect and must be unspecified for Risk jobs. Columns are derived
-        #     from the +Finding+ object. If appending to an existing table, any columns
+        #     from the `Finding` object. If appending to an existing table, any columns
         #     from the predefined schema that are missing will be added. No columns in
         #     the existing table will be deleted.
         #
@@ -493,8 +493,8 @@ module Google
           module OutputSchema
             OUTPUT_SCHEMA_UNSPECIFIED = 0
 
-            # Basic schema including only +info_type+, +quote+, +certainty+, and
-            # +timestamp+.
+            # Basic schema including only `info_type`, `quote`, `certainty`, and
+            # `timestamp`.
             BASIC_COLUMNS = 1
 
             # Schema tailored to findings from scanning Google Cloud Storage.
@@ -1135,7 +1135,7 @@ module Google
         #   @return [Google::Privacy::Dlp::V2::DateShiftConfig]
         class PrimitiveTransformation; end
 
-        # For use with +Date+, +Timestamp+, and +TimeOfDay+, extract or preserve a
+        # For use with `Date`, `Timestamp`, and `TimeOfDay`, extract or preserve a
         # portion of the value.
         # @!attribute [rw] part_to_extract
         #   @return [Google::Privacy::Dlp::V2::TimePartConfig::TimePart]
@@ -1174,7 +1174,7 @@ module Google
         #     The key used by the hash function.
         class CryptoHashConfig; end
 
-        # Replace each input value with a given +Value+.
+        # Replace each input value with a given `Value`.
         # @!attribute [rw] new_value
         #   @return [Google::Privacy::Dlp::V2::Value]
         #     Value to replace it with.
@@ -1183,7 +1183,7 @@ module Google
         # Replace each matching finding with the name of the info_type.
         class ReplaceWithInfoTypeConfig; end
 
-        # Redact a given value. For example, if used with an +InfoTypeTransformation+
+        # Redact a given value. For example, if used with an `InfoTypeTransformation`
         # transforming PHONE_NUMBER, and input 'My phone number is 206-555-0123', the
         # output would be 'My phone number is '.
         class RedactConfig; end
@@ -1207,7 +1207,7 @@ module Google
             # a-z
             ALPHA_LOWER_CASE = 3
 
-            # US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_+{|}~
+            # US Punctuation, one of !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
             PUNCTUATION = 4
 
             # Whitespace character, one of [ \t\n\x0B\f\r]
@@ -1233,15 +1233,15 @@ module Google
         #     masked. Skipped characters do not count towards this tally.
         # @!attribute [rw] reverse_order
         #   @return [true, false]
-        #     Mask characters in reverse order. For example, if +masking_character+ is
-        #     '0', number_to_mask is 14, and +reverse_order+ is false, then
+        #     Mask characters in reverse order. For example, if `masking_character` is
+        #     '0', number_to_mask is 14, and `reverse_order` is false, then
         #     1234-5678-9012-3456 -> 00000000000000-3456
-        #     If +masking_character+ is '*', +number_to_mask+ is 3, and +reverse_order+
+        #     If `masking_character` is '*', `number_to_mask` is 3, and `reverse_order`
         #     is true, then 12345 -> 12***
         # @!attribute [rw] characters_to_ignore
         #   @return [Array<Google::Privacy::Dlp::V2::CharsToIgnore>]
         #     When masking a string, items in this list will be skipped when replacing.
-        #     For example, if your string is 555-555-5555 and you ask us to skip +-+ and
+        #     For example, if your string is 555-555-5555 and you ask us to skip `-` and
         #     mask 5 chars with * we would produce ***-*55-5555.
         class CharacterMaskConfig; end
 
@@ -1263,19 +1263,19 @@ module Google
         # See https://cloud.google.com/dlp/docs/concepts-bucketing to learn more.
         # @!attribute [rw] lower_bound
         #   @return [Google::Privacy::Dlp::V2::Value]
-        #     Lower bound value of buckets. All values less than +lower_bound+ are
-        #     grouped together into a single bucket; for example if +lower_bound+ = 10,
+        #     Lower bound value of buckets. All values less than `lower_bound` are
+        #     grouped together into a single bucket; for example if `lower_bound` = 10,
         #     then all values less than 10 are replaced with the value “-10”. [Required].
         # @!attribute [rw] upper_bound
         #   @return [Google::Privacy::Dlp::V2::Value]
         #     Upper bound value of buckets. All values greater than upper_bound are
-        #     grouped together into a single bucket; for example if +upper_bound+ = 89,
+        #     grouped together into a single bucket; for example if `upper_bound` = 89,
         #     then all values greater than 89 are replaced with the value “89+”.
         #     [Required].
         # @!attribute [rw] bucket_size
         #   @return [Float]
         #     Size of each bucket (except for minimum and maximum buckets). So if
-        #     +lower_bound+ = 10, +upper_bound+ = 89, and +bucket_size+ = 10, then the
+        #     `lower_bound` = 10, `upper_bound` = 89, and `bucket_size` = 10, then the
         #     following buckets would be used: -10, 10-20, 20-30, 30-40, 40-50, 50-60,
         #     60-70, 70-80, 80-89, 89+. Precision up to 2 decimals works. [Required].
         class FixedSizeBucketingConfig; end
@@ -1285,7 +1285,7 @@ module Google
         # such as 1-30 -> LOW 31-65 -> MEDIUM 66-100 -> HIGH
         # This can be used on
         # data of type: number, long, string, timestamp.
-        # If the bound +Value+ type differs from the type of data being transformed, we
+        # If the bound `Value` type differs from the type of data being transformed, we
         # will first attempt converting the type of the data to be transformed to match
         # the type of the bound before comparing.
         # See https://cloud.google.com/dlp/docs/concepts-bucketing to learn more.
@@ -1309,7 +1309,7 @@ module Google
         end
 
         # Replaces an identifier with a surrogate using FPE with the FFX
-        # mode of operation; however when used in the +ReidentifyContent+ API method,
+        # mode of operation; however when used in the `ReidentifyContent` API method,
         # it serves the opposite function by reversing the surrogate back into
         # the original identifier.
         # The identifier must be encoded as ASCII.
@@ -1334,8 +1334,8 @@ module Google
         #
         #     a default tweak will be used.
         #
-        #     Note that case (1) is expected when an +InfoTypeTransformation+ is
-        #     applied to both structured and non-structured +ContentItem+s.
+        #     Note that case (1) is expected when an `InfoTypeTransformation` is
+        #     applied to both structured and non-structured `ContentItem`s.
         #     Currently, the referenced field may be of value type integer or string.
         #
         #     The tweak is constructed as a sequence of bytes in big endian byte order
@@ -1371,7 +1371,7 @@ module Google
         #
         #     This annotation identifies the surrogate when inspecting content using the
         #     custom infoType
-        #     [+SurrogateType+](https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#surrogatetype).
+        #     [`SurrogateType`](https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#surrogatetype).
         #     This facilitates reversal of the surrogate when it occurs in free text.
         #
         #     In order for inspection to work properly, the name of this infoType must
@@ -1424,7 +1424,7 @@ module Google
         #   @return [String]
         #     Name of the key. [required]
         #     This is an arbitrary string used to differentiate different keys.
-        #     A unique key is generated per name: two separate +TransientCryptoKey+
+        #     A unique key is generated per name: two separate `TransientCryptoKey`
         #     protos share the same generated key if their names are the same.
         #     When the data crypto key is generated, this name is not used in any way
         #     (repeating the api call will result in a different key being generated).
@@ -1476,7 +1476,7 @@ module Google
         class DateShiftConfig; end
 
         # A type of transformation that will scan unstructured text and
-        # apply various +PrimitiveTransformation+s to each finding, where the
+        # apply various `PrimitiveTransformation`s to each finding, where the
         # transformation is applied to only values that were identified as a specific
         # info_type.
         # @!attribute [rw] transformations
@@ -1490,7 +1490,7 @@ module Google
           #   @return [Array<Google::Privacy::Dlp::V2::InfoType>]
           #     InfoTypes to apply the transformation to. An empty list will cause
           #     this transformation to apply to all findings that correspond to
-          #     infoTypes that were requested in +InspectConfig+.
+          #     infoTypes that were requested in `InspectConfig`.
           # @!attribute [rw] primitive_transformation
           #   @return [Google::Privacy::Dlp::V2::PrimitiveTransformation]
           #     Primitive transformation to apply to the infoType. [required]
@@ -1504,7 +1504,7 @@ module Google
         # @!attribute [rw] condition
         #   @return [Google::Privacy::Dlp::V2::RecordCondition]
         #     Only apply the transformation if the condition evaluates to true for the
-        #     given +RecordCondition+. The conditions are allowed to reference fields
+        #     given `RecordCondition`. The conditions are allowed to reference fields
         #     that are not used in the actual transformation. [optional]
         #
         #     Example Use Cases:
@@ -1518,7 +1518,7 @@ module Google
         # @!attribute [rw] info_type_transformations
         #   @return [Google::Privacy::Dlp::V2::InfoTypeTransformations]
         #     Treat the contents of the field as free text, and selectively
-        #     transform content that matches an +InfoType+.
+        #     transform content that matches an `InfoType`.
         class FieldTransformation; end
 
         # A type of transformation that is applied over structured data such as a
@@ -1546,20 +1546,20 @@ module Google
         #   @return [Google::Privacy::Dlp::V2::RecordCondition::Expressions]
         #     An expression.
         class RecordCondition
-          # The field type of +value+ and +field+ do not need to match to be
+          # The field type of `value` and `field` do not need to match to be
           # considered equal, but not all comparisons are possible.
           #
-          # A +value+ of type:
+          # A `value` of type:
           #
-          # * +string+ can be compared against all other types
-          # * +boolean+ can only be compared against other booleans
-          # * +integer+ can be compared against doubles or a string if the string value
+          # * `string` can be compared against all other types
+          # * `boolean` can only be compared against other booleans
+          # * `integer` can be compared against doubles or a string if the string value
           #   can be parsed as an integer.
-          # * +double+ can be compared against integers or a string if the string can
+          # * `double` can be compared against integers or a string if the string can
           #   be parsed as a double.
-          # * +Timestamp+ can be compared against strings in RFC 3339 date string
+          # * `Timestamp` can be compared against strings in RFC 3339 date string
           #   format.
-          # * +TimeOfDay+ can be compared against timestamps and strings in the format
+          # * `TimeOfDay` can be compared against timestamps and strings in the format
           #   of 'HH:mm:ss'.
           #
           # If we fail to compare do to type mismatch, a warning will be given and
@@ -1572,7 +1572,7 @@ module Google
           #     Operator used to compare the field or infoType to the value. [required]
           # @!attribute [rw] value
           #   @return [Google::Privacy::Dlp::V2::Value]
-          #     Value to compare against. [Required, except for +EXISTS+ tests.]
+          #     Value to compare against. [Required, except for `EXISTS` tests.]
           class Condition; end
 
           # A collection of conditions.
@@ -1584,7 +1584,7 @@ module Google
           # @!attribute [rw] logical_operator
           #   @return [Google::Privacy::Dlp::V2::RecordCondition::Expressions::LogicalOperator]
           #     The operator to apply to the result of conditions. Default and currently
-          #     only supported value is +AND+.
+          #     only supported value is `AND`.
           # @!attribute [rw] conditions
           #   @return [Google::Privacy::Dlp::V2::RecordCondition::Conditions]
           class Expressions
@@ -1632,7 +1632,7 @@ module Google
         #     Total size in bytes that were transformed in some way.
         class TransformationSummary
           # A collection that informs the user the number of times a particular
-          # +TransformationResultCode+ and error details occurred.
+          # `TransformationResultCode` and error details occurred.
           # @!attribute [rw] count
           #   @return [Integer]
           # @!attribute [rw] code
@@ -1675,8 +1675,8 @@ module Google
         #     The template name. Output only.
         #
         #     The template will have one of the following formats:
-        #     +projects/PROJECT_ID/inspectTemplates/TEMPLATE_ID+ OR
-        #     +organizations/ORGANIZATION_ID/inspectTemplates/TEMPLATE_ID+
+        #     `projects/PROJECT_ID/inspectTemplates/TEMPLATE_ID` OR
+        #     `organizations/ORGANIZATION_ID/inspectTemplates/TEMPLATE_ID`
         # @!attribute [rw] display_name
         #   @return [String]
         #     Display name (max 256 chars).
@@ -1701,8 +1701,8 @@ module Google
         #     The template name. Output only.
         #
         #     The template will have one of the following formats:
-        #     +projects/PROJECT_ID/deidentifyTemplates/TEMPLATE_ID+ OR
-        #     +organizations/ORGANIZATION_ID/deidentifyTemplates/TEMPLATE_ID+
+        #     `projects/PROJECT_ID/deidentifyTemplates/TEMPLATE_ID` OR
+        #     `organizations/ORGANIZATION_ID/deidentifyTemplates/TEMPLATE_ID`
         # @!attribute [rw] display_name
         #   @return [String]
         #     Display name (max 256 chars).
@@ -1736,7 +1736,7 @@ module Google
         #   @return [String]
         #     Unique resource name for the triggeredJob, assigned by the service when the
         #     triggeredJob is created, for example
-        #     +projects/dlp-test-project/triggeredJobs/53234423+.
+        #     `projects/dlp-test-project/triggeredJobs/53234423`.
         # @!attribute [rw] display_name
         #   @return [String]
         #     Display name (max 100 chars)
@@ -1848,7 +1848,7 @@ module Google
         #   @return [String]
         #     The template id can contain uppercase and lowercase letters,
         #     numbers, and hyphens; that is, it must match the regular
-        #     expression: +[a-zA-Z\\d-]++. The maximum length is 100
+        #     expression: `[a-zA-Z\\d-]+`. The maximum length is 100
         #     characters. Can be empty to allow the system to generate one.
         class CreateInspectTemplateRequest; end
 
@@ -1856,7 +1856,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of organization and inspectTemplate to be updated, for
-        #     example +organizations/433245324/inspectTemplates/432452342+ or
+        #     example `organizations/433245324/inspectTemplates/432452342` or
         #     projects/project-id/inspectTemplates/432452342.
         # @!attribute [rw] inspect_template
         #   @return [Google::Privacy::Dlp::V2::InspectTemplate]
@@ -1870,7 +1870,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and inspectTemplate to be read, for
-        #     example +organizations/433245324/inspectTemplates/432452342+ or
+        #     example `organizations/433245324/inspectTemplates/432452342` or
         #     projects/project-id/inspectTemplates/432452342.
         class GetInspectTemplateRequest; end
 
@@ -1882,7 +1882,7 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional page token to continue retrieval. Comes from previous call
-        #     to +ListInspectTemplates+.
+        #     to `ListInspectTemplates`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional size of the page, can be limited by server. If zero server returns
@@ -1903,7 +1903,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and inspectTemplate to be deleted, for
-        #     example +organizations/433245324/inspectTemplates/432452342+ or
+        #     example `organizations/433245324/inspectTemplates/432452342` or
         #     projects/project-id/inspectTemplates/432452342.
         class DeleteInspectTemplateRequest; end
 
@@ -1918,7 +1918,7 @@ module Google
         #   @return [String]
         #     The trigger id can contain uppercase and lowercase letters,
         #     numbers, and hyphens; that is, it must match the regular
-        #     expression: +[a-zA-Z\\d-]++. The maximum length is 100
+        #     expression: `[a-zA-Z\\d-]+`. The maximum length is 100
         #     characters. Can be empty to allow the system to generate one.
         class CreateJobTriggerRequest; end
 
@@ -1926,7 +1926,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the project and the triggeredJob, for example
-        #     +projects/dlp-test-project/jobTriggers/53234423+.
+        #     `projects/dlp-test-project/jobTriggers/53234423`.
         # @!attribute [rw] job_trigger
         #   @return [Google::Privacy::Dlp::V2::JobTrigger]
         #     New JobTrigger value.
@@ -1939,7 +1939,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the project and the triggeredJob, for example
-        #     +projects/dlp-test-project/jobTriggers/53234423+.
+        #     `projects/dlp-test-project/jobTriggers/53234423`.
         class GetJobTriggerRequest; end
 
         # Request message for CreateDlpJobRequest. Used to initiate long running
@@ -1956,18 +1956,18 @@ module Google
         #   @return [String]
         #     The job id can contain uppercase and lowercase letters,
         #     numbers, and hyphens; that is, it must match the regular
-        #     expression: +[a-zA-Z\\d-]++. The maximum length is 100
+        #     expression: `[a-zA-Z\\d-]+`. The maximum length is 100
         #     characters. Can be empty to allow the system to generate one.
         class CreateDlpJobRequest; end
 
         # Request message for ListJobTriggers.
         # @!attribute [rw] parent
         #   @return [String]
-        #     The parent resource name, for example +projects/my-project-id+.
+        #     The parent resource name, for example `projects/my-project-id`.
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional page token to continue retrieval. Comes from previous call
-        #     to ListJobTriggers. +order_by+ field must not
+        #     to ListJobTriggers. `order_by` field must not
         #     change for subsequent calls.
         # @!attribute [rw] page_size
         #   @return [Integer]
@@ -1975,17 +1975,17 @@ module Google
         # @!attribute [rw] order_by
         #   @return [String]
         #     Optional comma separated list of triggeredJob fields to order by,
-        #     followed by +asc+ or +desc+ postfix. This list is case-insensitive,
+        #     followed by `asc` or `desc` postfix. This list is case-insensitive,
         #     default sorting order is ascending, redundant space characters are
         #     insignificant.
         #
-        #     Example: +name asc,update_time, create_time desc+
+        #     Example: `name asc,update_time, create_time desc`
         #
         #     Supported fields are:
         #
-        #     * +create_time+: corresponds to time the triggeredJob was created.
-        #     * +update_time+: corresponds to time the triggeredJob was last updated.
-        #     * +name+: corresponds to JobTrigger's name.
+        #     * `create_time`: corresponds to time the triggeredJob was created.
+        #     * `update_time`: corresponds to time the triggeredJob was last updated.
+        #     * `name`: corresponds to JobTrigger's name.
         class ListJobTriggersRequest; end
 
         # Response message for ListJobTriggers.
@@ -2002,7 +2002,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the project and the triggeredJob, for example
-        #     +projects/dlp-test-project/jobTriggers/53234423+.
+        #     `projects/dlp-test-project/jobTriggers/53234423`.
         class DeleteJobTriggerRequest; end
 
         # @!attribute [rw] storage_config
@@ -2014,7 +2014,7 @@ module Google
         # @!attribute [rw] inspect_template_name
         #   @return [String]
         #     If provided, will be used as the default for all values in InspectConfig.
-        #     +inspect_config+ will be merged into the values persisted as part of the
+        #     `inspect_config` will be merged into the values persisted as part of the
         #     template.
         # @!attribute [rw] actions
         #   @return [Array<Google::Privacy::Dlp::V2::Action>]
@@ -2092,16 +2092,16 @@ module Google
         #     Supported syntax:
         #
         #     * Filter expressions are made up of one or more restrictions.
-        #     * Restrictions can be combined by +AND+ or +OR+ logical operators. A
-        #       sequence of restrictions implicitly uses +AND+.
-        #     * A restriction has the form of +<field> <operator> <value>+.
+        #     * Restrictions can be combined by `AND` or `OR` logical operators. A
+        #       sequence of restrictions implicitly uses `AND`.
+        #     * A restriction has the form of `<field> <operator> <value>`.
         #     * Supported fields/values for inspect jobs:
-        #       * +state+ - PENDING|RUNNING|CANCELED|FINISHED|FAILED
-        #         * +inspected_storage+ - DATASTORE|CLOUD_STORAGE|BIGQUERY
-        #         * +trigger_name+ - The resource name of the trigger that created job.
+        #       * `state` - PENDING|RUNNING|CANCELED|FINISHED|FAILED
+        #         * `inspected_storage` - DATASTORE|CLOUD_STORAGE|BIGQUERY
+        #         * `trigger_name` - The resource name of the trigger that created job.
         #       * Supported fields for risk analysis jobs:
-        #         * +state+ - RUNNING|CANCELED|FINISHED|FAILED
-        #       * The operator must be +=+ or +!=+.
+        #         * `state` - RUNNING|CANCELED|FINISHED|FAILED
+        #       * The operator must be `=` or `!=`.
         #
         #       Examples:
         #
@@ -2118,7 +2118,7 @@ module Google
         #     The standard list page token.
         # @!attribute [rw] type
         #   @return [Google::Privacy::Dlp::V2::DlpJobType]
-        #     The type of job. Defaults to +DlpJobType.INSPECT+
+        #     The type of job. Defaults to `DlpJobType.INSPECT`
         class ListDlpJobsRequest; end
 
         # The response message for listing DLP jobs.
@@ -2154,7 +2154,7 @@ module Google
         #   @return [String]
         #     The template id can contain uppercase and lowercase letters,
         #     numbers, and hyphens; that is, it must match the regular
-        #     expression: +[a-zA-Z\\d-]++. The maximum length is 100
+        #     expression: `[a-zA-Z\\d-]+`. The maximum length is 100
         #     characters. Can be empty to allow the system to generate one.
         class CreateDeidentifyTemplateRequest; end
 
@@ -2162,7 +2162,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of organization and deidentify template to be updated, for
-        #     example +organizations/433245324/deidentifyTemplates/432452342+ or
+        #     example `organizations/433245324/deidentifyTemplates/432452342` or
         #     projects/project-id/deidentifyTemplates/432452342.
         # @!attribute [rw] deidentify_template
         #   @return [Google::Privacy::Dlp::V2::DeidentifyTemplate]
@@ -2176,7 +2176,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and deidentify template to be read, for
-        #     example +organizations/433245324/deidentifyTemplates/432452342+ or
+        #     example `organizations/433245324/deidentifyTemplates/432452342` or
         #     projects/project-id/deidentifyTemplates/432452342.
         class GetDeidentifyTemplateRequest; end
 
@@ -2188,7 +2188,7 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional page token to continue retrieval. Comes from previous call
-        #     to +ListDeidentifyTemplates+.
+        #     to `ListDeidentifyTemplates`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional size of the page, can be limited by server. If zero server returns
@@ -2210,7 +2210,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and deidentify template to be deleted,
-        #     for example +organizations/433245324/deidentifyTemplates/432452342+ or
+        #     for example `organizations/433245324/deidentifyTemplates/432452342` or
         #     projects/project-id/deidentifyTemplates/432452342.
         class DeleteDeidentifyTemplateRequest; end
 
@@ -2218,7 +2218,7 @@ module Google
         # up to the maximum size defined in the
         # [limits](https://cloud.google.com/dlp/limits) page. The artifacts of
         # dictionary creation are stored in the specified Google Cloud Storage
-        # location. Consider using +CustomInfoType.Dictionary+ for smaller dictionaries
+        # location. Consider using `CustomInfoType.Dictionary` for smaller dictionaries
         # that satisfy the size requirements.
         # @!attribute [rw] output_path
         #   @return [Google::Privacy::Dlp::V2::CloudStoragePath]
@@ -2270,7 +2270,7 @@ module Google
         #     deleted by the user or another system, the dictionary becomes invalid.
         #     <p>If any errors occur, fix the problem indicated by the error message and
         #     use the UpdateStoredInfoType API method to create another version of the
-        #     storedInfoType to continue using it, reusing the same +config+ if it was
+        #     storedInfoType to continue using it, reusing the same `config` if it was
         #     not the source of the error.
         class StoredInfoTypeVersion; end
 
@@ -2300,7 +2300,7 @@ module Google
         #   @return [String]
         #     The storedInfoType ID can contain uppercase and lowercase letters,
         #     numbers, and hyphens; that is, it must match the regular
-        #     expression: +[a-zA-Z\\d-]++. The maximum length is 100
+        #     expression: `[a-zA-Z\\d-]+`. The maximum length is 100
         #     characters. Can be empty to allow the system to generate one.
         class CreateStoredInfoTypeRequest; end
 
@@ -2308,7 +2308,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of organization and storedInfoType to be updated, for
-        #     example +organizations/433245324/storedInfoTypes/432452342+ or
+        #     example `organizations/433245324/storedInfoTypes/432452342` or
         #     projects/project-id/storedInfoTypes/432452342.
         # @!attribute [rw] config
         #   @return [Google::Privacy::Dlp::V2::StoredInfoTypeConfig]
@@ -2324,7 +2324,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and storedInfoType to be read, for
-        #     example +organizations/433245324/storedInfoTypes/432452342+ or
+        #     example `organizations/433245324/storedInfoTypes/432452342` or
         #     projects/project-id/storedInfoTypes/432452342.
         class GetStoredInfoTypeRequest; end
 
@@ -2336,7 +2336,7 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Optional page token to continue retrieval. Comes from previous call
-        #     to +ListStoredInfoTypes+.
+        #     to `ListStoredInfoTypes`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional size of the page, can be limited by server. If zero server returns
@@ -2357,7 +2357,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Resource name of the organization and storedInfoType to be deleted, for
-        #     example +organizations/433245324/storedInfoTypes/432452342+ or
+        #     example `organizations/433245324/storedInfoTypes/432452342` or
         #     projects/project-id/storedInfoTypes/432452342.
         class DeleteStoredInfoTypeRequest; end
 
@@ -2432,12 +2432,12 @@ module Google
           READY = 2
 
           # StoredInfoType creation failed. All relevant error messages are returned in
-          # the +StoredInfoTypeVersion+ message.
+          # the `StoredInfoTypeVersion` message.
           FAILED = 3
 
           # StoredInfoType is no longer valid because artifacts stored in
           # user-controlled storage were modified. To fix an invalid StoredInfoType,
-          # use the +UpdateStoredInfoType+ method to create a new version.
+          # use the `UpdateStoredInfoType` method to create a new version.
           INVALID = 4
         end
       end

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/privacy/dlp/v2/storage.rb
@@ -29,12 +29,12 @@ module Google
         # A reference to a StoredInfoType to use with scanning.
         # @!attribute [rw] name
         #   @return [String]
-        #     Resource name of the requested +StoredInfoType+, for example
-        #     +organizations/433245324/storedInfoTypes/432452342+ or
-        #     +projects/project-id/storedInfoTypes/432452342+.
+        #     Resource name of the requested `StoredInfoType`, for example
+        #     `organizations/433245324/storedInfoTypes/432452342` or
+        #     `projects/project-id/storedInfoTypes/432452342`.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Timestamp indicating when the version of the +StoredInfoType+ used for
+        #     Timestamp indicating when the version of the `StoredInfoType` used for
         #     inspection was created. Output-only field, populated by the system.
         class StoredType; end
 
@@ -48,7 +48,7 @@ module Google
         #   @return [Google::Privacy::Dlp::V2::Likelihood]
         #     Likelihood to return for this CustomInfoType. This base value can be
         #     altered by a detection rule if the finding meets the criteria specified by
-        #     the rule. Defaults to +VERY_LIKELY+ if not specified.
+        #     the rule. Defaults to `VERY_LIKELY` if not specified.
         # @!attribute [rw] dictionary
         #   @return [Google::Privacy::Dlp::V2::CustomInfoType::Dictionary]
         #     A list of phrases to detect as a CustomInfoType.
@@ -61,13 +61,13 @@ module Google
         #     support reversing.
         # @!attribute [rw] stored_type
         #   @return [Google::Privacy::Dlp::V2::StoredType]
-        #     Load an existing +StoredInfoType+ resource for use in
-        #     +InspectDataSource+. Not currently supported in +InspectContent+.
+        #     Load an existing `StoredInfoType` resource for use in
+        #     `InspectDataSource`. Not currently supported in `InspectContent`.
         # @!attribute [rw] detection_rules
         #   @return [Array<Google::Privacy::Dlp::V2::CustomInfoType::DetectionRule>]
         #     Set of detection rules to apply to all findings of this CustomInfoType.
         #     Rules are applied in order that they are specified. Not supported for the
-        #     +surrogate_type+ CustomInfoType.
+        #     `surrogate_type` CustomInfoType.
         class CustomInfoType
           # Custom information type based on a dictionary of words or phrases. This can
           # be used to match sensitive information specific to the data, such as a list
@@ -90,8 +90,8 @@ module Google
           # are treated as whitespace. The
           # [limits](https://cloud.google.com/dlp/limits) page contains details about
           # the size limits of dictionaries. For dictionaries that do not fit within
-          # these constraints, consider using +LargeCustomDictionaryConfig+ in the
-          # +StoredInfoType+ API.
+          # these constraints, consider using `LargeCustomDictionaryConfig` in the
+          # `StoredInfoType` API.
           # @!attribute [rw] word_list
           #   @return [Google::Privacy::Dlp::V2::CustomInfoType::Dictionary::WordList]
           #     List of words or phrases to search for.
@@ -117,17 +117,17 @@ module Google
 
           # Message for detecting output from deidentification transformations
           # such as
-          # [+CryptoReplaceFfxFpeConfig+](https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#cryptoreplaceffxfpeconfig).
+          # [`CryptoReplaceFfxFpeConfig`](https://cloud.google.com/dlp/docs/reference/rest/v2/organizations.deidentifyTemplates#cryptoreplaceffxfpeconfig).
           # These types of transformations are
           # those that perform pseudonymization, thereby producing a "surrogate" as
           # output. This should be used in conjunction with a field on the
-          # transformation such as +surrogate_info_type+. This CustomInfoType does
-          # not support the use of +detection_rules+.
+          # transformation such as `surrogate_info_type`. This CustomInfoType does
+          # not support the use of `detection_rules`.
           class SurrogateType; end
 
           # Rule for modifying a CustomInfoType to alter behavior under certain
           # circumstances, depending on the specific details of the rule. Not supported
-          # for the +surrogate_type+ custom info type.
+          # for the `surrogate_type` custom info type.
           # @!attribute [rw] hotword_rule
           #   @return [Google::Privacy::Dlp::V2::CustomInfoType::DetectionRule::HotwordRule]
           #     Hotword-based detection rule.
@@ -150,13 +150,13 @@ module Google
             # @!attribute [rw] relative_likelihood
             #   @return [Integer]
             #     Increase or decrease the likelihood by the specified number of
-            #     levels. For example, if a finding would be +POSSIBLE+ without the
-            #     detection rule and +relative_likelihood+ is 1, then it is upgraded to
-            #     +LIKELY+, while a value of -1 would downgrade it to +UNLIKELY+.
-            #     Likelihood may never drop below +VERY_UNLIKELY+ or exceed
-            #     +VERY_LIKELY+, so applying an adjustment of 1 followed by an
-            #     adjustment of -1 when base likelihood is +VERY_LIKELY+ will result in
-            #     a final likelihood of +LIKELY+.
+            #     levels. For example, if a finding would be `POSSIBLE` without the
+            #     detection rule and `relative_likelihood` is 1, then it is upgraded to
+            #     `LIKELY`, while a value of -1 would downgrade it to `UNLIKELY`.
+            #     Likelihood may never drop below `VERY_UNLIKELY` or exceed
+            #     `VERY_LIKELY`, so applying an adjustment of 1 followed by an
+            #     adjustment of -1 when base likelihood is `VERY_LIKELY` will result in
+            #     a final likelihood of `LIKELY`.
             class LikelihoodAdjustment; end
 
             # The rule that adjusts the likelihood of findings within a certain
@@ -248,7 +248,7 @@ module Google
           # Set of files to scan.
           # @!attribute [rw] url
           #   @return [String]
-          #     The url, in the format +gs://<bucket>/<path>+. Trailing wildcard in the
+          #     The url, in the format `gs://<bucket>/<path>`. Trailing wildcard in the
           #     path is allowed.
           class FileSet; end
 
@@ -270,7 +270,7 @@ module Google
         # Message representing a set of files in Cloud Storage.
         # @!attribute [rw] url
         #   @return [String]
-        #     The url, in the format +gs://<bucket>/<path>+. Trailing wildcard in the
+        #     The url, in the format `gs://<bucket>/<path>`. Trailing wildcard in the
         #     path is allowed.
         class CloudStorageFileSet; end
 
@@ -288,7 +288,7 @@ module Google
         # @!attribute [rw] identifying_fields
         #   @return [Array<Google::Privacy::Dlp::V2::FieldId>]
         #     References to fields uniquely identifying rows within the table.
-        #     Nested fields in the format, like +person.birthdate.year+, are allowed.
+        #     Nested fields in the format, like `person.birthdate.year`, are allowed.
         # @!attribute [rw] rows_limit
         #   @return [Integer]
         #     Max number of rows to scan. If the table has more rows than this value, the
@@ -405,9 +405,9 @@ module Google
           # @!attribute [rw] kind
           #   @return [String]
           #     The kind of the entity.
-          #     A kind matching regex +__.*__+ is reserved/read-only.
+          #     A kind matching regex `__.*__` is reserved/read-only.
           #     A kind must not contain more than 1500 bytes when UTF-8 encoded.
-          #     Cannot be +""+.
+          #     Cannot be `""`.
           # @!attribute [rw] id
           #   @return [Integer]
           #     The auto-allocated ID of the entity.
@@ -416,9 +416,9 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     The name of the entity.
-          #     A name matching regex +__.*__+ is reserved/read-only.
+          #     A name matching regex `__.*__` is reserved/read-only.
           #     A name must not be more than 1500 bytes when UTF-8 encoded.
-          #     Cannot be +""+.
+          #     Cannot be `""`.
           class PathElement; end
         end
 
@@ -432,8 +432,8 @@ module Google
         # Message defining the location of a BigQuery table. A table is uniquely
         # identified  by its project_id, dataset_id, and table_name. Within a query
         # a table is often referenced with a string in the format of:
-        # +<project_id>:<dataset_id>.<table_id>+ or
-        # +<project_id>.<dataset_id>.<table_id>+.
+        # `<project_id>:<dataset_id>.<table_id>` or
+        # `<project_id>.<dataset_id>.<table_id>`.
         # @!attribute [rw] project_id
         #   @return [String]
         #     The Google Cloud Platform project ID of the project containing the table.
@@ -456,7 +456,7 @@ module Google
         class BigQueryField; end
 
         # An entity in a dataset is a field or set of fields that correspond to a
-        # single person. For example, in medical records the +EntityId+ might be a
+        # single person. For example, in medical records the `EntityId` might be a
         # patient identifier, or for financial records it might be an account
         # identifier. This message is used when generalizations or analysis must take
         # into account that multiple rows correspond to the same entity.

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/duration.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/rpc/status.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/type/date.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/type/date.rb
@@ -21,7 +21,7 @@ module Google
     # represent a year and month where the day is not significant, e.g. credit card
     # expiration date. The year may be 0 to represent a month and day independent
     # of year, e.g. anniversary date. Related types are {Google::Type::TimeOfDay}
-    # and +google.protobuf.Timestamp+.
+    # and `google.protobuf.Timestamp`.
     # @!attribute [rw] year
     #   @return [Integer]
     #     Year of date. Must be from 1 to 9999, or 0 if specifying a date without

--- a/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/type/timeofday.rb
+++ b/google-cloud-dlp/lib/google/cloud/dlp/v2/doc/google/type/timeofday.rb
@@ -17,7 +17,7 @@ module Google
   module Type
     # Represents a time of day. The date and time zone are either not significant
     # or are specified elsewhere. An API may chose to allow leap seconds. Related
-    # types are {Google::Type::Date} and +google.protobuf.Timestamp+.
+    # types are {Google::Type::Date} and `google.protobuf.Timestamp`.
     # @!attribute [rw] hours
     #   @return [Integer]
     #     Hours of day in 24 hour format. Should be from 0 to 23. An API may choose

--- a/google-cloud-dlp/synth.py
+++ b/google-cloud-dlp/synth.py
@@ -38,10 +38,10 @@ s.copy(v2_library / 'google-cloud-dlp.gemspec', merge=ruby.merge_gemspec)
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/common.rb
@@ -46,7 +46,7 @@ module Google
         #     by the Error Reporting system is used.
         # @!attribute [rw] service_context
         #   @return [Google::Devtools::Clouderrorreporting::V1beta1::ServiceContext]
-        #     The +ServiceContext+ for which this error was reported.
+        #     The `ServiceContext` for which this error was reported.
         # @!attribute [rw] message
         #   @return [String]
         #     The stack trace that was reported or logged by the service.
@@ -62,10 +62,10 @@ module Google
         #     An identifier of the service, such as the name of the
         #     executable, job, or Google App Engine service name. This field is expected
         #     to have a low number of values that are relatively stable over time, as
-        #     opposed to +version+, which can be changed whenever new code is deployed.
+        #     opposed to `version`, which can be changed whenever new code is deployed.
         #
         #     Contains the service name for error reports extracted from Google
-        #     App Engine logs or +default+ if the App Engine default service is used.
+        #     App Engine logs or `default` if the App Engine default service is used.
         # @!attribute [rw] version
         #   @return [String]
         #     Represents the source code version that the developer provided,
@@ -95,15 +95,15 @@ module Google
         #     When sending an error report, leave this field empty if the user was not
         #     logged in. In this case the
         #     Error Reporting system will use other data, such as remote IP address, to
-        #     distinguish affected users. See +affected_users_count+ in
-        #     +ErrorGroupStats+.
+        #     distinguish affected users. See `affected_users_count` in
+        #     `ErrorGroupStats`.
         # @!attribute [rw] report_location
         #   @return [Google::Devtools::Clouderrorreporting::V1beta1::SourceLocation]
         #     The location in the source code where the decision was made to
         #     report the error, usually the place where it was logged.
         #     For a logged exception this would be the source line where the
         #     exception is logged, usually close to the place where it was
-        #     caught. This value is in contrast to +Exception.cause_location+,
+        #     caught. This value is in contrast to `Exception.cause_location`,
         #     which describes the source line where the exception was thrown.
         class ErrorContext; end
 
@@ -113,7 +113,7 @@ module Google
         # error report has been generated automatically from Google App Engine logs.
         # @!attribute [rw] method
         #   @return [String]
-        #     The type of HTTP request, such as +GET+, +POST+, etc.
+        #     The type of HTTP request, such as `GET`, `POST`, etc.
         # @!attribute [rw] url
         #   @return [String]
         #     The URL of the request.
@@ -150,7 +150,7 @@ module Google
         #   @return [String]
         #     Human-readable name of a function or method.
         #     The value can include optional context like the class or package name.
-        #     For example, +my.package.MyClass.method+ in case of Java.
+        #     For example, `my.package.MyClass.method` in case of Java.
         class SourceLocation; end
       end
     end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/error_stats_service.rb
@@ -17,7 +17,7 @@ module Google
   module Devtools
     module Clouderrorreporting
       module V1beta1
-        # Specifies a set of +ErrorGroupStats+ to return.
+        # Specifies a set of `ErrorGroupStats` to return.
         # @!attribute [rw] project_name
         #   @return [String]
         #     [Required] The resource name of the Google Cloud Platform project. Written
@@ -45,12 +45,12 @@ module Google
         #     occurrences are returned.
         # @!attribute [rw] timed_count_duration
         #   @return [Google::Protobuf::Duration]
-        #     [Optional] The preferred duration for a single returned +TimedCount+.
+        #     [Optional] The preferred duration for a single returned `TimedCount`.
         #     If not set, no timed counts are returned.
         # @!attribute [rw] alignment
         #   @return [Google::Devtools::Clouderrorreporting::V1beta1::TimedCountAlignment]
         #     [Optional] The alignment of the timed counts to be returned.
-        #     Default is +ALIGNMENT_EQUAL_AT_END+.
+        #     Default is `ALIGNMENT_EQUAL_AT_END`.
         # @!attribute [rw] alignment_time
         #   @return [Google::Protobuf::Timestamp]
         #     [Optional] Time where the timed counts shall be aligned if rounded
@@ -58,14 +58,14 @@ module Google
         # @!attribute [rw] order
         #   @return [Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupOrder]
         #     [Optional] The sort order in which the results are returned.
-        #     Default is +COUNT_DESC+.
+        #     Default is `COUNT_DESC`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     [Optional] The maximum number of results to return per response.
         #     Default is 20.
         # @!attribute [rw] page_token
         #   @return [String]
-        #     [Optional] A +next_page_token+ provided by a previous response. To view
+        #     [Optional] A `next_page_token` provided by a previous response. To view
         #     additional results, pass this token along with the identical query
         #     parameters as the first request.
         class ListGroupStatsRequest; end
@@ -100,7 +100,7 @@ module Google
         #   @return [Integer]
         #     Approximate number of affected users in the given group that
         #     match the filter criteria.
-        #     Users are distinguished by data in the +ErrorContext+ of the
+        #     Users are distinguished by data in the `ErrorContext` of the
         #     individual error events, such as their login name or their remote
         #     IP address in case of HTTP requests.
         #     The number of affected users can be zero even if the number of
@@ -132,7 +132,7 @@ module Google
         #   @return [Array<Google::Devtools::Clouderrorreporting::V1beta1::ServiceContext>]
         #     Service contexts with a non-zero error count for the given filter
         #     criteria. This list can be truncated if multiple services are affected.
-        #     Refer to +num_affected_services+ for the total count.
+        #     Refer to `num_affected_services` for the total count.
         # @!attribute [rw] num_affected_services
         #   @return [Integer]
         #     The total number of services with a non-zero error count for the given
@@ -154,20 +154,20 @@ module Google
         #     Approximate number of occurrences in the given time period.
         # @!attribute [rw] start_time
         #   @return [Google::Protobuf::Timestamp]
-        #     Start of the time period to which +count+ refers (included).
+        #     Start of the time period to which `count` refers (included).
         # @!attribute [rw] end_time
         #   @return [Google::Protobuf::Timestamp]
-        #     End of the time period to which +count+ refers (excluded).
+        #     End of the time period to which `count` refers (excluded).
         class TimedCount; end
 
         # Specifies a set of error events to return.
         # @!attribute [rw] project_name
         #   @return [String]
         #     [Required] The resource name of the Google Cloud Platform project. Written
-        #     as +projects/+ plus the
+        #     as `projects/` plus the
         #     [Google Cloud Platform project
         #     ID](https://support.google.com/cloud/answer/6158840).
-        #     Example: +projects/my-project-123+.
+        #     Example: `projects/my-project-123`.
         # @!attribute [rw] group_id
         #   @return [String]
         #     [Required] The group for which events shall be returned.
@@ -186,7 +186,7 @@ module Google
         #     [Optional] The maximum number of results to return per response.
         # @!attribute [rw] page_token
         #   @return [String]
-        #     [Optional] A +next_page_token+ provided by a previous response.
+        #     [Optional] A `next_page_token` provided by a previous response.
         class ListEventsRequest; end
 
         # Contains a set of requested error events.
@@ -237,31 +237,31 @@ module Google
         end
 
         # Specifies criteria for filtering a subset of service contexts.
-        # The fields in the filter correspond to the fields in +ServiceContext+.
+        # The fields in the filter correspond to the fields in `ServiceContext`.
         # Only exact, case-sensitive matches are supported.
         # If a field is unset or empty, it matches arbitrary values.
         # @!attribute [rw] service
         #   @return [String]
         #     [Optional] The exact value to match against
-        #     [+ServiceContext.service+](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
+        #     [`ServiceContext.service`](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.service).
         # @!attribute [rw] version
         #   @return [String]
         #     [Optional] The exact value to match against
-        #     [+ServiceContext.version+](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
+        #     [`ServiceContext.version`](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.version).
         # @!attribute [rw] resource_type
         #   @return [String]
         #     [Optional] The exact value to match against
-        #     [+ServiceContext.resource_type+](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.resource_type).
+        #     [`ServiceContext.resource_type`](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext#FIELDS.resource_type).
         class ServiceContextFilter; end
 
         # Deletes all events in the project.
         # @!attribute [rw] project_name
         #   @return [String]
         #     [Required] The resource name of the Google Cloud Platform project. Written
-        #     as +projects/+ plus the
+        #     as `projects/` plus the
         #     [Google Cloud Platform project
         #     ID](https://support.google.com/cloud/answer/6158840).
-        #     Example: +projects/my-project-123+.
+        #     Example: `projects/my-project-123`.
         class DeleteEventsRequest; end
 
         # Response message for deleting error events.
@@ -273,9 +273,9 @@ module Google
           ERROR_COUNT_ALIGNMENT_UNSPECIFIED = 0
 
           # The time periods shall be consecutive, have width equal to the
-          # requested duration, and be aligned at the +alignment_time+ provided in
+          # requested duration, and be aligned at the `alignment_time` provided in
           # the request.
-          # The +alignment_time+ does not have to be inside the query period but
+          # The `alignment_time` does not have to be inside the query period but
           # even if it is outside, only time periods are returned which overlap
           # with the query period.
           # A rounded alignment will typically result in a

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/devtools/clouderrorreporting/v1beta1/report_errors_service.rb
@@ -21,9 +21,9 @@ module Google
         # @!attribute [rw] project_name
         #   @return [String]
         #     [Required] The resource name of the Google Cloud Platform project. Written
-        #     as +projects/+ plus the
+        #     as `projects/` plus the
         #     [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
-        #     Example: +projects/my-project-123+.
+        #     Example: `projects/my-project-123`.
         # @!attribute [rw] event
         #   @return [Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent]
         #     [Required] The error event to be reported.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_group_service_client.rb
@@ -248,7 +248,7 @@ module Google
           #
           #   error_group_service_client = Google::Cloud::ErrorReporting::ErrorGroup.new(version: :v1beta1)
           #
-          #   # TODO: Initialize +group+:
+          #   # TODO: Initialize `group`:
           #   group = {}
           #   response = error_group_service_client.update_group(group)
 

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/error_stats_service_client.rb
@@ -237,13 +237,13 @@ module Google
           #   A hash of the same form as `Google::Devtools::Clouderrorreporting::V1beta1::ServiceContextFilter`
           #   can also be provided.
           # @param timed_count_duration [Google::Protobuf::Duration | Hash]
-          #   [Optional] The preferred duration for a single returned +TimedCount+.
+          #   [Optional] The preferred duration for a single returned `TimedCount`.
           #   If not set, no timed counts are returned.
           #   A hash of the same form as `Google::Protobuf::Duration`
           #   can also be provided.
           # @param alignment [Google::Devtools::Clouderrorreporting::V1beta1::TimedCountAlignment]
           #   [Optional] The alignment of the timed counts to be returned.
-          #   Default is +ALIGNMENT_EQUAL_AT_END+.
+          #   Default is `ALIGNMENT_EQUAL_AT_END`.
           # @param alignment_time [Google::Protobuf::Timestamp | Hash]
           #   [Optional] Time where the timed counts shall be aligned if rounded
           #   alignment is chosen. Default is 00:00 UTC.
@@ -251,7 +251,7 @@ module Google
           #   can also be provided.
           # @param order [Google::Devtools::Clouderrorreporting::V1beta1::ErrorGroupOrder]
           #   [Optional] The sort order in which the results are returned.
-          #   Default is +COUNT_DESC+.
+          #   Default is `COUNT_DESC`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -276,7 +276,7 @@ module Google
           #   error_stats_service_client = Google::Cloud::ErrorReporting::ErrorStats.new(version: :v1beta1)
           #   formatted_project_name = Google::Cloud::ErrorReporting::V1beta1::ErrorStatsServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +time_range+:
+          #   # TODO: Initialize `time_range`:
           #   time_range = {}
           #
           #   # Iterate over all results.
@@ -323,10 +323,10 @@ module Google
           #
           # @param project_name [String]
           #   [Required] The resource name of the Google Cloud Platform project. Written
-          #   as +projects/+ plus the
+          #   as `projects/` plus the
           #   [Google Cloud Platform project
           #   ID](https://support.google.com/cloud/answer/6158840).
-          #   Example: +projects/my-project-123+.
+          #   Example: `projects/my-project-123`.
           # @param group_id [String]
           #   [Required] The group for which events shall be returned.
           # @param service_filter [Google::Devtools::Clouderrorreporting::V1beta1::ServiceContextFilter | Hash]
@@ -365,7 +365,7 @@ module Google
           #   error_stats_service_client = Google::Cloud::ErrorReporting::ErrorStats.new(version: :v1beta1)
           #   formatted_project_name = Google::Cloud::ErrorReporting::V1beta1::ErrorStatsServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +group_id+:
+          #   # TODO: Initialize `group_id`:
           #   group_id = ''
           #
           #   # Iterate over all results.
@@ -404,10 +404,10 @@ module Google
           #
           # @param project_name [String]
           #   [Required] The resource name of the Google Cloud Platform project. Written
-          #   as +projects/+ plus the
+          #   as `projects/` plus the
           #   [Google Cloud Platform project
           #   ID](https://support.google.com/cloud/answer/6158840).
-          #   Example: +projects/my-project-123+.
+          #   Example: `projects/my-project-123`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
+++ b/google-cloud-error_reporting/lib/google/cloud/error_reporting/v1beta1/report_errors_service_client.rb
@@ -190,14 +190,14 @@ module Google
           # <strong>or</strong> an
           # <a href="https://support.google.com/cloud/answer/6158862">API key</a>
           # for authentication. To use an API key, append it to the URL as the value of
-          # a +key+ parameter. For example:
+          # a `key` parameter. For example:
           # <pre>POST https://clouderrorreporting.googleapis.com/v1beta1/projects/example-project/events:report?key=123ABC456</pre>
           #
           # @param project_name [String]
           #   [Required] The resource name of the Google Cloud Platform project. Written
-          #   as +projects/+ plus the
+          #   as `projects/` plus the
           #   [Google Cloud Platform project ID](https://support.google.com/cloud/answer/6158840).
-          #   Example: +projects/my-project-123+.
+          #   Example: `projects/my-project-123`.
           # @param event [Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent | Hash]
           #   [Required] The error event to be reported.
           #   A hash of the same form as `Google::Devtools::Clouderrorreporting::V1beta1::ReportedErrorEvent`
@@ -216,7 +216,7 @@ module Google
           #   report_errors_service_client = Google::Cloud::ErrorReporting::ReportErrors.new(version: :v1beta1)
           #   formatted_project_name = Google::Cloud::ErrorReporting::V1beta1::ReportErrorsServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +event+:
+          #   # TODO: Initialize `event`:
           #   event = {}
           #   response = report_errors_service_client.report_error_event(formatted_project_name, event)
 

--- a/google-cloud-error_reporting/synth.py
+++ b/google-cloud-error_reporting/synth.py
@@ -36,10 +36,10 @@ s.copy(v1beta1_library / 'lib/google/devtools/clouderrorreporting/v1beta1')
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1.rb
@@ -83,17 +83,17 @@ module Google
         #
         # This service exposes several types of comparable timestamps:
         #
-        # * +create_time+ - The time at which a document was created. Changes only
+        # * `create_time` - The time at which a document was created. Changes only
         #   when a document is deleted, then re-created. Increases in a strict
         #   monotonic fashion.
-        # * +update_time+ - The time at which a document was last updated. Changes
+        # * `update_time` - The time at which a document was last updated. Changes
         #   every time a document is modified. Does not change when a write results
         #   in no modifications. Increases in a strict monotonic fashion.
-        # * +read_time+ - The time at which a particular state was observed. Used
+        # * `read_time` - The time at which a particular state was observed. Used
         #   to denote a consistent snapshot of the database or the time at which a
         #   Document was observed to not exist.
-        # * +commit_time+ - The time at which the writes in a transaction were
-        #   committed. Any read with an equal or greater +read_time+ is guaranteed
+        # * `commit_time` - The time at which the writes in a transaction were
+        #   committed. Any read with an equal or greater `read_time` is guaranteed
         #   to see the effects of the transaction.
         #
         # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/common.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/common.rb
@@ -30,8 +30,8 @@ module Google
       # A precondition on a document, used for conditional operations.
       # @!attribute [rw] exists
       #   @return [true, false]
-      #     When set to +true+, the target document must exist.
-      #     When set to +false+, the target document must not exist.
+      #     When set to `true`, the target document must exist.
+      #     When set to `false`, the target document must not exist.
       # @!attribute [rw] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     When set, the target document must exist and have been last updated at

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/document.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/document.rb
@@ -22,47 +22,47 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the document, for example
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] fields
       #   @return [Hash{String => Google::Firestore::V1beta1::Value}]
       #     The document's fields.
       #
       #     The map keys represent field names.
       #
-      #     A simple field name contains only characters +a+ to +z+, +A+ to +Z+,
-      #     +0+ to +9+, or +_+, and must not start with +0+ to +9+. For example,
-      #     +foo_bar_17+.
+      #     A simple field name contains only characters `a` to `z`, `A` to `Z`,
+      #     `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
+      #     `foo_bar_17`.
       #
-      #     Field names matching the regular expression +__.*__+ are reserved. Reserved
+      #     Field names matching the regular expression `__.*__` are reserved. Reserved
       #     field names are forbidden except in certain documented contexts. The map
       #     keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
       #     empty.
       #
       #     Field paths may be used in other contexts to refer to structured fields
-      #     defined here. For +map_value+, the field path is represented by the simple
-      #     or quoted field names of the containing fields, delimited by +.+. For
+      #     defined here. For `map_value`, the field path is represented by the simple
+      #     or quoted field names of the containing fields, delimited by `.`. For
       #     example, the structured field
-      #     +"foo" : { map_value: { "x&y" : { string_value: "hello" }}}+ would be
-      #     represented by the field path +foo.x&y+.
+      #     `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
+      #     represented by the field path `foo.x&y`.
       #
-      #     Within a field path, a quoted field name starts and ends with + + + and
-      #     may contain any character. Some characters, including + + +, must be
-      #     escaped using a +\+. For example, + +x&y+ + represents +x&y+ and
-      #     + +bak\+tik+ + represents + bak+tik +.
+      #     Within a field path, a quoted field name starts and ends with `` ` `` and
+      #     may contain any character. Some characters, including `` ` ``, must be
+      #     escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
+      #     `` `bak\`tik` `` represents `` bak`tik ``.
       # @!attribute [rw] create_time
       #   @return [Google::Protobuf::Timestamp]
       #     Output only. The time at which the document was created.
       #
       #     This value increases monotonically when a document is deleted then
       #     recreated. It can also be compared to values from other documents and
-      #     the +read_time+ of a query.
+      #     the `read_time` of a query.
       # @!attribute [rw] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     Output only. The time at which the document was last changed.
       #
-      #     This value is initially set to the +create_time+ then increases
+      #     This value is initially set to the `create_time` then increases
       #     monotonically with each change to the document. It can also be
-      #     compared to values from other documents and the +read_time+ of a query.
+      #     compared to values from other documents and the `read_time` of a query.
       class Document; end
 
       # A message that can hold any of the supported value types.
@@ -100,7 +100,7 @@ module Google
       # @!attribute [rw] reference_value
       #   @return [String]
       #     A reference to a document. For example:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] geo_point_value
       #   @return [Google::Type::LatLng]
       #     A geo point value representing a point on the surface of Earth.
@@ -127,7 +127,7 @@ module Google
       #     The map's fields.
       #
       #     The map keys represent field names. Field names matching the regular
-      #     expression +__.*__+ are reserved. Reserved field names are forbidden except
+      #     expression `__.*__` are reserved. Reserved field names are forbidden except
       #     in certain documented contexts. The map keys, represented as UTF-8, must
       #     not exceed 1,500 bytes and cannot be empty.
       class MapValue; end

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/firestore.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/firestore.rb
@@ -20,7 +20,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the Document to get. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to return. If not set, returns all fields.
@@ -40,24 +40,24 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents` or
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       #     For example:
-      #     +projects/my-project/databases/my-database/documents+ or
-      #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+      #     `projects/my-project/databases/my-database/documents` or
+      #     `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
       # @!attribute [rw] collection_id
       #   @return [String]
-      #     The collection ID, relative to +parent+, to list. For example: +chatrooms+
-      #     or +messages+.
+      #     The collection ID, relative to `parent`, to list. For example: `chatrooms`
+      #     or `messages`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of documents to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The +next_page_token+ value returned from a previous List request, if any.
+      #     The `next_page_token` value returned from a previous List request, if any.
       # @!attribute [rw] order_by
       #   @return [String]
-      #     The order to sort results by. For example: +priority desc, name+.
+      #     The order to sort results by. For example: `priority desc, name`.
       # @!attribute [rw] mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to return. If not set, returns all fields.
@@ -78,8 +78,8 @@ module Google
       #     be returned with a key but will not have fields, {Google::Firestore::V1beta1::Document#create_time Document#create_time},
       #     or {Google::Firestore::V1beta1::Document#update_time Document#update_time} set.
       #
-      #     Requests with +show_missing+ may not specify +where+ or
-      #     +order_by+.
+      #     Requests with `show_missing` may not specify `where` or
+      #     `order_by`.
       class ListDocumentsRequest; end
 
       # The response for {Google::Firestore::V1beta1::Firestore::ListDocuments Firestore::ListDocuments}.
@@ -95,11 +95,11 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource. For example:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/chatrooms/\\{chatroom_id}+
+      #     `projects/{project_id}/databases/{database_id}/documents` or
+      #     `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
       # @!attribute [rw] collection_id
       #   @return [String]
-      #     The collection ID, relative to +parent+, to list. For example: +chatrooms+.
+      #     The collection ID, relative to `parent`, to list. For example: `chatrooms`.
       # @!attribute [rw] document_id
       #   @return [String]
       #     The client-assigned document ID to use for this document.
@@ -107,7 +107,7 @@ module Google
       #     Optional. If not specified, an ID will be assigned by the service.
       # @!attribute [rw] document
       #   @return [Google::Firestore::V1beta1::Document]
-      #     The document to create. +name+ must not be set.
+      #     The document to create. `name` must not be set.
       # @!attribute [rw] mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to return. If not set, returns all fields.
@@ -146,7 +146,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The resource name of the Document to delete. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] current_document
       #   @return [Google::Firestore::V1beta1::Precondition]
       #     An optional precondition on the document.
@@ -157,13 +157,13 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       # @!attribute [rw] documents
       #   @return [Array<String>]
       #     The names of the documents to retrieve. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       #     The request will fail if any of the document is not a child resource of the
-      #     given +database+. Duplicate names will be elided.
+      #     given `database`. Duplicate names will be elided.
       # @!attribute [rw] mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to return. If not set, returns all fields.
@@ -192,7 +192,7 @@ module Google
       # @!attribute [rw] missing
       #   @return [String]
       #     A document name that was requested but does not exist. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The transaction that was started as part of this request.
@@ -210,7 +210,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       # @!attribute [rw] options
       #   @return [Google::Firestore::V1beta1::TransactionOptions]
       #     The options for the transaction.
@@ -227,7 +227,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       # @!attribute [rw] writes
       #   @return [Array<Google::Firestore::V1beta1::Write>]
       #     The writes to apply.
@@ -254,7 +254,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       # @!attribute [rw] transaction
       #   @return [String]
       #     The transaction to roll back.
@@ -264,11 +264,11 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent resource name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents` or
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       #     For example:
-      #     +projects/my-project/databases/my-database/documents+ or
-      #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+      #     `projects/my-project/databases/my-database/documents` or
+      #     `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
       # @!attribute [rw] structured_query
       #   @return [Google::Firestore::V1beta1::StructuredQuery]
       #     A structured query.
@@ -302,10 +302,10 @@ module Google
       #   @return [Google::Protobuf::Timestamp]
       #     The time at which the document was read. This may be monotonically
       #     increasing; in this case, the previous documents in the result stream are
-      #     guaranteed not to have changed between their +read_time+ and this one.
+      #     guaranteed not to have changed between their `read_time` and this one.
       #
-      #     If the query returns no results, a response with +read_time+ and no
-      #     +document+ will be sent, and this represents the time at which the query
+      #     If the query returns no results, a response with `read_time` and no
+      #     `document` will be sent, and this represents the time at which the query
       #     was run.
       # @!attribute [rw] skipped_results
       #   @return [Integer]
@@ -326,7 +326,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       #     This is only required in the first message.
       # @!attribute [rw] stream_id
       #   @return [String]
@@ -354,7 +354,7 @@ module Google
       #     responses.
       #
       #     Leave this field unset when creating a new stream. To resume a stream at
-      #     a specific point, set this field and the +stream_id+ field.
+      #     a specific point, set this field and the `stream_id` field.
       #
       #     Leave this field unset when creating a new stream.
       # @!attribute [rw] labels
@@ -388,7 +388,7 @@ module Google
       # @!attribute [rw] database
       #   @return [String]
       #     The database name. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}+.
+      #     `projects/{project_id}/databases/{database_id}`.
       # @!attribute [rw] add_target
       #   @return [Google::Firestore::V1beta1::Target]
       #     A target to add to this stream.
@@ -437,7 +437,7 @@ module Google
       #     Using a resume token with a different target is unsupported and may fail.
       # @!attribute [rw] read_time
       #   @return [Google::Protobuf::Timestamp]
-      #     Start listening after a specific +read_time+.
+      #     Start listening after a specific `read_time`.
       #
       #     The client must know the state of matching documents at this time.
       # @!attribute [rw] target_id
@@ -458,20 +458,20 @@ module Google
         # @!attribute [rw] documents
         #   @return [Array<String>]
         #     The names of the documents to retrieve. In the format:
-        #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+        #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
         #     The request will fail if any of the document is not a child resource of
-        #     the given +database+. Duplicate names will be elided.
+        #     the given `database`. Duplicate names will be elided.
         class DocumentsTarget; end
 
         # A target specified by a query.
         # @!attribute [rw] parent
         #   @return [String]
         #     The parent resource name. In the format:
-        #     +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-        #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+        #     `projects/{project_id}/databases/{database_id}/documents` or
+        #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
         #     For example:
-        #     +projects/my-project/databases/my-database/documents+ or
-        #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+        #     `projects/my-project/databases/my-database/documents` or
+        #     `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
         # @!attribute [rw] structured_query
         #   @return [Google::Firestore::V1beta1::StructuredQuery]
         #     A structured query.
@@ -488,7 +488,7 @@ module Google
       #
       #     If empty, the change applies to all targets.
       #
-      #     For +target_change_type=ADD+, the order of the target IDs matches the order
+      #     For `target_change_type=ADD`, the order of the target IDs matches the order
       #     of the requests to add the targets. This allows clients to unambiguously
       #     associate server-assigned target IDs with added targets.
       #
@@ -498,26 +498,26 @@ module Google
       #     The error that resulted in this change, if applicable.
       # @!attribute [rw] resume_token
       #   @return [String]
-      #     A token that can be used to resume the stream for the given +target_ids+,
-      #     or all targets if +target_ids+ is empty.
+      #     A token that can be used to resume the stream for the given `target_ids`,
+      #     or all targets if `target_ids` is empty.
       #
       #     Not set on every target change.
       # @!attribute [rw] read_time
       #   @return [Google::Protobuf::Timestamp]
-      #     The consistent +read_time+ for the given +target_ids+ (omitted when the
+      #     The consistent `read_time` for the given `target_ids` (omitted when the
       #     target_ids are not at a consistent snapshot).
       #
-      #     The stream is guaranteed to send a +read_time+ with +target_ids+ empty
+      #     The stream is guaranteed to send a `read_time` with `target_ids` empty
       #     whenever the entire stream reaches a new consistent snapshot. ADD,
       #     CURRENT, and RESET messages are guaranteed to (eventually) result in a
       #     new consistent snapshot (while NO_CHANGE and REMOVE messages are not).
       #
-      #     For a given stream, +read_time+ is guaranteed to be monotonically
+      #     For a given stream, `read_time` is guaranteed to be monotonically
       #     increasing.
       class TargetChange
         # The type of change.
         module TargetChangeType
-          # No change has occurred. Used only to send an updated +resume_token+.
+          # No change has occurred. Used only to send an updated `resume_token`.
           NO_CHANGE = 0
 
           # The targets have been added.
@@ -529,7 +529,7 @@ module Google
           # The targets reflect all changes committed before the targets were added
           # to the stream.
           #
-          # This will be sent after or with a +read_time+ that is greater than or
+          # This will be sent after or with a `read_time` that is greater than or
           # equal to the time at which the targets were added.
           #
           # Listeners can wait for this change if read-after-write semantics
@@ -539,8 +539,8 @@ module Google
           # The targets have been reset, and a new initial state for the targets
           # will be returned in subsequent changes.
           #
-          # After the initial state is complete, +CURRENT+ will be returned even
-          # if the target was previously indicated to be +CURRENT+.
+          # After the initial state is complete, `CURRENT` will be returned even
+          # if the target was previously indicated to be `CURRENT`.
           RESET = 4
         end
       end
@@ -549,9 +549,9 @@ module Google
       # @!attribute [rw] parent
       #   @return [String]
       #     The parent document. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       #     For example:
-      #     +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+      #     `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of results to return.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/query.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/query.rb
@@ -32,20 +32,20 @@ module Google
       #
       #     Firestore guarantees a stable ordering through the following rules:
       #
-      #     * Any field required to appear in +order_by+, that is not already
-      #       specified in +order_by+, is appended to the order in field name order
+      #     * Any field required to appear in `order_by`, that is not already
+      #       specified in `order_by`, is appended to the order in field name order
       #       by default.
-      #     * If an order on +__name__+ is not specified, it is appended by default.
+      #     * If an order on `__name__` is not specified, it is appended by default.
       #
       #     Fields are appended with the same sort direction as the last order
       #     specified, or 'ASCENDING' if no order was specified. For example:
       #
-      #     * +SELECT * FROM Foo ORDER BY A+ becomes
-      #       +SELECT * FROM Foo ORDER BY A, __name__+
-      #     * +SELECT * FROM Foo ORDER BY A DESC+ becomes
-      #       +SELECT * FROM Foo ORDER BY A DESC, __name__ DESC+
-      #     * +SELECT * FROM Foo WHERE A > 1+ becomes
-      #       +SELECT * FROM Foo WHERE A > 1 ORDER BY A, __name__+
+      #     * `SELECT * FROM Foo ORDER BY A` becomes
+      #       `SELECT * FROM Foo ORDER BY A, __name__`
+      #     * `SELECT * FROM Foo ORDER BY A DESC` becomes
+      #       `SELECT * FROM Foo ORDER BY A DESC, __name__ DESC`
+      #     * `SELECT * FROM Foo WHERE A > 1` becomes
+      #       `SELECT * FROM Foo WHERE A > 1 ORDER BY A, __name__`
       # @!attribute [rw] start_at
       #   @return [Google::Firestore::V1beta1::Cursor]
       #     A starting point for the query results.
@@ -65,7 +65,7 @@ module Google
       #     Applies after all other constraints.
       #     Must be >= 0 if specified.
       class StructuredQuery
-        # A selection of a collection, such as +messages as m1+.
+        # A selection of a collection, such as `messages as m1`.
         # @!attribute [rw] collection_id
         #   @return [String]
         #     The collection ID.
@@ -73,7 +73,7 @@ module Google
         # @!attribute [rw] all_descendants
         #   @return [true, false]
         #     When false, selects only collections that are immediate children of
-        #     the +parent+ specified in the containing +RunQueryRequest+.
+        #     the `parent` specified in the containing `RunQueryRequest`.
         #     When true, selects all descendant collections.
         class CollectionSelector; end
 
@@ -124,17 +124,17 @@ module Google
             # Unspecified. This value must not be used.
             OPERATOR_UNSPECIFIED = 0
 
-            # Less than. Requires that the field come first in +order_by+.
+            # Less than. Requires that the field come first in `order_by`.
             LESS_THAN = 1
 
-            # Less than or equal. Requires that the field come first in +order_by+.
+            # Less than or equal. Requires that the field come first in `order_by`.
             LESS_THAN_OR_EQUAL = 2
 
-            # Greater than. Requires that the field come first in +order_by+.
+            # Greater than. Requires that the field come first in `order_by`.
             GREATER_THAN = 3
 
             # Greater than or equal. Requires that the field come first in
-            # +order_by+.
+            # `order_by`.
             GREATER_THAN_OR_EQUAL = 4
 
             # Equal.
@@ -172,10 +172,10 @@ module Google
         #     The field to order by.
         # @!attribute [rw] direction
         #   @return [Google::Firestore::V1beta1::StructuredQuery::Direction]
-        #     The direction to order by. Defaults to +ASCENDING+.
+        #     The direction to order by. Defaults to `ASCENDING`.
         class Order; end
 
-        # A reference to a field, such as +max(messages.time) as max_time+.
+        # A reference to a field, such as `max(messages.time) as max_time`.
         # @!attribute [rw] field_path
         #   @return [String]
         class FieldReference; end
@@ -186,7 +186,7 @@ module Google
         #     The fields to return.
         #
         #     If empty, all fields are returned. To only return the name
-        #     of the document, use +['__name__']+.
+        #     of the document, use `['__name__']`.
         class Projection; end
 
         # A sort direction.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/write.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/firestore/v1beta1/write.rb
@@ -23,19 +23,19 @@ module Google
       # @!attribute [rw] delete
       #   @return [String]
       #     A document name to delete. In the format:
-      #     +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+      #     `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
       # @!attribute [rw] transform
       #   @return [Google::Firestore::V1beta1::DocumentTransform]
       #     Applies a tranformation to a document.
-      #     At most one +transform+ per document is allowed in a given request.
-      #     An +update+ cannot follow a +transform+ on the same document in a given
+      #     At most one `transform` per document is allowed in a given request.
+      #     An `update` cannot follow a `transform` on the same document in a given
       #     request.
       # @!attribute [rw] update_mask
       #   @return [Google::Firestore::V1beta1::DocumentMask]
       #     The fields to update in this write.
       #
-      #     This field can be set only when the operation is +update+.
-      #     If the mask is not set for an +update+ and the document exists, any
+      #     This field can be set only when the operation is `update`.
+      #     If the mask is not set for an `update` and the document exists, any
       #     existing data will be overwritten.
       #     If the mask is set and the document on the server has fields not covered by
       #     the mask, they are left unchanged.
@@ -110,7 +110,7 @@ module Google
       # @!attribute [rw] update_time
       #   @return [Google::Protobuf::Timestamp]
       #     The last update time of the document after applying the write. Not set
-      #     after a +delete+.
+      #     after a `delete`.
       #
       #     If the write did not actually change the document, this will be the
       #     previous update_time.
@@ -131,7 +131,7 @@ module Google
       #   @return [Google::Firestore::V1beta1::Document]
       #     The new state of the {Google::Firestore::V1beta1::Document Document}.
       #
-      #     If +mask+ is set, contains only fields that were updated or added.
+      #     If `mask` is set, contains only fields that were updated or added.
       # @!attribute [rw] target_ids
       #   @return [Array<Integer>]
       #     A set of target IDs of targets that match this document.
@@ -157,7 +157,7 @@ module Google
       #   @return [Google::Protobuf::Timestamp]
       #     The read timestamp at which the delete was observed.
       #
-      #     Greater or equal to the +commit_time+ of the delete.
+      #     Greater or equal to the `commit_time` of the delete.
       class DocumentDelete; end
 
       # A {Google::Firestore::V1beta1::Document Document} has been removed from the view of the targets.
@@ -178,7 +178,7 @@ module Google
       #   @return [Google::Protobuf::Timestamp]
       #     The read timestamp at which the remove was observed.
       #
-      #     Greater or equal to the +commit_time+ of the change/delete/remove.
+      #     Greater or equal to the `commit_time` of the change/delete/remove.
       class DocumentRemove; end
 
       # A digest of all the documents that match a given target.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/empty.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
+++ b/google-cloud-firestore/lib/google/cloud/firestore/v1beta1/firestore_client.rb
@@ -36,17 +36,17 @@ module Google
         #
         # This service exposes several types of comparable timestamps:
         #
-        # * +create_time+ - The time at which a document was created. Changes only
+        # * `create_time` - The time at which a document was created. Changes only
         #   when a document is deleted, then re-created. Increases in a strict
         #   monotonic fashion.
-        # * +update_time+ - The time at which a document was last updated. Changes
+        # * `update_time` - The time at which a document was last updated. Changes
         #   every time a document is modified. Does not change when a write results
         #   in no modifications. Increases in a strict monotonic fashion.
-        # * +read_time+ - The time at which a particular state was observed. Used
+        # * `read_time` - The time at which a particular state was observed. Used
         #   to denote a consistent snapshot of the database or the time at which a
         #   Document was observed to not exist.
-        # * +commit_time+ - The time at which the writes in a transaction were
-        #   committed. Any read with an equal or greater +read_time+ is guaranteed
+        # * `commit_time` - The time at which the writes in a transaction were
+        #   committed. Any read with an equal or greater `read_time` is guaranteed
         #   to see the effects of the transaction.
         #
         # @!attribute [r] firestore_stub
@@ -337,7 +337,7 @@ module Google
           #
           # @param name [String]
           #   The resource name of the Document to get. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
           #   The fields to return. If not set, returns all fields.
           #
@@ -388,14 +388,14 @@ module Google
           #
           # @param parent [String]
           #   The parent resource name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents` or
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           #   For example:
-          #   +projects/my-project/databases/my-database/documents+ or
-          #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+          #   `projects/my-project/databases/my-database/documents` or
+          #   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
           # @param collection_id [String]
-          #   The collection ID, relative to +parent+, to list. For example: +chatrooms+
-          #   or +messages+.
+          #   The collection ID, relative to `parent`, to list. For example: `chatrooms`
+          #   or `messages`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -403,7 +403,7 @@ module Google
           #   performed per-page, this determines the maximum number of
           #   resources in a page.
           # @param order_by [String]
-          #   The order to sort results by. For example: +priority desc, name+.
+          #   The order to sort results by. For example: `priority desc, name`.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
           #   The fields to return. If not set, returns all fields.
           #
@@ -424,8 +424,8 @@ module Google
           #   be returned with a key but will not have fields, {Google::Firestore::V1beta1::Document#create_time Document#create_time},
           #   or {Google::Firestore::V1beta1::Document#update_time Document#update_time} set.
           #
-          #   Requests with +show_missing+ may not specify +where+ or
-          #   +order_by+.
+          #   Requests with `show_missing` may not specify `where` or
+          #   `order_by`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -444,7 +444,7 @@ module Google
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #   formatted_parent = Google::Cloud::Firestore::V1beta1::FirestoreClient.any_path_path("[PROJECT]", "[DATABASE]", "[DOCUMENT]", "[ANY_PATH]")
           #
-          #   # TODO: Initialize +collection_id+:
+          #   # TODO: Initialize `collection_id`:
           #   collection_id = ''
           #
           #   # Iterate over all results.
@@ -489,16 +489,16 @@ module Google
           #
           # @param parent [String]
           #   The parent resource. For example:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/chatrooms/\\{chatroom_id}+
+          #   `projects/{project_id}/databases/{database_id}/documents` or
+          #   `projects/{project_id}/databases/{database_id}/documents/chatrooms/{chatroom_id}`
           # @param collection_id [String]
-          #   The collection ID, relative to +parent+, to list. For example: +chatrooms+.
+          #   The collection ID, relative to `parent`, to list. For example: `chatrooms`.
           # @param document_id [String]
           #   The client-assigned document ID to use for this document.
           #
           #   Optional. If not specified, an ID will be assigned by the service.
           # @param document [Google::Firestore::V1beta1::Document | Hash]
-          #   The document to create. +name+ must not be set.
+          #   The document to create. `name` must not be set.
           #   A hash of the same form as `Google::Firestore::V1beta1::Document`
           #   can also be provided.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
@@ -522,13 +522,13 @@ module Google
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #   formatted_parent = Google::Cloud::Firestore::V1beta1::FirestoreClient.any_path_path("[PROJECT]", "[DATABASE]", "[DOCUMENT]", "[ANY_PATH]")
           #
-          #   # TODO: Initialize +collection_id+:
+          #   # TODO: Initialize `collection_id`:
           #   collection_id = ''
           #
-          #   # TODO: Initialize +document_id+:
+          #   # TODO: Initialize `document_id`:
           #   document_id = ''
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = firestore_client.create_document(formatted_parent, collection_id, document_id, document)
 
@@ -593,10 +593,10 @@ module Google
           #
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = firestore_client.update_document(document, update_mask)
 
@@ -621,7 +621,7 @@ module Google
           #
           # @param name [String]
           #   The resource name of the Document to delete. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           # @param current_document [Google::Firestore::V1beta1::Precondition | Hash]
           #   An optional precondition on the document.
           #   The request will fail if this is set and not met by the target document.
@@ -662,12 +662,12 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}+.
+          #   `projects/{project_id}/databases/{database_id}`.
           # @param documents [Array<String>]
           #   The names of the documents to retrieve. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           #   The request will fail if any of the document is not a child resource of the
-          #   given +database+. Duplicate names will be elided.
+          #   given `database`. Duplicate names will be elided.
           # @param mask [Google::Firestore::V1beta1::DocumentMask | Hash]
           #   The fields to return. If not set, returns all fields.
           #
@@ -702,7 +702,7 @@ module Google
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #   formatted_database = Google::Cloud::Firestore::V1beta1::FirestoreClient.database_root_path("[PROJECT]", "[DATABASE]")
           #
-          #   # TODO: Initialize +documents+:
+          #   # TODO: Initialize `documents`:
           #   documents = []
           #   firestore_client.batch_get_documents(formatted_database, documents).each do |element|
           #     # Process element.
@@ -732,7 +732,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}+.
+          #   `projects/{project_id}/databases/{database_id}`.
           # @param options_ [Google::Firestore::V1beta1::TransactionOptions | Hash]
           #   The options for the transaction.
           #   Defaults to a read-write transaction.
@@ -770,7 +770,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}+.
+          #   `projects/{project_id}/databases/{database_id}`.
           # @param writes [Array<Google::Firestore::V1beta1::Write | Hash>]
           #   The writes to apply.
           #
@@ -793,7 +793,7 @@ module Google
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #   formatted_database = Google::Cloud::Firestore::V1beta1::FirestoreClient.database_root_path("[PROJECT]", "[DATABASE]")
           #
-          #   # TODO: Initialize +writes+:
+          #   # TODO: Initialize `writes`:
           #   writes = []
           #   response = firestore_client.commit(formatted_database, writes)
 
@@ -816,7 +816,7 @@ module Google
           #
           # @param database [String]
           #   The database name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}+.
+          #   `projects/{project_id}/databases/{database_id}`.
           # @param transaction [String]
           #   The transaction to roll back.
           # @param options [Google::Gax::CallOptions]
@@ -832,7 +832,7 @@ module Google
           #   firestore_client = Google::Cloud::Firestore::V1beta1.new
           #   formatted_database = Google::Cloud::Firestore::V1beta1::FirestoreClient.database_root_path("[PROJECT]", "[DATABASE]")
           #
-          #   # TODO: Initialize +transaction+:
+          #   # TODO: Initialize `transaction`:
           #   transaction = ''
           #   firestore_client.rollback(formatted_database, transaction)
 
@@ -854,11 +854,11 @@ module Google
           #
           # @param parent [String]
           #   The parent resource name. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents+ or
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents` or
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           #   For example:
-          #   +projects/my-project/databases/my-database/documents+ or
-          #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+          #   `projects/my-project/databases/my-database/documents` or
+          #   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
           # @param structured_query [Google::Firestore::V1beta1::StructuredQuery | Hash]
           #   A structured query.
           #   A hash of the same form as `Google::Firestore::V1beta1::StructuredQuery`
@@ -985,9 +985,9 @@ module Google
           #
           # @param parent [String]
           #   The parent document. In the format:
-          #   +projects/\\{project_id}/databases/\\{database_id}/documents/\\{document_path}+.
+          #   `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
           #   For example:
-          #   +projects/my-project/databases/my-database/documents/chatrooms/my-chatroom+
+          #   `projects/my-project/databases/my-database/documents/chatrooms/my-chatroom`
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this

--- a/google-cloud-firestore/synth.py
+++ b/google-cloud-firestore/synth.py
@@ -53,15 +53,15 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(
     'lib/google/cloud/firestore/v1beta1/**/*.rb',
-    '\n(\\s+)#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
+    '\n\\s+#[^\n]*[^\n#\\$\\\\]\\{[\\w,]+\\}',
     escape_braces)
 
 # https://github.com/googleapis/gapic-generator/issues/2243

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/resources.rb
@@ -21,7 +21,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Output only. The resource name for the {Google::Cloud::Kms::V1::KeyRing KeyRing} in the format
-        #     +projects/*/locations/*/keyRings/*+.
+        #     `projects/*/locations/*/keyRings/*`.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time at which this {Google::Cloud::Kms::V1::KeyRing KeyRing} was created.
@@ -35,7 +35,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Output only. The resource name for this {Google::Cloud::Kms::V1::CryptoKey CryptoKey} in the format
-        #     +projects/*/locations/*/keyRings/*/cryptoKeys/*+.
+        #     `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         # @!attribute [rw] primary
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion]
         #     Output only. A copy of the "primary" {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} that will be used
@@ -164,7 +164,7 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Output only. The resource name for this {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} in the format
-        #     +projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*+.
+        #     `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`.
         # @!attribute [rw] state
         #   @return [Google::Cloud::Kms::V1::CryptoKeyVersion::CryptoKeyVersionState]
         #     The current state of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}.

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/cloud/kms/v1/service.rb
@@ -21,7 +21,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the location associated with the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format +projects/*/locations/*+.
+        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional limit on the number of {Google::Cloud::Kms::V1::KeyRing KeyRings} to include in the
@@ -38,7 +38,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
-        #     +projects/*/locations/*/keyRings/*+.
+        #     `projects/*/locations/*/keyRings/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional limit on the number of {Google::Cloud::Kms::V1::CryptoKey CryptoKeys} to include in the
@@ -58,7 +58,7 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
-        #     +projects/*/locations/*/keyRings/*/cryptoKeys/*+.
+        #     `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Optional limit on the number of {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersions} to
@@ -145,11 +145,11 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the location associated with the
-        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format +projects/*/locations/*+.
+        #     {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
         # @!attribute [rw] key_ring_id
         #   @return [String]
         #     Required. It must be unique within a location and match the regular
-        #     expression +[a-zA-Z0-9_-]\\{1,63}+
+        #     expression `[a-zA-Z0-9_-]{1,63}`
         # @!attribute [rw] key_ring
         #   @return [Google::Cloud::Kms::V1::KeyRing]
         #     A {Google::Cloud::Kms::V1::KeyRing KeyRing} with initial field values.
@@ -163,7 +163,7 @@ module Google
         # @!attribute [rw] crypto_key_id
         #   @return [String]
         #     Required. It must be unique within a KeyRing and match the regular
-        #     expression +[a-zA-Z0-9_-]\\{1,63}+
+        #     expression `[a-zA-Z0-9_-]{1,63}`
         # @!attribute [rw] crypto_key
         #   @return [Google::Cloud::Kms::V1::CryptoKey]
         #     A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client.rb
@@ -431,6 +431,30 @@ module Google
                 {'name' => request.name}
               end
             )
+            @get_public_key = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:get_public_key),
+              defaults["get_public_key"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
+            @asymmetric_decrypt = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:asymmetric_decrypt),
+              defaults["asymmetric_decrypt"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
+            @asymmetric_sign = Google::Gax.create_api_call(
+              @key_management_service_stub.method(:asymmetric_sign),
+              defaults["asymmetric_sign"],
+              exception_transformer: exception_transformer,
+              params_extractor: proc do |request|
+                {'name' => request.name}
+              end
+            )
             @set_iam_policy = Google::Gax.create_api_call(
               @iam_policy_stub.method(:set_iam_policy),
               defaults["set_iam_policy"],
@@ -463,7 +487,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the location associated with the
-          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format +projects/*/locations/*+.
+          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -518,7 +542,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the {Google::Cloud::Kms::V1::KeyRing KeyRing} to list, in the format
-          #   +projects/*/locations/*/keyRings/*+.
+          #   `projects/*/locations/*/keyRings/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -577,7 +601,7 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKey CryptoKey} to list, in the format
-          #   +projects/*/locations/*/keyRings/*/cryptoKeys/*+.
+          #   `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -727,10 +751,10 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the location associated with the
-          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format +projects/*/locations/*+.
+          #   {Google::Cloud::Kms::V1::KeyRing KeyRings}, in the format `projects/*/locations/*`.
           # @param key_ring_id [String]
           #   Required. It must be unique within a location and match the regular
-          #   expression +[a-zA-Z0-9_-]\\{1,63}+
+          #   expression `[a-zA-Z0-9_-]{1,63}`
           # @param key_ring [Google::Cloud::Kms::V1::KeyRing | Hash]
           #   A {Google::Cloud::Kms::V1::KeyRing KeyRing} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::KeyRing`
@@ -749,10 +773,10 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.location_path("[PROJECT]", "[LOCATION]")
           #
-          #   # TODO: Initialize +key_ring_id+:
+          #   # TODO: Initialize `key_ring_id`:
           #   key_ring_id = ''
           #
-          #   # TODO: Initialize +key_ring+:
+          #   # TODO: Initialize `key_ring`:
           #   key_ring = {}
           #   response = key_management_service_client.create_key_ring(formatted_parent, key_ring_id, key_ring)
 
@@ -782,7 +806,7 @@ module Google
           #   {Google::Cloud::Kms::V1::CryptoKey CryptoKeys}.
           # @param crypto_key_id [String]
           #   Required. It must be unique within a KeyRing and match the regular
-          #   expression +[a-zA-Z0-9_-]\\{1,63}+
+          #   expression `[a-zA-Z0-9_-]{1,63}`
           # @param crypto_key [Google::Cloud::Kms::V1::CryptoKey | Hash]
           #   A {Google::Cloud::Kms::V1::CryptoKey CryptoKey} with initial field values.
           #   A hash of the same form as `Google::Cloud::Kms::V1::CryptoKey`
@@ -855,7 +879,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_parent = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
           #
-          #   # TODO: Initialize +crypto_key_version+:
+          #   # TODO: Initialize `crypto_key_version`:
           #   crypto_key_version = {}
           #   response = key_management_service_client.create_crypto_key_version(formatted_parent, crypto_key_version)
 
@@ -895,10 +919,10 @@ module Google
           #
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #
-          #   # TODO: Initialize +crypto_key+:
+          #   # TODO: Initialize `crypto_key`:
           #   crypto_key = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = key_management_service_client.update_crypto_key(crypto_key, update_mask)
 
@@ -944,10 +968,10 @@ module Google
           #
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #
-          #   # TODO: Initialize +crypto_key_version+:
+          #   # TODO: Initialize `crypto_key_version`:
           #   crypto_key_version = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = key_management_service_client.update_crypto_key_version(crypto_key_version, update_mask)
 
@@ -1007,7 +1031,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY_PATH]")
           #
-          #   # TODO: Initialize +plaintext+:
+          #   # TODO: Initialize `plaintext`:
           #   plaintext = ''
           #   response = key_management_service_client.encrypt(formatted_name, plaintext)
 
@@ -1052,7 +1076,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
           #
-          #   # TODO: Initialize +ciphertext+:
+          #   # TODO: Initialize `ciphertext`:
           #   ciphertext = ''
           #   response = key_management_service_client.decrypt(formatted_name, ciphertext)
 
@@ -1093,7 +1117,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]")
           #
-          #   # TODO: Initialize +crypto_key_version_id+:
+          #   # TODO: Initialize `crypto_key_version_id`:
           #   crypto_key_version_id = ''
           #   response = key_management_service_client.update_crypto_key_primary_version(formatted_name, crypto_key_version_id)
 
@@ -1187,15 +1211,133 @@ module Google
             @restore_crypto_key_version.call(req, options, &block)
           end
 
+          # Returns the public key for the given {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}. The
+          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} must be
+          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_SIGN ASYMMETRIC_SIGN} or
+          # {Google::Cloud::Kms::V1::CryptoKey::CryptoKeyPurpose::ASYMMETRIC_DECRYPT ASYMMETRIC_DECRYPT}.
+          #
+          # @param name [String]
+          #   The {Google::Cloud::Kms::V1::CryptoKeyVersion#name name} of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} public key to
+          #   get.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::PublicKey]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::PublicKey]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+          #   response = key_management_service_client.get_public_key(formatted_name)
+
+          def get_public_key \
+              name,
+              options: nil,
+              &block
+            req = {
+              name: name
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::GetPublicKeyRequest)
+            @get_public_key.call(req, options, &block)
+          end
+
+          # Decrypts data that was encrypted with a public key retrieved from
+          # {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey} corresponding to a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with
+          # {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose} ASYMMETRIC_DECRYPT.
+          #
+          # @param name [String]
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for
+          #   decryption.
+          # @param ciphertext [String]
+          #   Required. The data encrypted with the named {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion}'s public
+          #   key using OAEP.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::AsymmetricDecryptResponse]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::AsymmetricDecryptResponse]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+          #
+          #   # TODO: Initialize `ciphertext`:
+          #   ciphertext = ''
+          #   response = key_management_service_client.asymmetric_decrypt(formatted_name, ciphertext)
+
+          def asymmetric_decrypt \
+              name,
+              ciphertext,
+              options: nil,
+              &block
+            req = {
+              name: name,
+              ciphertext: ciphertext
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::AsymmetricDecryptRequest)
+            @asymmetric_decrypt.call(req, options, &block)
+          end
+
+          # Signs data using a {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} with {Google::Cloud::Kms::V1::CryptoKey#purpose CryptoKey#purpose}
+          # ASYMMETRIC_SIGN, producing a signature that can be verified with the public
+          # key retrieved from {Google::Cloud::Kms::V1::KeyManagementService::GetPublicKey GetPublicKey}.
+          #
+          # @param name [String]
+          #   Required. The resource name of the {Google::Cloud::Kms::V1::CryptoKeyVersion CryptoKeyVersion} to use for signing.
+          # @param digest [Google::Cloud::Kms::V1::Digest | Hash]
+          #   Required. The digest of the data to sign. The digest must be produced with
+          #   the same digest algorithm as specified by the key version's
+          #   {Google::Cloud::Kms::V1::CryptoKeyVersion#algorithm algorithm}.
+          #   A hash of the same form as `Google::Cloud::Kms::V1::Digest`
+          #   can also be provided.
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @yield [result, operation] Access the result along with the RPC operation
+          # @yieldparam result [Google::Cloud::Kms::V1::AsymmetricSignResponse]
+          # @yieldparam operation [GRPC::ActiveCall::Operation]
+          # @return [Google::Cloud::Kms::V1::AsymmetricSignResponse]
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          # @example
+          #   require "google/cloud/kms"
+          #
+          #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
+          #   formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+          #
+          #   # TODO: Initialize `digest`:
+          #   digest = {}
+          #   response = key_management_service_client.asymmetric_sign(formatted_name, digest)
+
+          def asymmetric_sign \
+              name,
+              digest,
+              options: nil,
+              &block
+            req = {
+              name: name,
+              digest: digest
+            }.delete_if { |_, v| v.nil? }
+            req = Google::Gax::to_proto(req, Google::Cloud::Kms::V1::AsymmetricSignRequest)
+            @asymmetric_sign.call(req, options, &block)
+          end
+
           # Sets the access control policy on the specified resource. Replaces any
           # existing policy.
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param policy [Google::Iam::V1::Policy | Hash]
-          #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+          #   REQUIRED: The complete policy to be applied to the `resource`. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
           #   valid policy but certain Cloud Platform services (such as Projects)
           #   might reject them.
@@ -1215,7 +1357,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_resource = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
           #
-          #   # TODO: Initialize +policy+:
+          #   # TODO: Initialize `policy`:
           #   policy = {}
           #   response = key_management_service_client.set_iam_policy(formatted_resource, policy)
 
@@ -1238,8 +1380,8 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1272,10 +1414,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param permissions [Array<String>]
-          #   The set of permissions to check for the +resource+. Permissions with
+          #   The set of permissions to check for the `resource`. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more
           #   information see
           #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -1293,7 +1435,7 @@ module Google
           #   key_management_service_client = Google::Cloud::Kms.new(version: :v1)
           #   formatted_resource = Google::Cloud::Kms::V1::KeyManagementServiceClient.key_ring_path("[PROJECT]", "[LOCATION]", "[KEY_RING]")
           #
-          #   # TODO: Initialize +permissions+:
+          #   # TODO: Initialize `permissions`:
           #   permissions = []
           #   response = key_management_service_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json
+++ b/google-cloud-kms/lib/google/cloud/kms/v1/key_management_service_client_config.json
@@ -100,6 +100,21 @@
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
+        "GetPublicKey": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "AsymmetricDecrypt": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
+        "AsymmetricSign": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "SetIamPolicy": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/google-cloud-kms/synth.py
+++ b/google-cloud-kms/synth.py
@@ -48,10 +48,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
+++ b/google-cloud-kms/test/google/cloud/kms/v1/key_management_service_client_test.rb
@@ -1344,6 +1344,236 @@ describe Google::Cloud::Kms::V1::KeyManagementServiceClient do
     end
   end
 
+  describe 'get_public_key' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#get_public_key."
+
+    it 'invokes get_public_key without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+
+      # Create expected grpc response
+      pem = "pem110872"
+      expected_response = { pem: pem }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::PublicKey)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::GetPublicKeyRequest, request)
+        assert_equal(formatted_name, request.name)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_public_key, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("get_public_key")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.get_public_key(formatted_name)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.get_public_key(formatted_name) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes get_public_key with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::GetPublicKeyRequest, request)
+        assert_equal(formatted_name, request.name)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:get_public_key, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("get_public_key")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_public_key(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'asymmetric_decrypt' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#asymmetric_decrypt."
+
+    it 'invokes asymmetric_decrypt without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+      ciphertext = ''
+
+      # Create expected grpc response
+      plaintext = "-9"
+      expected_response = { plaintext: plaintext }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::AsymmetricDecryptResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::AsymmetricDecryptRequest, request)
+        assert_equal(formatted_name, request.name)
+        assert_equal(ciphertext, request.ciphertext)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:asymmetric_decrypt, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("asymmetric_decrypt")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.asymmetric_decrypt(formatted_name, ciphertext)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.asymmetric_decrypt(formatted_name, ciphertext) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes asymmetric_decrypt with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+      ciphertext = ''
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::AsymmetricDecryptRequest, request)
+        assert_equal(formatted_name, request.name)
+        assert_equal(ciphertext, request.ciphertext)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:asymmetric_decrypt, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("asymmetric_decrypt")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.asymmetric_decrypt(formatted_name, ciphertext)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
+  describe 'asymmetric_sign' do
+    custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#asymmetric_sign."
+
+    it 'invokes asymmetric_sign without error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+      digest = {}
+
+      # Create expected grpc response
+      signature = "-72"
+      expected_response = { signature: signature }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Cloud::Kms::V1::AsymmetricSignResponse)
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::AsymmetricSignRequest, request)
+        assert_equal(formatted_name, request.name)
+        assert_equal(Google::Gax::to_proto(digest, Google::Cloud::Kms::V1::Digest), request.digest)
+        OpenStruct.new(execute: expected_response)
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:asymmetric_sign, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("asymmetric_sign")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          response = client.asymmetric_sign(formatted_name, digest)
+
+          # Verify the response
+          assert_equal(expected_response, response)
+
+          # Call method with block
+          client.asymmetric_sign(formatted_name, digest) do |response, operation|
+            # Verify the response
+            assert_equal(expected_response, response)
+            refute_nil(operation)
+          end
+        end
+      end
+    end
+
+    it 'invokes asymmetric_sign with error' do
+      # Create request parameters
+      formatted_name = Google::Cloud::Kms::V1::KeyManagementServiceClient.crypto_key_version_path("[PROJECT]", "[LOCATION]", "[KEY_RING]", "[CRYPTO_KEY]", "[CRYPTO_KEY_VERSION]")
+      digest = {}
+
+      # Mock Grpc layer
+      mock_method = proc do |request|
+        assert_instance_of(Google::Cloud::Kms::V1::AsymmetricSignRequest, request)
+        assert_equal(formatted_name, request.name)
+        assert_equal(Google::Gax::to_proto(digest, Google::Cloud::Kms::V1::Digest), request.digest)
+        raise custom_error
+      end
+      mock_stub = MockGrpcClientStub_v1.new(:asymmetric_sign, mock_method)
+
+      # Mock auth layer
+      mock_credentials = MockKeyManagementServiceCredentials_v1.new("asymmetric_sign")
+
+      Google::Cloud::Kms::V1::KeyManagementService::Stub.stub(:new, mock_stub) do
+        Google::Cloud::Kms::V1::Credentials.stub(:default, mock_credentials) do
+          client = Google::Cloud::Kms.new(version: :v1)
+
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.asymmetric_sign(formatted_name, digest)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
+        end
+      end
+    end
+  end
+
   describe 'set_iam_policy' do
     custom_error = CustomTestError_v1.new "Custom test error for Google::Cloud::Kms::V1::KeyManagementServiceClient#set_iam_policy."
 

--- a/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/doc/google/cloud/language/v1/language_service.rb
@@ -22,8 +22,8 @@ module Google
         # Represents the input to API methods.
         # @!attribute [rw] type
         #   @return [Google::Cloud::Language::V1::Document::Type]
-        #     Required. If the type is not set or is +TYPE_UNSPECIFIED+,
-        #     returns an +INVALID_ARGUMENT+ error.
+        #     Required. If the type is not set or is `TYPE_UNSPECIFIED`,
+        #     returns an `INVALID_ARGUMENT` error.
         # @!attribute [rw] content
         #   @return [String]
         #     The content of the input in string format.
@@ -41,7 +41,7 @@ module Google
         #     [Language Support](https://cloud.google.com/natural-language/docs/languages)
         #     lists currently supported languages for each API method.
         #     If the language (either specified by the caller or automatically detected)
-        #     is not supported by the called API method, an +INVALID_ARGUMENT+ error
+        #     is not supported by the called API method, an `INVALID_ARGUMENT` error
         #     is returned.
         class Document
           # The document types enum.
@@ -497,7 +497,7 @@ module Google
         #     This is the index of the token which has an arc going to this token.
         #     The index is the position of the token in the array of tokens returned
         #     by the API method. If this token is a root token, then the
-        #     +head_token_index+ is its own index.
+        #     `head_token_index` is its own index.
         # @!attribute [rw] label
         #   @return [Google::Cloud::Language::V1::DependencyEdge::Label]
         #     The parse label for the token.
@@ -963,26 +963,26 @@ module Google
         class AnnotateTextResponse; end
 
         # Represents the text encoding that the caller uses to process the output.
-        # Providing an +EncodingType+ is recommended because the API provides the
+        # Providing an `EncodingType` is recommended because the API provides the
         # beginning offsets for various outputs, such as tokens and mentions, and
         # languages that natively use different text encodings may access offsets
         # differently.
         module EncodingType
-          # If +EncodingType+ is not specified, encoding-dependent information (such as
-          # +begin_offset+) will be set at +-1+.
+          # If `EncodingType` is not specified, encoding-dependent information (such as
+          # `begin_offset`) will be set at `-1`.
           NONE = 0
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-8 encoding of the input. C++ and Go are examples of languages
           # that use this encoding natively.
           UTF8 = 1
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-16 encoding of the input. Java and Javascript are examples of
           # languages that use this encoding natively.
           UTF16 = 2
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-32 encoding of the input. Python is an example of a language
           # that uses this encoding natively.
           UTF32 = 3

--- a/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1/language_service_client.rb
@@ -216,7 +216,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_sentiment(document)
 
@@ -256,7 +256,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_entities(document)
 
@@ -295,7 +295,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_entity_sentiment(document)
 
@@ -335,7 +335,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_syntax(document)
 
@@ -371,7 +371,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.classify_text(document)
 
@@ -412,10 +412,10 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #
-          #   # TODO: Initialize +features+:
+          #   # TODO: Initialize `features`:
           #   features = {}
           #   response = language_service_client.annotate_text(document, features)
 

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/doc/google/cloud/language/v1beta2/language_service.rb
@@ -22,8 +22,8 @@ module Google
         # Represents the input to API methods.
         # @!attribute [rw] type
         #   @return [Google::Cloud::Language::V1beta2::Document::Type]
-        #     Required. If the type is not set or is +TYPE_UNSPECIFIED+,
-        #     returns an +INVALID_ARGUMENT+ error.
+        #     Required. If the type is not set or is `TYPE_UNSPECIFIED`,
+        #     returns an `INVALID_ARGUMENT` error.
         # @!attribute [rw] content
         #   @return [String]
         #     The content of the input in string format.
@@ -41,7 +41,7 @@ module Google
         #     [Language Support](https://cloud.google.com/natural-language/docs/languages)
         #     lists currently supported languages for each API method.
         #     If the language (either specified by the caller or automatically detected)
-        #     is not supported by the called API method, an +INVALID_ARGUMENT+ error
+        #     is not supported by the called API method, an `INVALID_ARGUMENT` error
         #     is returned.
         class Document
           # The document types enum.
@@ -493,7 +493,7 @@ module Google
         #     This is the index of the token which has an arc going to this token.
         #     The index is the position of the token in the array of tokens returned
         #     by the API method. If this token is a root token, then the
-        #     +head_token_index+ is its own index.
+        #     `head_token_index` is its own index.
         # @!attribute [rw] label
         #   @return [Google::Cloud::Language::V1beta2::DependencyEdge::Label]
         #     The parse label for the token.
@@ -960,26 +960,26 @@ module Google
         class AnnotateTextResponse; end
 
         # Represents the text encoding that the caller uses to process the output.
-        # Providing an +EncodingType+ is recommended because the API provides the
+        # Providing an `EncodingType` is recommended because the API provides the
         # beginning offsets for various outputs, such as tokens and mentions, and
         # languages that natively use different text encodings may access offsets
         # differently.
         module EncodingType
-          # If +EncodingType+ is not specified, encoding-dependent information (such as
-          # +begin_offset+) will be set at +-1+.
+          # If `EncodingType` is not specified, encoding-dependent information (such as
+          # `begin_offset`) will be set at `-1`.
           NONE = 0
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-8 encoding of the input. C++ and Go are examples of languages
           # that use this encoding natively.
           UTF8 = 1
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-16 encoding of the input. Java and Javascript are examples of
           # languages that use this encoding natively.
           UTF16 = 2
 
-          # Encoding-dependent information (such as +begin_offset+) is calculated based
+          # Encoding-dependent information (such as `begin_offset`) is calculated based
           # on the UTF-32 encoding of the input. Python is an example of a language
           # that uses this encoding natively.
           UTF32 = 3

--- a/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
+++ b/google-cloud-language/lib/google/cloud/language/v1beta2/language_service_client.rb
@@ -217,7 +217,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_sentiment(document)
 
@@ -257,7 +257,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_entities(document)
 
@@ -296,7 +296,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_entity_sentiment(document)
 
@@ -336,7 +336,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.analyze_syntax(document)
 
@@ -372,7 +372,7 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #   response = language_service_client.classify_text(document)
 
@@ -413,10 +413,10 @@ module Google
           #
           #   language_service_client = Google::Cloud::Language.new(version: :v1beta2)
           #
-          #   # TODO: Initialize +document+:
+          #   # TODO: Initialize `document`:
           #   document = {}
           #
-          #   # TODO: Initialize +features+:
+          #   # TODO: Initialize `features`:
           #   features = {}
           #   response = language_service_client.annotate_text(document, features)
 

--- a/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/config_service_v2_client.rb
@@ -351,7 +351,7 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
           #       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
           #
-          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          #   Example: `"projects/my-project-id/sinks/my-sink-id"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -380,7 +380,7 @@ module Google
 
           # Creates a sink that exports specified log entries to a destination.  The
           # export of newly-ingested log entries begins immediately, unless the sink's
-          # +writer_identity+ is not permitted to write to the destination.  A sink can
+          # `writer_identity` is not permitted to write to the destination.  A sink can
           # export log entries only from the resource owning the sink.
           #
           # @param parent [String]
@@ -391,24 +391,24 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]"
           #       "folders/[FOLDER_ID]"
           #
-          #   Examples: +"projects/my-logging-project"+, +"organizations/123456789"+.
+          #   Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
           # @param sink [Google::Logging::V2::LogSink | Hash]
-          #   Required. The new sink, whose +name+ parameter is a sink identifier that
+          #   Required. The new sink, whose `name` parameter is a sink identifier that
           #   is not already in use.
           #   A hash of the same form as `Google::Logging::V2::LogSink`
           #   can also be provided.
           # @param unique_writer_identity [true, false]
-          #   Optional. Determines the kind of IAM identity returned as +writer_identity+
+          #   Optional. Determines the kind of IAM identity returned as `writer_identity`
           #   in the new sink.  If this value is omitted or set to false, and if the
-          #   sink's parent is a project, then the value returned as +writer_identity+ is
+          #   sink's parent is a project, then the value returned as `writer_identity` is
           #   the same group or service account used by Stackdriver Logging before the
           #   addition of writer identities to this API. The sink's destination must be
           #   in the same project as the sink itself.
           #
           #   If this field is set to true, or if the sink is owned by a non-project
-          #   resource such as an organization, then the value of +writer_identity+ will
+          #   resource such as an organization, then the value of `writer_identity` will
           #   be a unique service account used only for exports from the new sink.  For
-          #   more information, see +writer_identity+ in {Google::Logging::V2::LogSink LogSink}.
+          #   more information, see `writer_identity` in {Google::Logging::V2::LogSink LogSink}.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -423,7 +423,7 @@ module Google
           #   config_service_v2_client = Google::Cloud::Logging::V2::ConfigServiceV2Client.new
           #   formatted_parent = Google::Cloud::Logging::V2::ConfigServiceV2Client.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +sink+:
+          #   # TODO: Initialize `sink`:
           #   sink = {}
           #   response = config_service_v2_client.create_sink(formatted_parent, sink)
 
@@ -443,9 +443,9 @@ module Google
           end
 
           # Updates a sink.  This method replaces the following fields in the existing
-          # sink with values from the new sink: +destination+, and +filter+.
-          # The updated sink might also have a new +writer_identity+; see the
-          # +unique_writer_identity+ field.
+          # sink with values from the new sink: `destination`, and `filter`.
+          # The updated sink might also have a new `writer_identity`; see the
+          # `unique_writer_identity` field.
           #
           # @param sink_name [String]
           #   Required. The full resource name of the sink to update, including the
@@ -456,29 +456,29 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
           #       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
           #
-          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          #   Example: `"projects/my-project-id/sinks/my-sink-id"`.
           # @param sink [Google::Logging::V2::LogSink | Hash]
           #   Required. The updated sink, whose name is the same identifier that appears
-          #   as part of +sink_name+.
+          #   as part of `sink_name`.
           #   A hash of the same form as `Google::Logging::V2::LogSink`
           #   can also be provided.
           # @param unique_writer_identity [true, false]
           #   Optional. See
           #   [sinks.create](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/create)
           #   for a description of this field.  When updating a sink, the effect of this
-          #   field on the value of +writer_identity+ in the updated sink depends on both
+          #   field on the value of `writer_identity` in the updated sink depends on both
           #   the old and new values of this field:
           #
           #   * If the old and new values of this field are both false or both true,
-          #     then there is no change to the sink's +writer_identity+.
+          #     then there is no change to the sink's `writer_identity`.
           #   * If the old value is false and the new value is true, then
-          #     +writer_identity+ is changed to a unique service account.
+          #     `writer_identity` is changed to a unique service account.
           #   * It is an error if the old value is true and the new value is
           #     set to false or defaulted to false.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
-          #   Optional. Field mask that specifies the fields in +sink+ that need
+          #   Optional. Field mask that specifies the fields in `sink` that need
           #   an update. A sink field will be overwritten if, and only if, it is
-          #   in the update mask.  +name+ and output only fields cannot be updated.
+          #   in the update mask.  `name` and output only fields cannot be updated.
           #
           #   An empty updateMask is temporarily treated as using the following mask
           #   for backwards compatibility purposes:
@@ -486,10 +486,10 @@ module Google
           #   At some point in the future, behavior will be removed and specifying an
           #   empty updateMask will be an error.
           #
-          #   For a detailed +FieldMask+ definition, see
+          #   For a detailed `FieldMask` definition, see
           #   https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
           #
-          #   Example: +updateMask=filter+.
+          #   Example: `updateMask=filter`.
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -506,7 +506,7 @@ module Google
           #   config_service_v2_client = Google::Cloud::Logging::V2::ConfigServiceV2Client.new
           #   formatted_sink_name = Google::Cloud::Logging::V2::ConfigServiceV2Client.sink_path("[PROJECT]", "[SINK]")
           #
-          #   # TODO: Initialize +sink+:
+          #   # TODO: Initialize `sink`:
           #   sink = {}
           #   response = config_service_v2_client.update_sink(formatted_sink_name, sink)
 
@@ -527,7 +527,7 @@ module Google
             @update_sink.call(req, options, &block)
           end
 
-          # Deletes a sink. If the sink has a unique +writer_identity+, then that
+          # Deletes a sink. If the sink has a unique `writer_identity`, then that
           # service account is also deleted.
           #
           # @param sink_name [String]
@@ -539,7 +539,7 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
           #       "folders/[FOLDER_ID]/sinks/[SINK_ID]"
           #
-          #   Example: +"projects/my-project-id/sinks/my-sink-id"+.
+          #   Example: `"projects/my-project-id/sinks/my-sink-id"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -635,7 +635,7 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
           #       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
           #
-          #   Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+          #   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -674,9 +674,9 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]"
           #       "folders/[FOLDER_ID]"
           #
-          #   Examples: +"projects/my-logging-project"+, +"organizations/123456789"+.
+          #   Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
           # @param exclusion [Google::Logging::V2::LogExclusion | Hash]
-          #   Required. The new exclusion, whose +name+ parameter is an exclusion name
+          #   Required. The new exclusion, whose `name` parameter is an exclusion name
           #   that is not already used in the parent resource.
           #   A hash of the same form as `Google::Logging::V2::LogExclusion`
           #   can also be provided.
@@ -694,7 +694,7 @@ module Google
           #   config_service_v2_client = Google::Cloud::Logging::V2::ConfigServiceV2Client.new
           #   formatted_parent = Google::Cloud::Logging::V2::ConfigServiceV2Client.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +exclusion+:
+          #   # TODO: Initialize `exclusion`:
           #   exclusion = {}
           #   response = config_service_v2_client.create_exclusion(formatted_parent, exclusion)
 
@@ -721,20 +721,20 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
           #       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
           #
-          #   Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+          #   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
           # @param exclusion [Google::Logging::V2::LogExclusion | Hash]
           #   Required. New values for the existing exclusion. Only the fields specified
-          #   in +update_mask+ are relevant.
+          #   in `update_mask` are relevant.
           #   A hash of the same form as `Google::Logging::V2::LogExclusion`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
           #   Required. A nonempty list of fields to change in the existing exclusion.
           #   New values for the fields are taken from the corresponding fields in the
           #   {Google::Logging::V2::LogExclusion LogExclusion} included in this request. Fields not mentioned in
-          #   +update_mask+ are not changed and are ignored in the request.
+          #   `update_mask` are not changed and are ignored in the request.
           #
           #   For example, to change the filter and description of an exclusion,
-          #   specify an +update_mask+ of +"filter,description"+.
+          #   specify an `update_mask` of `"filter,description"`.
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -751,10 +751,10 @@ module Google
           #   config_service_v2_client = Google::Cloud::Logging::V2::ConfigServiceV2Client.new
           #   formatted_name = Google::Cloud::Logging::V2::ConfigServiceV2Client.exclusion_path("[PROJECT]", "[EXCLUSION]")
           #
-          #   # TODO: Initialize +exclusion+:
+          #   # TODO: Initialize `exclusion`:
           #   exclusion = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = config_service_v2_client.update_exclusion(formatted_name, exclusion, update_mask)
 
@@ -783,7 +783,7 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
           #       "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
           #
-          #   Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+          #   Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/distribution.rb
@@ -29,13 +29,13 @@ module Google
     #
     # Although it is not forbidden, it is generally a bad idea to include
     # non-finite values (infinities or NaNs) in the population of values, as this
-    # will render the +mean+ and +sum_of_squared_deviation+ fields meaningless.
+    # will render the `mean` and `sum_of_squared_deviation` fields meaningless.
     # @!attribute [rw] count
     #   @return [Integer]
     #     The number of values in the population. Must be non-negative.
     # @!attribute [rw] mean
     #   @return [Float]
-    #     The arithmetic mean of the values in the population. If +count+ is zero
+    #     The arithmetic mean of the values in the population. If `count` is zero
     #     then this field must be zero.
     # @!attribute [rw] sum_of_squared_deviation
     #   @return [Float]
@@ -47,26 +47,26 @@ module Google
     #     Knuth, "The Art of Computer Programming", Vol. 2, page 323, 3rd edition
     #     describes Welford's method for accumulating this sum in one pass.
     #
-    #     If +count+ is zero then this field must be zero.
+    #     If `count` is zero then this field must be zero.
     # @!attribute [rw] range
     #   @return [Google::Api::Distribution::Range]
     #     If specified, contains the range of the population values. The field
-    #     must not be present if the +count+ is zero.
+    #     must not be present if the `count` is zero.
     # @!attribute [rw] bucket_options
     #   @return [Google::Api::Distribution::BucketOptions]
     #     Defines the histogram bucket boundaries.
     # @!attribute [rw] bucket_counts
     #   @return [Array<Integer>]
-    #     If +bucket_options+ is given, then the sum of the values in +bucket_counts+
-    #     must equal the value in +count+.  If +bucket_options+ is not given, no
-    #     +bucket_counts+ fields may be given.
+    #     If `bucket_options` is given, then the sum of the values in `bucket_counts`
+    #     must equal the value in `count`.  If `bucket_options` is not given, no
+    #     `bucket_counts` fields may be given.
     #
     #     Bucket counts are given in order under the numbering scheme described
     #     above (the underflow bucket has number 0; the finite buckets, if any,
     #     have numbers 1 through N-2; the overflow bucket has number N-1).
     #
-    #     The size of +bucket_counts+ must be no greater than N as defined in
-    #     +bucket_options+.
+    #     The size of `bucket_counts` must be no greater than N as defined in
+    #     `bucket_options`.
     #
     #     Any suffix of trailing zero bucket_count fields may be omitted.
     class Distribution
@@ -80,9 +80,9 @@ module Google
       class Range; end
 
       # A Distribution may optionally contain a histogram of the values in the
-      # population.  The histogram is given in +bucket_counts+ as counts of values
+      # population.  The histogram is given in `bucket_counts` as counts of values
       # that fall into one of a sequence of non-overlapping buckets.  The sequence
-      # of buckets is described by +bucket_options+.
+      # of buckets is described by `bucket_options`.
       #
       # A bucket specifies an inclusive lower bound and exclusive upper bound for
       # the values that are counted for that bucket.  The upper bound of a bucket
@@ -97,11 +97,11 @@ module Google
       # +infinity.  The finite buckets are so-called because both bounds are
       # finite.
       #
-      # +BucketOptions+ describes bucket boundaries in one of three ways.  Two
+      # `BucketOptions` describes bucket boundaries in one of three ways.  Two
       # describe the boundaries by giving parameters for a formula to generate
       # boundaries and one gives the bucket boundaries explicitly.
       #
-      # If +bucket_boundaries+ is not given, then no +bucket_counts+ may be given.
+      # If `bucket_boundaries` is not given, then no `bucket_counts` may be given.
       # @!attribute [rw] linear_buckets
       #   @return [Google::Api::Distribution::BucketOptions::Linear]
       #     The linear bucket.
@@ -116,8 +116,8 @@ module Google
         # overflow and underflow).  Each bucket represents a constant absolute
         # uncertainty on the specific value in the bucket.
         #
-        # Defines +num_finite_buckets + 2+ (= N) buckets with these boundaries for
-        # bucket +i+:
+        # Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
+        # bucket `i`:
         #
         #    Upper bound (0 <= i < N-1):     offset + (width * i).
         #    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
@@ -136,7 +136,7 @@ module Google
         # the value of the lower bound.  Each bucket represents a constant relative
         # uncertainty on a specific value in the bucket.
         #
-        # Defines +num_finite_buckets + 2+ (= N) buckets with these boundaries for
+        # Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
         # bucket i:
         #
         #    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
@@ -154,13 +154,13 @@ module Google
 
         # A set of buckets with arbitrary widths.
         #
-        # Defines +size(bounds) + 1+ (= N) buckets with these boundaries for
+        # Defines `size(bounds) + 1` (= N) buckets with these boundaries for
         # bucket i:
         #
         #    Upper bound (0 <= i < N-1):     bounds[i]
         #    Lower bound (1 <= i < N);       bounds[i - 1]
         #
-        # There must be at least one element in +bounds+.  If +bounds+ has only one
+        # There must be at least one element in `bounds`.  If `bounds` has only one
         # element, there are no finite buckets, and that single element is the
         # common boundary of the overflow and underflow buckets.
         # @!attribute [rw] bounds

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/metric.rb
@@ -25,7 +25,7 @@ module Google
     #   @return [String]
     #     The metric type, including its DNS name prefix. The type is not
     #     URL-encoded.  All user-defined custom metric types have the DNS name
-    #     +custom.googleapis.com+.  Metric types should use a natural hierarchical
+    #     `custom.googleapis.com`.  Metric types should use a natural hierarchical
     #     grouping. For example:
     #
     #         "custom.googleapis.com/invoice/paid/amount"
@@ -34,63 +34,63 @@ module Google
     #   @return [Array<Google::Api::LabelDescriptor>]
     #     The set of labels that can be used to describe a specific
     #     instance of this metric type. For example, the
-    #     +appengine.googleapis.com/http/server/response_latencies+ metric
-    #     type has a label for the HTTP response code, +response_code+, so
+    #     `appengine.googleapis.com/http/server/response_latencies` metric
+    #     type has a label for the HTTP response code, `response_code`, so
     #     you can look at latencies for successful responses or just
     #     for responses that failed.
     # @!attribute [rw] metric_kind
     #   @return [Google::Api::MetricDescriptor::MetricKind]
     #     Whether the metric records instantaneous values, changes to a value, etc.
-    #     Some combinations of +metric_kind+ and +value_type+ might not be supported.
+    #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] value_type
     #   @return [Google::Api::MetricDescriptor::ValueType]
     #     Whether the measurement is an integer, a floating-point number, etc.
-    #     Some combinations of +metric_kind+ and +value_type+ might not be supported.
+    #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] unit
     #   @return [String]
     #     The unit in which the metric value is reported. It is only applicable
-    #     if the +value_type+ is +INT64+, +DOUBLE+, or +DISTRIBUTION+. The
+    #     if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The
     #     supported units are a subset of [The Unified Code for Units of
     #     Measure](http://unitsofmeasure.org/ucum.html) standard:
     #
     #     **Basic units (UNIT)**
     #
-    #     * +bit+   bit
-    #     * +By+    byte
-    #     * +s+     second
-    #     * +min+   minute
-    #     * +h+     hour
-    #     * +d+     day
+    #     * `bit`   bit
+    #     * `By`    byte
+    #     * `s`     second
+    #     * `min`   minute
+    #     * `h`     hour
+    #     * `d`     day
     #
     #     **Prefixes (PREFIX)**
     #
-    #     * +k+     kilo    (10**3)
-    #     * +M+     mega    (10**6)
-    #     * +G+     giga    (10**9)
-    #     * +T+     tera    (10**12)
-    #     * +P+     peta    (10**15)
-    #     * +E+     exa     (10**18)
-    #     * +Z+     zetta   (10**21)
-    #     * +Y+     yotta   (10**24)
-    #     * +m+     milli   (10**-3)
-    #     * +u+     micro   (10**-6)
-    #     * +n+     nano    (10**-9)
-    #     * +p+     pico    (10**-12)
-    #     * +f+     femto   (10**-15)
-    #     * +a+     atto    (10**-18)
-    #     * +z+     zepto   (10**-21)
-    #     * +y+     yocto   (10**-24)
-    #     * +Ki+    kibi    (2**10)
-    #     * +Mi+    mebi    (2**20)
-    #     * +Gi+    gibi    (2**30)
-    #     * +Ti+    tebi    (2**40)
+    #     * `k`     kilo    (10**3)
+    #     * `M`     mega    (10**6)
+    #     * `G`     giga    (10**9)
+    #     * `T`     tera    (10**12)
+    #     * `P`     peta    (10**15)
+    #     * `E`     exa     (10**18)
+    #     * `Z`     zetta   (10**21)
+    #     * `Y`     yotta   (10**24)
+    #     * `m`     milli   (10**-3)
+    #     * `u`     micro   (10**-6)
+    #     * `n`     nano    (10**-9)
+    #     * `p`     pico    (10**-12)
+    #     * `f`     femto   (10**-15)
+    #     * `a`     atto    (10**-18)
+    #     * `z`     zepto   (10**-21)
+    #     * `y`     yocto   (10**-24)
+    #     * `Ki`    kibi    (2**10)
+    #     * `Mi`    mebi    (2**20)
+    #     * `Gi`    gibi    (2**30)
+    #     * `Ti`    tebi    (2**40)
     #
     #     **Grammar**
     #
     #     The grammar also includes these connectors:
     #
-    #     * +/+    division (as an infix operator, e.g. +1/s+).
-    #     * +.+    multiplication (as an infix operator, e.g. +GBy.d+)
+    #     * `/`    division (as an infix operator, e.g. `1/s`).
+    #     * `.`    multiplication (as an infix operator, e.g. `GBy.d`)
     #
     #     The grammar for a unit is as follows:
     #
@@ -105,13 +105,13 @@ module Google
     #
     #     Notes:
     #
-    #     * +Annotation+ is just a comment if it follows a +UNIT+ and is
-    #       equivalent to +1+ if it is used alone. For examples,
-    #       +\\{requests}/s == 1/s+, +By\\{transmitted}/s == By/s+.
-    #     * +NAME+ is a sequence of non-blank printable ASCII characters not
+    #     * `Annotation` is just a comment if it follows a `UNIT` and is
+    #       equivalent to `1` if it is used alone. For examples,
+    #       `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.
+    #     * `NAME` is a sequence of non-blank printable ASCII characters not
     #       containing '{' or '}'.
-    #     * +1+ represents dimensionless value 1, such as in +1/s+.
-    #     * +%+ represents dimensionless value 1/100, and annotates values giving
+    #     * `1` represents dimensionless value 1, such as in `1/s`.
+    #     * `%` represents dimensionless value 1/100, and annotates values giving
     #       a percentage.
     # @!attribute [rw] description
     #   @return [String]
@@ -148,7 +148,7 @@ module Google
         VALUE_TYPE_UNSPECIFIED = 0
 
         # The value is a boolean.
-        # This value type can be used only if the metric kind is +GAUGE+.
+        # This value type can be used only if the metric kind is `GAUGE`.
         BOOL = 1
 
         # The value is a signed 64-bit integer.
@@ -158,10 +158,10 @@ module Google
         DOUBLE = 3
 
         # The value is a text string.
-        # This value type can be used only if the metric kind is +GAUGE+.
+        # This value type can be used only if the metric kind is `GAUGE`.
         STRING = 4
 
-        # The value is a {Google::Api::Distribution +Distribution+}.
+        # The value is a {Google::Api::Distribution `Distribution`}.
         DISTRIBUTION = 5
 
         # The value is money.
@@ -170,15 +170,15 @@ module Google
     end
 
     # A specific metric, identified by specifying values for all of the
-    # labels of a {Google::Api::MetricDescriptor +MetricDescriptor+}.
+    # labels of a {Google::Api::MetricDescriptor `MetricDescriptor`}.
     # @!attribute [rw] type
     #   @return [String]
     #     An existing metric type, see {Google::Api::MetricDescriptor}.
-    #     For example, +custom.googleapis.com/invoice/paid/amount+.
+    #     For example, `custom.googleapis.com/invoice/paid/amount`.
     # @!attribute [rw] labels
     #   @return [Hash{String => String}]
     #     The set of label values that uniquely identify this metric. All
-    #     labels listed in the +MetricDescriptor+ must be assigned values.
+    #     labels listed in the `MetricDescriptor` must be assigned values.
     class Metric; end
   end
 end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/api/monitored_resource.rb
@@ -18,31 +18,31 @@ module Google
     # An object that describes the schema of a {Google::Api::MonitoredResource MonitoredResource} object using a
     # type name and a set of labels.  For example, the monitored resource
     # descriptor for Google Compute Engine VM instances has a type of
-    # +"gce_instance"+ and specifies the use of the labels +"instance_id"+ and
-    # +"zone"+ to identify particular VM instances.
+    # `"gce_instance"` and specifies the use of the labels `"instance_id"` and
+    # `"zone"` to identify particular VM instances.
     #
     # Different APIs can support different monitored resource types. APIs generally
-    # provide a +list+ method that returns the monitored resource descriptors used
+    # provide a `list` method that returns the monitored resource descriptors used
     # by the API.
     # @!attribute [rw] name
     #   @return [String]
     #     Optional. The resource name of the monitored resource descriptor:
-    #     +"projects/\\{project_id}/monitoredResourceDescriptors/\\{type}"+ where
-    #     \\{type} is the value of the +type+ field in this object and
+    #     `"projects/{project_id}/monitoredResourceDescriptors/{type}"` where
+    #     \\{type} is the value of the `type` field in this object and
     #     \\{project_id} is a project ID that provides API-specific context for
     #     accessing the type.  APIs that do not use project information can use the
-    #     resource name format +"monitoredResourceDescriptors/\\{type}"+.
+    #     resource name format `"monitoredResourceDescriptors/{type}"`.
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. For example, the type
-    #     +"cloudsql_database"+ represents databases in Google Cloud SQL.
+    #     `"cloudsql_database"` represents databases in Google Cloud SQL.
     #     The maximum length of this value is 256 characters.
     # @!attribute [rw] display_name
     #   @return [String]
     #     Optional. A concise name for the monitored resource type that might be
     #     displayed in user interfaces. It should be a Title Cased Noun Phrase,
     #     without any article or other determiners. For example,
-    #     +"Google Cloud SQL Database"+.
+    #     `"Google Cloud SQL Database"`.
     # @!attribute [rw] description
     #   @return [String]
     #     Optional. A detailed description of the monitored resource type that might
@@ -51,18 +51,18 @@ module Google
     #   @return [Array<Google::Api::LabelDescriptor>]
     #     Required. A set of labels used to describe instances of this monitored
     #     resource type. For example, an individual Google Cloud SQL database is
-    #     identified by values for the labels +"database_id"+ and +"zone"+.
+    #     identified by values for the labels `"database_id"` and `"zone"`.
     class MonitoredResourceDescriptor; end
 
     # An object representing a resource that can be used for monitoring, logging,
     # billing, or other purposes. Examples include virtual machine instances,
-    # databases, and storage devices such as disks. The +type+ field identifies a
+    # databases, and storage devices such as disks. The `type` field identifies a
     # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object that describes the resource's
-    # schema. Information in the +labels+ field identifies the actual resource and
+    # schema. Information in the `labels` field identifies the actual resource and
     # its attributes according to the schema. For example, a particular Compute
     # Engine VM instance could be represented by the following object, because the
-    # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} for +"gce_instance"+ has labels
-    # +"instance_id"+ and +"zone"+:
+    # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} for `"gce_instance"` has labels
+    # `"instance_id"` and `"zone"`:
     #
     #     { "type": "gce_instance",
     #       "labels": { "instance_id": "12345678901234",
@@ -70,13 +70,13 @@ module Google
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. This field must match
-    #     the +type+ field of a {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object. For
-    #     example, the type of a Compute Engine VM instance is +gce_instance+.
+    #     the `type` field of a {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object. For
+    #     example, the type of a Compute Engine VM instance is `gce_instance`.
     # @!attribute [rw] labels
     #   @return [Hash{String => String}]
     #     Required. Values for all of the labels listed in the associated monitored
     #     resource descriptor. For example, Compute Engine VM instances use the
-    #     labels +"project_id"+, +"instance_id"+, and +"zone"+.
+    #     labels `"project_id"`, `"instance_id"`, and `"zone"`.
     class MonitoredResource; end
 
     # Auxiliary metadata for a {Google::Api::MonitoredResource MonitoredResource} object.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/type/http_request.rb
@@ -21,12 +21,12 @@ module Google
       # information MUST be defined in a separate message.
       # @!attribute [rw] request_method
       #   @return [String]
-      #     The request method. Examples: +"GET"+, +"HEAD"+, +"PUT"+, +"POST"+.
+      #     The request method. Examples: `"GET"`, `"HEAD"`, `"PUT"`, `"POST"`.
       # @!attribute [rw] request_url
       #   @return [String]
       #     The scheme (http, https), the host name, the path and the query
       #     portion of the URL that was requested.
-      #     Example: +"http://example.com/some/info?color=red"+.
+      #     Example: `"http://example.com/some/info?color=red"`.
       # @!attribute [rw] request_size
       #   @return [Integer]
       #     The size of the HTTP request message in bytes, including the request
@@ -42,11 +42,11 @@ module Google
       # @!attribute [rw] user_agent
       #   @return [String]
       #     The user agent sent by the client. Example:
-      #     +"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET CLR 1.0.3705)"+.
+      #     `"Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Q312461; .NET CLR 1.0.3705)"`.
       # @!attribute [rw] remote_ip
       #   @return [String]
       #     The IP address (IPv4 or IPv6) of the client that issued the HTTP
-      #     request. Examples: +"192.168.1.1"+, +"FE80::0202:B3FF:FE1E:8329"+.
+      #     request. Examples: `"192.168.1.1"`, `"FE80::0202:B3FF:FE1E:8329"`.
       # @!attribute [rw] server_ip
       #   @return [String]
       #     The IP address (IPv4 or IPv6) of the origin server that the request was
@@ -69,7 +69,7 @@ module Google
       # @!attribute [rw] cache_validated_with_origin_server
       #   @return [true, false]
       #     Whether or not the response was validated with the origin server before
-      #     being served from cache. This field is only meaningful if +cache_hit+ is
+      #     being served from cache. This field is only meaningful if `cache_hit` is
       #     True.
       # @!attribute [rw] cache_fill_bytes
       #   @return [Integer]

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/log_entry.rb
@@ -28,16 +28,16 @@ module Google
       #
       #      A project number may optionally be used in place of PROJECT_ID. The
       #      project number is translated to its corresponding PROJECT_ID internally
-      #      and the +log_name+ field will contain PROJECT_ID in queries and exports.
+      #      and the `log_name` field will contain PROJECT_ID in queries and exports.
       #
-      #     +[LOG_ID]+ must be URL-encoded within +log_name+. Example:
-      #     +"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"+.
-      #     +[LOG_ID]+ must be less than 512 characters long and can only include the
+      #     `[LOG_ID]` must be URL-encoded within `log_name`. Example:
+      #     `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
+      #     `[LOG_ID]` must be less than 512 characters long and can only include the
       #     following characters: upper and lower case alphanumeric characters,
       #     forward-slash, underscore, hyphen, and period.
       #
-      #     For backward compatibility, if +log_name+ begins with a forward-slash, such
-      #     as +/projects/...+, then the log entry is ingested as usual but the
+      #     For backward compatibility, if `log_name` begins with a forward-slash, such
+      #     as `/projects/...`, then the log entry is ingested as usual but the
       #     forward-slash is removed. Listing the log entry will not show the leading
       #     slash and filtering for a log name with a leading slash will never return
       #     any results.
@@ -71,7 +71,7 @@ module Google
       #     Incoming log entries should have timestamps that are no more than
       #     the [logs retention period](https://cloud.google.com/logging/quotas) in the past,
       #     and no more than 24 hours in the future. Log entries outside those time
-      #     boundaries will not be available when calling +entries.list+, but
+      #     boundaries will not be available when calling `entries.list`, but
       #     those log entries can still be exported with
       #     [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
       # @!attribute [rw] receive_timestamp
@@ -80,15 +80,15 @@ module Google
       # @!attribute [rw] severity
       #   @return [Google::Logging::Type::LogSeverity]
       #     Optional. The severity of the log entry. The default value is
-      #     +LogSeverity.DEFAULT+.
+      #     `LogSeverity.DEFAULT`.
       # @!attribute [rw] insert_id
       #   @return [String]
       #     Optional. A unique identifier for the log entry. If you provide a value,
       #     then Stackdriver Logging considers other log entries in the same project,
-      #     with the same +timestamp+, and with the same +insert_id+ to be duplicates
+      #     with the same `timestamp`, and with the same `insert_id` to be duplicates
       #     which can be removed.  If omitted in new log entries, then Stackdriver
-      #     Logging assigns its own unique identifier. The +insert_id+ is also used
-      #     to order log entries that have the same +timestamp+ value.
+      #     Logging assigns its own unique identifier. The `insert_id` is also used
+      #     to order log entries that have the same `timestamp` value.
       # @!attribute [rw] http_request
       #   @return [Google::Logging::Type::HttpRequest]
       #     Optional. Information about the HTTP request associated with this
@@ -100,7 +100,7 @@ module Google
       # @!attribute [rw] metadata
       #   @return [Google::Api::MonitoredResourceMetadata]
       #     Output only. Additional metadata about the monitored resource.
-      #     Only +k8s_container+, +k8s_pod+, and +k8s_node+ MonitoredResources have
+      #     Only `k8s_container`, `k8s_pod`, and `k8s_node` MonitoredResources have
       #     this field populated.
       # @!attribute [rw] operation
       #   @return [Google::Logging::V2::LogEntryOperation]
@@ -110,8 +110,8 @@ module Google
       #   @return [String]
       #     Optional. Resource name of the trace associated with the log entry, if any.
       #     If it contains a relative resource name, the name is assumed to be relative
-      #     to +//tracing.googleapis.com+. Example:
-      #     +projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824+
+      #     to `//tracing.googleapis.com`. Example:
+      #     `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
       # @!attribute [rw] span_id
       #   @return [String]
       #     Optional. The span ID within the trace associated with the log entry. For
@@ -133,8 +133,8 @@ module Google
       # @!attribute [rw] producer
       #   @return [String]
       #     Optional. An arbitrary producer identifier. The combination of
-      #     +id+ and +producer+ must be globally unique.  Examples for +producer+:
-      #     +"MyDivision.MyBigCompany.com"+, +"github.com/MyProject/MyApplication"+.
+      #     `id` and `producer` must be globally unique.  Examples for `producer`:
+      #     `"MyDivision.MyBigCompany.com"`, `"github.com/MyProject/MyApplication"`.
       # @!attribute [rw] first
       #   @return [true, false]
       #     Optional. Set this to True if this is the first log entry in the operation.
@@ -159,7 +159,7 @@ module Google
       #     optional context such as the class or package name. This information may be
       #     used in contexts such as the logs viewer, where a file and line number are
       #     less meaningful. The format can vary by language. For example:
-      #     +qual.if.ied.Class.method+ (Java), +dir/package.func+ (Go), +function+
+      #     `qual.if.ied.Class.method` (Java), `dir/package.func` (Go), `function`
       #     (Python).
       class LogEntrySourceLocation; end
     end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging.rb
@@ -26,9 +26,9 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
       #         "folders/[FOLDER_ID]/logs/[LOG_ID]"
       #
-      #     +[LOG_ID]+ must be URL-encoded. For example,
-      #     +"projects/my-project-id/logs/syslog"+,
-      #     +"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"+.
+      #     `[LOG_ID]` must be URL-encoded. For example,
+      #     `"projects/my-project-id/logs/syslog"`,
+      #     `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
       #     For more information about log names, see
       #     {Google::Logging::V2::LogEntry LogEntry}.
       class DeleteLogRequest; end
@@ -37,22 +37,22 @@ module Google
       # @!attribute [rw] log_name
       #   @return [String]
       #     Optional. A default log resource name that is assigned to all log entries
-      #     in +entries+ that do not specify a value for +log_name+:
+      #     in `entries` that do not specify a value for `log_name`:
       #
       #         "projects/[PROJECT_ID]/logs/[LOG_ID]"
       #         "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
       #         "folders/[FOLDER_ID]/logs/[LOG_ID]"
       #
-      #     +[LOG_ID]+ must be URL-encoded. For example,
-      #     +"projects/my-project-id/logs/syslog"+ or
-      #     +"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"+.
+      #     `[LOG_ID]` must be URL-encoded. For example,
+      #     `"projects/my-project-id/logs/syslog"` or
+      #     `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
       #     For more information about log names, see
       #     {Google::Logging::V2::LogEntry LogEntry}.
       # @!attribute [rw] resource
       #   @return [Google::Api::MonitoredResource]
       #     Optional. A default monitored resource object that is assigned to all log
-      #     entries in +entries+ that do not specify a value for +resource+. Example:
+      #     entries in `entries` that do not specify a value for `resource`. Example:
       #
       #         { "type": "gce_instance",
       #           "labels": {
@@ -61,33 +61,33 @@ module Google
       #     See {Google::Logging::V2::LogEntry LogEntry}.
       # @!attribute [rw] labels
       #   @return [Hash{String => String}]
-      #     Optional. Default labels that are added to the +labels+ field of all log
-      #     entries in +entries+. If a log entry already has a label with the same key
+      #     Optional. Default labels that are added to the `labels` field of all log
+      #     entries in `entries`. If a log entry already has a label with the same key
       #     as a label in this parameter, then the log entry's label is not changed.
       #     See {Google::Logging::V2::LogEntry LogEntry}.
       # @!attribute [rw] entries
       #   @return [Array<Google::Logging::V2::LogEntry>]
       #     Required. The log entries to send to Stackdriver Logging. The order of log
       #     entries in this list does not matter. Values supplied in this method's
-      #     +log_name+, +resource+, and +labels+ fields are copied into those log
+      #     `log_name`, `resource`, and `labels` fields are copied into those log
       #     entries in this list that do not include values for their corresponding
       #     fields. For more information, see the
       #     {Google::Logging::V2::LogEntry LogEntry} type.
       #
-      #     If the +timestamp+ or +insert_id+ fields are missing in log entries, then
+      #     If the `timestamp` or `insert_id` fields are missing in log entries, then
       #     this method supplies the current time or a unique identifier, respectively.
       #     The supplied values are chosen so that, among the log entries that did not
       #     supply their own values, the entries earlier in the list will sort before
-      #     the entries later in the list. See the +entries.list+ method.
+      #     the entries later in the list. See the `entries.list` method.
       #
       #     Log entries with timestamps that are more than the
       #     [logs retention period](https://cloud.google.com/logging/quota-policy) in the past or more than
-      #     24 hours in the future will not be available when calling +entries.list+.
+      #     24 hours in the future will not be available when calling `entries.list`.
       #     However, those log entries can still be exported with
       #     [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
       #
       #     To improve throughput and to avoid exceeding the
-      #     [quota limit](https://cloud.google.com/logging/quota-policy) for calls to +entries.write+,
+      #     [quota limit](https://cloud.google.com/logging/quota-policy) for calls to `entries.write`,
       #     you should try to include several log entries in this list,
       #     rather than calling this method for each individual log entry.
       # @!attribute [rw] partial_success
@@ -96,7 +96,7 @@ module Google
       #     entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any
       #     entry is not written, then the response status is the error associated
       #     with one of the failed entries and the response includes error details
-      #     keyed by the entries' zero-based index in the +entries.write+ method.
+      #     keyed by the entries' zero-based index in the `entries.write` method.
       # @!attribute [rw] dry_run
       #   @return [true, false]
       #     Optional. If true, the request should expect normal response, but the
@@ -111,22 +111,22 @@ module Google
       # Error details for WriteLogEntries with partial success.
       # @!attribute [rw] log_entry_errors
       #   @return [Hash{Integer => Google::Rpc::Status}]
-      #     When +WriteLogEntriesRequest.partial_success+ is true, records the error
+      #     When `WriteLogEntriesRequest.partial_success` is true, records the error
       #     status for entries that were not written due to a permanent error, keyed
-      #     by the entry's zero-based index in +WriteLogEntriesRequest.entries+.
+      #     by the entry's zero-based index in `WriteLogEntriesRequest.entries`.
       #
       #     Failed requests for which no entries are written will not include
       #     per-entry errors.
       class WriteLogEntriesPartialErrors; end
 
-      # The parameters to +ListLogEntries+.
+      # The parameters to `ListLogEntries`.
       # @!attribute [rw] project_ids
       #   @return [Array<String>]
-      #     Deprecated. Use +resource_names+ instead.  One or more project identifiers
+      #     Deprecated. Use `resource_names` instead.  One or more project identifiers
       #     or project numbers from which to retrieve log entries.  Example:
-      #     +"my-project-1A"+. If present, these project identifiers are converted to
+      #     `"my-project-1A"`. If present, these project identifiers are converted to
       #     resource name format and added to the list of resources in
-      #     +resource_names+.
+      #     `resource_names`.
       # @!attribute [rw] resource_names
       #   @return [Array<String>]
       #     Required. Names of one or more parent resources from which to
@@ -137,53 +137,53 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]"
       #         "folders/[FOLDER_ID]"
       #
-      #     Projects listed in the +project_ids+ field are added to this list.
+      #     Projects listed in the `project_ids` field are added to this list.
       # @!attribute [rw] filter
       #   @return [String]
       #     Optional. A filter that chooses which log entries to return.  See [Advanced
       #     Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
       #     match the filter are returned.  An empty filter matches all log entries in
-      #     the resources listed in +resource_names+. Referencing a parent resource
-      #     that is not listed in +resource_names+ will cause the filter to return no
+      #     the resources listed in `resource_names`. Referencing a parent resource
+      #     that is not listed in `resource_names` will cause the filter to return no
       #     results.
       #     The maximum length of the filter is 20000 characters.
       # @!attribute [rw] order_by
       #   @return [String]
       #     Optional. How the results should be sorted.  Presently, the only permitted
-      #     values are +"timestamp asc"+ (default) and +"timestamp desc"+. The first
+      #     values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
       #     option returns entries in order of increasing values of
-      #     +LogEntry.timestamp+ (oldest first), and the second option returns entries
+      #     `LogEntry.timestamp` (oldest first), and the second option returns entries
       #     in order of decreasing timestamps (newest first).  Entries with equal
-      #     timestamps are returned in order of their +insert_id+ values.
+      #     timestamps are returned in order of their `insert_id` values.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +next_page_token+ in the
+      #     Non-positive values are ignored.  The presence of `next_page_token` in the
       #     response indicates that more results might be available.
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +page_token+ must be the value of
-      #     +next_page_token+ from the previous response.  The values of other method
+      #     preceding call to this method.  `page_token` must be the value of
+      #     `next_page_token` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       class ListLogEntriesRequest; end
 
-      # Result returned from +ListLogEntries+.
+      # Result returned from `ListLogEntries`.
       # @!attribute [rw] entries
       #   @return [Array<Google::Logging::V2::LogEntry>]
-      #     A list of log entries.  If +entries+ is empty, +nextPageToken+ may still be
-      #     returned, indicating that more entries may exist.  See +nextPageToken+ for
+      #     A list of log entries.  If `entries` is empty, `nextPageToken` may still be
+      #     returned, indicating that more entries may exist.  See `nextPageToken` for
       #     more information.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than those appearing in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call this
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call this
+      #     method again using the value of `nextPageToken` as `pageToken`.
       #
-      #     If a value for +next_page_token+ appears and the +entries+ field is empty,
+      #     If a value for `next_page_token` appears and the `entries` field is empty,
       #     it means that the search found no log entries so far but it did not have
       #     time to search all the possible log entries.  Retry the method with this
-      #     value for +page_token+ to continue the search.  Alternatively, consider
+      #     value for `page_token` to continue the search.  Alternatively, consider
       #     speeding up the search by changing your filter to specify a single log name
       #     or resource type, or to narrow the time range of the search.
       class ListLogEntriesResponse; end
@@ -192,13 +192,13 @@ module Google
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +nextPageToken+ in the
+      #     Non-positive values are ignored.  The presence of `nextPageToken` in the
       #     response indicates that more results might be available.
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +pageToken+ must be the value of
-      #     +nextPageToken+ from the previous response.  The values of other method
+      #     preceding call to this method.  `pageToken` must be the value of
+      #     `nextPageToken` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       class ListMonitoredResourceDescriptorsRequest; end
 
@@ -209,8 +209,8 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than those appearing in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call this
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call this
+      #     method again using the value of `nextPageToken` as `pageToken`.
       class ListMonitoredResourceDescriptorsResponse; end
 
       # The parameters to ListLogs.
@@ -225,13 +225,13 @@ module Google
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +nextPageToken+ in the
+      #     Non-positive values are ignored.  The presence of `nextPageToken` in the
       #     response indicates that more results might be available.
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +pageToken+ must be the value of
-      #     +nextPageToken+ from the previous response.  The values of other method
+      #     preceding call to this method.  `pageToken` must be the value of
+      #     `nextPageToken` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       class ListLogsRequest; end
 
@@ -239,13 +239,13 @@ module Google
       # @!attribute [rw] log_names
       #   @return [Array<String>]
       #     A list of log names. For example,
-      #     +"projects/my-project/syslog"+ or
-      #     +"organizations/123/cloudresourcemanager.googleapis.com%2Factivity"+.
+      #     `"projects/my-project/syslog"` or
+      #     `"organizations/123/cloudresourcemanager.googleapis.com%2Factivity"`.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than those appearing in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call this
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call this
+      #     method again using the value of `nextPageToken` as `pageToken`.
       class ListLogsResponse; end
     end
   end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_config.rb
@@ -24,7 +24,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     Required. The client-assigned sink identifier, unique within the
-      #     project. Example: +"my-syslog-errors-to-pubsub"+.  Sink identifiers are
+      #     project. Example: `"my-syslog-errors-to-pubsub"`.  Sink identifiers are
       #     limited to 100 characters and can include only the following characters:
       #     upper and lower-case alphanumeric characters, underscores, hyphens, and
       #     periods.
@@ -36,7 +36,7 @@ module Google
       #         "bigquery.googleapis.com/projects/[PROJECT_ID]/datasets/[DATASET]"
       #         "pubsub.googleapis.com/projects/[PROJECT_ID]/topics/[TOPIC_ID]"
       #
-      #     The sink's +writer_identity+, set when the sink is created, must
+      #     The sink's `writer_identity`, set when the sink is created, must
       #     have permission to write to the destination or else the log
       #     entries are not exported.  For more information, see
       #     [Exporting Logs With Sinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
@@ -60,7 +60,7 @@ module Google
       #     [sinks.create](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/create)
       #     and
       #     [sinks.update](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/update),
-      #     based on the setting of +unique_writer_identity+ in those methods.
+      #     based on the setting of `unique_writer_identity` in those methods.
       #
       #     Until you grant this identity write-access to the destination, log entry
       #     exports from this sink will fail. For more information,
@@ -77,7 +77,7 @@ module Google
       #     sink's parent resource are also available for export. Whether a particular
       #     log entry from the children is exported depends on the sink's filter
       #     expression. For example, if this field is true, then the filter
-      #     +resource.type=gce_instance+ would export all Compute Engine VM instance
+      #     `resource.type=gce_instance` would export all Compute Engine VM instance
       #     log entries from all projects in the sink's parent. To only export entries
       #     from certain child projects, filter on the project part of the log name:
       #
@@ -97,15 +97,15 @@ module Google
           # An unspecified format version that will default to V2.
           VERSION_FORMAT_UNSPECIFIED = 0
 
-          # +LogEntry+ version 2 format.
+          # `LogEntry` version 2 format.
           V2 = 1
 
-          # +LogEntry+ version 1 format.
+          # `LogEntry` version 1 format.
           V1 = 2
         end
       end
 
-      # The parameters to +ListSinks+.
+      # The parameters to `ListSinks`.
       # @!attribute [rw] parent
       #   @return [String]
       #     Required. The parent resource whose sinks are to be listed:
@@ -117,28 +117,28 @@ module Google
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +pageToken+ must be the value of
-      #     +nextPageToken+ from the previous response.  The values of other method
+      #     preceding call to this method.  `pageToken` must be the value of
+      #     `nextPageToken` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +nextPageToken+ in the
+      #     Non-positive values are ignored.  The presence of `nextPageToken` in the
       #     response indicates that more results might be available.
       class ListSinksRequest; end
 
-      # Result returned from +ListSinks+.
+      # Result returned from `ListSinks`.
       # @!attribute [rw] sinks
       #   @return [Array<Google::Logging::V2::LogSink>]
       #     A list of sinks.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than appear in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call the same
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call the same
+      #     method again using the value of `nextPageToken` as `pageToken`.
       class ListSinksResponse; end
 
-      # The parameters to +GetSink+.
+      # The parameters to `GetSink`.
       # @!attribute [rw] sink_name
       #   @return [String]
       #     Required. The resource name of the sink:
@@ -148,10 +148,10 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
       #         "folders/[FOLDER_ID]/sinks/[SINK_ID]"
       #
-      #     Example: +"projects/my-project-id/sinks/my-sink-id"+.
+      #     Example: `"projects/my-project-id/sinks/my-sink-id"`.
       class GetSinkRequest; end
 
-      # The parameters to +CreateSink+.
+      # The parameters to `CreateSink`.
       # @!attribute [rw] parent
       #   @return [String]
       #     Required. The resource in which to create the sink:
@@ -161,27 +161,27 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]"
       #         "folders/[FOLDER_ID]"
       #
-      #     Examples: +"projects/my-logging-project"+, +"organizations/123456789"+.
+      #     Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
       # @!attribute [rw] sink
       #   @return [Google::Logging::V2::LogSink]
-      #     Required. The new sink, whose +name+ parameter is a sink identifier that
+      #     Required. The new sink, whose `name` parameter is a sink identifier that
       #     is not already in use.
       # @!attribute [rw] unique_writer_identity
       #   @return [true, false]
-      #     Optional. Determines the kind of IAM identity returned as +writer_identity+
+      #     Optional. Determines the kind of IAM identity returned as `writer_identity`
       #     in the new sink.  If this value is omitted or set to false, and if the
-      #     sink's parent is a project, then the value returned as +writer_identity+ is
+      #     sink's parent is a project, then the value returned as `writer_identity` is
       #     the same group or service account used by Stackdriver Logging before the
       #     addition of writer identities to this API. The sink's destination must be
       #     in the same project as the sink itself.
       #
       #     If this field is set to true, or if the sink is owned by a non-project
-      #     resource such as an organization, then the value of +writer_identity+ will
+      #     resource such as an organization, then the value of `writer_identity` will
       #     be a unique service account used only for exports from the new sink.  For
-      #     more information, see +writer_identity+ in {Google::Logging::V2::LogSink LogSink}.
+      #     more information, see `writer_identity` in {Google::Logging::V2::LogSink LogSink}.
       class CreateSinkRequest; end
 
-      # The parameters to +UpdateSink+.
+      # The parameters to `UpdateSink`.
       # @!attribute [rw] sink_name
       #   @return [String]
       #     Required. The full resource name of the sink to update, including the
@@ -192,30 +192,30 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
       #         "folders/[FOLDER_ID]/sinks/[SINK_ID]"
       #
-      #     Example: +"projects/my-project-id/sinks/my-sink-id"+.
+      #     Example: `"projects/my-project-id/sinks/my-sink-id"`.
       # @!attribute [rw] sink
       #   @return [Google::Logging::V2::LogSink]
       #     Required. The updated sink, whose name is the same identifier that appears
-      #     as part of +sink_name+.
+      #     as part of `sink_name`.
       # @!attribute [rw] unique_writer_identity
       #   @return [true, false]
       #     Optional. See
       #     [sinks.create](https://cloud.google.com/logging/docs/api/reference/rest/v2/projects.sinks/create)
       #     for a description of this field.  When updating a sink, the effect of this
-      #     field on the value of +writer_identity+ in the updated sink depends on both
+      #     field on the value of `writer_identity` in the updated sink depends on both
       #     the old and new values of this field:
       #
       #     * If the old and new values of this field are both false or both true,
-      #       then there is no change to the sink's +writer_identity+.
+      #       then there is no change to the sink's `writer_identity`.
       #     * If the old value is false and the new value is true, then
-      #       +writer_identity+ is changed to a unique service account.
+      #       `writer_identity` is changed to a unique service account.
       #     * It is an error if the old value is true and the new value is
       #       set to false or defaulted to false.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
-      #     Optional. Field mask that specifies the fields in +sink+ that need
+      #     Optional. Field mask that specifies the fields in `sink` that need
       #     an update. A sink field will be overwritten if, and only if, it is
-      #     in the update mask.  +name+ and output only fields cannot be updated.
+      #     in the update mask.  `name` and output only fields cannot be updated.
       #
       #     An empty updateMask is temporarily treated as using the following mask
       #     for backwards compatibility purposes:
@@ -223,13 +223,13 @@ module Google
       #     At some point in the future, behavior will be removed and specifying an
       #     empty updateMask will be an error.
       #
-      #     For a detailed +FieldMask+ definition, see
+      #     For a detailed `FieldMask` definition, see
       #     https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
       #
-      #     Example: +updateMask=filter+.
+      #     Example: `updateMask=filter`.
       class UpdateSinkRequest; end
 
-      # The parameters to +DeleteSink+.
+      # The parameters to `DeleteSink`.
       # @!attribute [rw] sink_name
       #   @return [String]
       #     Required. The full resource name of the sink to delete, including the
@@ -240,7 +240,7 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/sinks/[SINK_ID]"
       #         "folders/[FOLDER_ID]/sinks/[SINK_ID]"
       #
-      #     Example: +"projects/my-project-id/sinks/my-sink-id"+.
+      #     Example: `"projects/my-project-id/sinks/my-sink-id"`.
       class DeleteSinkRequest; end
 
       # Specifies a set of log entries that are not to be stored in Stackdriver
@@ -252,7 +252,7 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     Required. A client-assigned identifier, such as
-      #     +"load-balancer-exclusion"+. Identifiers are limited to 100 characters and
+      #     `"load-balancer-exclusion"`. Identifiers are limited to 100 characters and
       #     can include only letters, digits, underscores, hyphens, and periods.
       # @!attribute [rw] description
       #   @return [String]
@@ -267,7 +267,7 @@ module Google
       #     For example, the following filter matches 99% of low-severity log
       #     entries from load balancers:
       #
-      #     +"resource.type=http_load_balancer severity<ERROR sample(insertId, 0.99)"+
+      #     `"resource.type=http_load_balancer severity<ERROR sample(insertId, 0.99)"`
       # @!attribute [rw] disabled
       #   @return [true, false]
       #     Optional. If set to True, then this exclusion is disabled and it does not
@@ -276,7 +276,7 @@ module Google
       #     to change the value of this field.
       class LogExclusion; end
 
-      # The parameters to +ListExclusions+.
+      # The parameters to `ListExclusions`.
       # @!attribute [rw] parent
       #   @return [String]
       #     Required. The parent resource whose exclusions are to be listed.
@@ -288,28 +288,28 @@ module Google
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +pageToken+ must be the value of
-      #     +nextPageToken+ from the previous response.  The values of other method
+      #     preceding call to this method.  `pageToken` must be the value of
+      #     `nextPageToken` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +nextPageToken+ in the
+      #     Non-positive values are ignored.  The presence of `nextPageToken` in the
       #     response indicates that more results might be available.
       class ListExclusionsRequest; end
 
-      # Result returned from +ListExclusions+.
+      # Result returned from `ListExclusions`.
       # @!attribute [rw] exclusions
       #   @return [Array<Google::Logging::V2::LogExclusion>]
       #     A list of exclusions.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than appear in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call the same
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call the same
+      #     method again using the value of `nextPageToken` as `pageToken`.
       class ListExclusionsResponse; end
 
-      # The parameters to +GetExclusion+.
+      # The parameters to `GetExclusion`.
       # @!attribute [rw] name
       #   @return [String]
       #     Required. The resource name of an existing exclusion:
@@ -319,10 +319,10 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
       #         "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
       #
-      #     Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+      #     Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
       class GetExclusionRequest; end
 
-      # The parameters to +CreateExclusion+.
+      # The parameters to `CreateExclusion`.
       # @!attribute [rw] parent
       #   @return [String]
       #     Required. The parent resource in which to create the exclusion:
@@ -332,14 +332,14 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]"
       #         "folders/[FOLDER_ID]"
       #
-      #     Examples: +"projects/my-logging-project"+, +"organizations/123456789"+.
+      #     Examples: `"projects/my-logging-project"`, `"organizations/123456789"`.
       # @!attribute [rw] exclusion
       #   @return [Google::Logging::V2::LogExclusion]
-      #     Required. The new exclusion, whose +name+ parameter is an exclusion name
+      #     Required. The new exclusion, whose `name` parameter is an exclusion name
       #     that is not already used in the parent resource.
       class CreateExclusionRequest; end
 
-      # The parameters to +UpdateExclusion+.
+      # The parameters to `UpdateExclusion`.
       # @!attribute [rw] name
       #   @return [String]
       #     Required. The resource name of the exclusion to update:
@@ -349,23 +349,23 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
       #         "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
       #
-      #     Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+      #     Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
       # @!attribute [rw] exclusion
       #   @return [Google::Logging::V2::LogExclusion]
       #     Required. New values for the existing exclusion. Only the fields specified
-      #     in +update_mask+ are relevant.
+      #     in `update_mask` are relevant.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     Required. A nonempty list of fields to change in the existing exclusion.
       #     New values for the fields are taken from the corresponding fields in the
       #     {Google::Logging::V2::LogExclusion LogExclusion} included in this request. Fields not mentioned in
-      #     +update_mask+ are not changed and are ignored in the request.
+      #     `update_mask` are not changed and are ignored in the request.
       #
       #     For example, to change the filter and description of an exclusion,
-      #     specify an +update_mask+ of +"filter,description"+.
+      #     specify an `update_mask` of `"filter,description"`.
       class UpdateExclusionRequest; end
 
-      # The parameters to +DeleteExclusion+.
+      # The parameters to `DeleteExclusion`.
       # @!attribute [rw] name
       #   @return [String]
       #     Required. The resource name of an existing exclusion to delete:
@@ -375,7 +375,7 @@ module Google
       #         "billingAccounts/[BILLING_ACCOUNT_ID]/exclusions/[EXCLUSION_ID]"
       #         "folders/[FOLDER_ID]/exclusions/[EXCLUSION_ID]"
       #
-      #     Example: +"projects/my-project-id/exclusions/my-exclusion-id"+.
+      #     Example: `"projects/my-project-id/exclusions/my-exclusion-id"`.
       class DeleteExclusionRequest; end
     end
   end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/logging/v2/logging_metrics.rb
@@ -26,20 +26,20 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     Required. The client-assigned metric identifier.
-      #     Examples: +"error_count"+, +"nginx/requests"+.
+      #     Examples: `"error_count"`, `"nginx/requests"`.
       #
       #     Metric identifiers are limited to 100 characters and can include
-      #     only the following characters: +A-Z+, +a-z+, +0-9+, and the
-      #     special characters +_-.,+!*',()%/+.  The forward-slash character
-      #     (+/+) denotes a hierarchy of name pieces, and it cannot be the
+      #     only the following characters: `A-Z`, `a-z`, `0-9`, and the
+      #     special characters `_-.,+!*',()%/`.  The forward-slash character
+      #     (`/`) denotes a hierarchy of name pieces, and it cannot be the
       #     first character of the name.
       #
       #     The metric identifier in this field must not be
       #     [URL-encoded](https://en.wikipedia.org/wiki/Percent-encoding).
-      #     However, when the metric identifier appears as the +[METRIC_ID]+
-      #     part of a +metric_name+ API parameter, then the metric identifier
+      #     However, when the metric identifier appears as the `[METRIC_ID]`
+      #     part of a `metric_name` API parameter, then the metric identifier
       #     must be URL-encoded. Example:
-      #     +"projects/my-project/metrics/nginx%2Frequests"+.
+      #     `"projects/my-project/metrics/nginx%2Frequests"`.
       # @!attribute [rw] description
       #   @return [String]
       #     Optional. A description of this metric, which is used in documentation.
@@ -57,30 +57,30 @@ module Google
       #     Optional. The metric descriptor associated with the logs-based metric.
       #     If unspecified, it uses a default metric descriptor with a DELTA metric
       #     kind, INT64 value type, with no labels and a unit of "1". Such a metric
-      #     counts the number of log entries matching the +filter+ expression.
+      #     counts the number of log entries matching the `filter` expression.
       #
-      #     The +name+, +type+, and +description+ fields in the +metric_descriptor+
-      #     are output only, and is constructed using the +name+ and +description+
+      #     The `name`, `type`, and `description` fields in the `metric_descriptor`
+      #     are output only, and is constructed using the `name` and `description`
       #     field in the LogMetric.
       #
       #     To create a logs-based metric that records a distribution of log values, a
       #     DELTA metric kind with a DISTRIBUTION value type must be used along with
-      #     a +value_extractor+ expression in the LogMetric.
+      #     a `value_extractor` expression in the LogMetric.
       #
       #     Each label in the metric descriptor must have a matching label
       #     name as the key and an extractor expression as the value in the
-      #     +label_extractors+ map.
+      #     `label_extractors` map.
       #
-      #     The +metric_kind+ and +value_type+ fields in the +metric_descriptor+ cannot
+      #     The `metric_kind` and `value_type` fields in the `metric_descriptor` cannot
       #     be updated once initially configured. New labels can be added in the
-      #     +metric_descriptor+, but existing labels cannot be modified except for
+      #     `metric_descriptor`, but existing labels cannot be modified except for
       #     their description.
       # @!attribute [rw] value_extractor
       #   @return [String]
-      #     Optional. A +value_extractor+ is required when using a distribution
+      #     Optional. A `value_extractor` is required when using a distribution
       #     logs-based metric to extract the values to record from a log entry.
-      #     Two functions are supported for value extraction: +EXTRACT(field)+ or
-      #     +REGEXP_EXTRACT(field, regex)+. The argument are:
+      #     Two functions are supported for value extraction: `EXTRACT(field)` or
+      #     `REGEXP_EXTRACT(field, regex)`. The argument are:
       #       1. field: The name of the log entry field from which the value is to be
       #          extracted.
       #       2. regex: A regular expression using the Google RE2 syntax
@@ -95,26 +95,26 @@ module Google
       #     the conversion to double fails, then those values are not recorded in the
       #     distribution.
       #
-      #     Example: +REGEXP_EXTRACT(jsonPayload.request, ".*quantity=(\d+).*")+
+      #     Example: `REGEXP_EXTRACT(jsonPayload.request, ".*quantity=(\d+).*")`
       # @!attribute [rw] label_extractors
       #   @return [Hash{String => String}]
       #     Optional. A map from a label key string to an extractor expression which is
       #     used to extract data from a log entry field and assign as the label value.
       #     Each label key specified in the LabelDescriptor must have an associated
       #     extractor expression in this map. The syntax of the extractor expression
-      #     is the same as for the +value_extractor+ field.
+      #     is the same as for the `value_extractor` field.
       #
       #     The extracted value is converted to the type defined in the label
       #     descriptor. If the either the extraction or the type conversion fails,
       #     the label will have a default value. The default value for a string
       #     label is an empty string, for an integer label its 0, and for a boolean
-      #     label its +false+.
+      #     label its `false`.
       #
       #     Note that there are upper bounds on the maximum number of labels and the
       #     number of active time series that are allowed in a project.
       # @!attribute [rw] bucket_options
       #   @return [Google::Api::Distribution::BucketOptions]
-      #     Optional. The +bucket_options+ are required when the logs-based metric is
+      #     Optional. The `bucket_options` are required when the logs-based metric is
       #     using a DISTRIBUTION value type and it describes the bucket boundaries
       #     used to create a histogram of the extracted values.
       # @!attribute [rw] version
@@ -141,13 +141,13 @@ module Google
       # @!attribute [rw] page_token
       #   @return [String]
       #     Optional. If present, then retrieve the next batch of results from the
-      #     preceding call to this method.  +pageToken+ must be the value of
-      #     +nextPageToken+ from the previous response.  The values of other method
+      #     preceding call to this method.  `pageToken` must be the value of
+      #     `nextPageToken` from the previous response.  The values of other method
       #     parameters should be identical to those in the previous call.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Optional. The maximum number of results to return from this request.
-      #     Non-positive values are ignored.  The presence of +nextPageToken+ in the
+      #     Non-positive values are ignored.  The presence of `nextPageToken` in the
       #     response indicates that more results might be available.
       class ListLogMetricsRequest; end
 
@@ -158,8 +158,8 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there might be more results than appear in this response, then
-      #     +nextPageToken+ is included.  To get the next set of results, call this
-      #     method again using the value of +nextPageToken+ as +pageToken+.
+      #     `nextPageToken` is included.  To get the next set of results, call this
+      #     method again using the value of `nextPageToken` as `pageToken`.
       class ListLogMetricsResponse; end
 
       # The parameters to GetLogMetric.
@@ -192,8 +192,8 @@ module Google
       #         "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
       #
       #     The updated metric must be provided in the request and it's
-      #     +name+ field must be the same as +[METRIC_ID]+ If the metric
-      #     does not exist in +[PROJECT_ID]+, then a new metric is created.
+      #     `name` field must be the same as `[METRIC_ID]` If the metric
+      #     does not exist in `[PROJECT_ID]`, then a new metric is created.
       # @!attribute [rw] metric
       #   @return [Google::Logging::V2::LogMetric]
       #     The updated metric.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/struct.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/logging_service_v2_client.rb
@@ -269,9 +269,9 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
           #       "folders/[FOLDER_ID]/logs/[LOG_ID]"
           #
-          #   +[LOG_ID]+ must be URL-encoded. For example,
-          #   +"projects/my-project-id/logs/syslog"+,
-          #   +"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"+.
+          #   `[LOG_ID]` must be URL-encoded. For example,
+          #   `"projects/my-project-id/logs/syslog"`,
+          #   `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
           #   For more information about log names, see
           #   {Google::Logging::V2::LogEntry LogEntry}.
           # @param options [Google::Gax::CallOptions]
@@ -312,46 +312,46 @@ module Google
           # @param entries [Array<Google::Logging::V2::LogEntry | Hash>]
           #   Required. The log entries to send to Stackdriver Logging. The order of log
           #   entries in this list does not matter. Values supplied in this method's
-          #   +log_name+, +resource+, and +labels+ fields are copied into those log
+          #   `log_name`, `resource`, and `labels` fields are copied into those log
           #   entries in this list that do not include values for their corresponding
           #   fields. For more information, see the
           #   {Google::Logging::V2::LogEntry LogEntry} type.
           #
-          #   If the +timestamp+ or +insert_id+ fields are missing in log entries, then
+          #   If the `timestamp` or `insert_id` fields are missing in log entries, then
           #   this method supplies the current time or a unique identifier, respectively.
           #   The supplied values are chosen so that, among the log entries that did not
           #   supply their own values, the entries earlier in the list will sort before
-          #   the entries later in the list. See the +entries.list+ method.
+          #   the entries later in the list. See the `entries.list` method.
           #
           #   Log entries with timestamps that are more than the
           #   [logs retention period](https://cloud.google.com/logging/quota-policy) in the past or more than
-          #   24 hours in the future will not be available when calling +entries.list+.
+          #   24 hours in the future will not be available when calling `entries.list`.
           #   However, those log entries can still be exported with
           #   [LogSinks](https://cloud.google.com/logging/docs/api/tasks/exporting-logs).
           #
           #   To improve throughput and to avoid exceeding the
-          #   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to +entries.write+,
+          #   [quota limit](https://cloud.google.com/logging/quota-policy) for calls to `entries.write`,
           #   you should try to include several log entries in this list,
           #   rather than calling this method for each individual log entry.
           #   A hash of the same form as `Google::Logging::V2::LogEntry`
           #   can also be provided.
           # @param log_name [String]
           #   Optional. A default log resource name that is assigned to all log entries
-          #   in +entries+ that do not specify a value for +log_name+:
+          #   in `entries` that do not specify a value for `log_name`:
           #
           #       "projects/[PROJECT_ID]/logs/[LOG_ID]"
           #       "organizations/[ORGANIZATION_ID]/logs/[LOG_ID]"
           #       "billingAccounts/[BILLING_ACCOUNT_ID]/logs/[LOG_ID]"
           #       "folders/[FOLDER_ID]/logs/[LOG_ID]"
           #
-          #   +[LOG_ID]+ must be URL-encoded. For example,
-          #   +"projects/my-project-id/logs/syslog"+ or
-          #   +"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"+.
+          #   `[LOG_ID]` must be URL-encoded. For example,
+          #   `"projects/my-project-id/logs/syslog"` or
+          #   `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
           #   For more information about log names, see
           #   {Google::Logging::V2::LogEntry LogEntry}.
           # @param resource [Google::Api::MonitoredResource | Hash]
           #   Optional. A default monitored resource object that is assigned to all log
-          #   entries in +entries+ that do not specify a value for +resource+. Example:
+          #   entries in `entries` that do not specify a value for `resource`. Example:
           #
           #       { "type": "gce_instance",
           #         "labels": {
@@ -361,8 +361,8 @@ module Google
           #   A hash of the same form as `Google::Api::MonitoredResource`
           #   can also be provided.
           # @param labels [Hash{String => String}]
-          #   Optional. Default labels that are added to the +labels+ field of all log
-          #   entries in +entries+. If a log entry already has a label with the same key
+          #   Optional. Default labels that are added to the `labels` field of all log
+          #   entries in `entries`. If a log entry already has a label with the same key
           #   as a label in this parameter, then the log entry's label is not changed.
           #   See {Google::Logging::V2::LogEntry LogEntry}.
           # @param partial_success [true, false]
@@ -370,7 +370,7 @@ module Google
           #   entries fail due to INVALID_ARGUMENT or PERMISSION_DENIED errors. If any
           #   entry is not written, then the response status is the error associated
           #   with one of the failed entries and the response includes error details
-          #   keyed by the entries' zero-based index in the +entries.write+ method.
+          #   keyed by the entries' zero-based index in the `entries.write` method.
           # @param dry_run [true, false]
           #   Optional. If true, the request should expect normal response, but the
           #   entries won't be persisted nor exported. Useful for checking whether the
@@ -388,7 +388,7 @@ module Google
           #
           #   logging_service_v2_client = Google::Cloud::Logging::V2::LoggingServiceV2Client.new
           #
-          #   # TODO: Initialize +entries+:
+          #   # TODO: Initialize `entries`:
           #   entries = []
           #   response = logging_service_v2_client.write_log_entries(entries)
 
@@ -426,28 +426,28 @@ module Google
           #       "billingAccounts/[BILLING_ACCOUNT_ID]"
           #       "folders/[FOLDER_ID]"
           #
-          #   Projects listed in the +project_ids+ field are added to this list.
+          #   Projects listed in the `project_ids` field are added to this list.
           # @param project_ids [Array<String>]
-          #   Deprecated. Use +resource_names+ instead.  One or more project identifiers
+          #   Deprecated. Use `resource_names` instead.  One or more project identifiers
           #   or project numbers from which to retrieve log entries.  Example:
-          #   +"my-project-1A"+. If present, these project identifiers are converted to
+          #   `"my-project-1A"`. If present, these project identifiers are converted to
           #   resource name format and added to the list of resources in
-          #   +resource_names+.
+          #   `resource_names`.
           # @param filter [String]
           #   Optional. A filter that chooses which log entries to return.  See [Advanced
           #   Logs Filters](/logging/docs/view/advanced_filters).  Only log entries that
           #   match the filter are returned.  An empty filter matches all log entries in
-          #   the resources listed in +resource_names+. Referencing a parent resource
-          #   that is not listed in +resource_names+ will cause the filter to return no
+          #   the resources listed in `resource_names`. Referencing a parent resource
+          #   that is not listed in `resource_names` will cause the filter to return no
           #   results.
           #   The maximum length of the filter is 20000 characters.
           # @param order_by [String]
           #   Optional. How the results should be sorted.  Presently, the only permitted
-          #   values are +"timestamp asc"+ (default) and +"timestamp desc"+. The first
+          #   values are `"timestamp asc"` (default) and `"timestamp desc"`. The first
           #   option returns entries in order of increasing values of
-          #   +LogEntry.timestamp+ (oldest first), and the second option returns entries
+          #   `LogEntry.timestamp` (oldest first), and the second option returns entries
           #   in order of decreasing timestamps (newest first).  Entries with equal
-          #   timestamps are returned in order of their +insert_id+ values.
+          #   timestamps are returned in order of their `insert_id` values.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -471,7 +471,7 @@ module Google
           #
           #   logging_service_v2_client = Google::Cloud::Logging::V2::LoggingServiceV2Client.new
           #
-          #   # TODO: Initialize +formatted_resource_names+:
+          #   # TODO: Initialize `formatted_resource_names`:
           #   formatted_resource_names = []
           #
           #   # Iterate over all results.

--- a/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/v2/metrics_service_v2_client.rb
@@ -350,7 +350,7 @@ module Google
           #   metrics_service_v2_client = Google::Cloud::Logging::V2::MetricsServiceV2Client.new
           #   formatted_parent = Google::Cloud::Logging::V2::MetricsServiceV2Client.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +metric+:
+          #   # TODO: Initialize `metric`:
           #   metric = {}
           #   response = metrics_service_v2_client.create_log_metric(formatted_parent, metric)
 
@@ -375,8 +375,8 @@ module Google
           #       "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
           #
           #   The updated metric must be provided in the request and it's
-          #   +name+ field must be the same as +[METRIC_ID]+ If the metric
-          #   does not exist in +[PROJECT_ID]+, then a new metric is created.
+          #   `name` field must be the same as `[METRIC_ID]` If the metric
+          #   does not exist in `[PROJECT_ID]`, then a new metric is created.
           # @param metric [Google::Logging::V2::LogMetric | Hash]
           #   The updated metric.
           #   A hash of the same form as `Google::Logging::V2::LogMetric`
@@ -395,7 +395,7 @@ module Google
           #   metrics_service_v2_client = Google::Cloud::Logging::V2::MetricsServiceV2Client.new
           #   formatted_metric_name = Google::Cloud::Logging::V2::MetricsServiceV2Client.metric_path("[PROJECT]", "[METRIC]")
           #
-          #   # TODO: Initialize +metric+:
+          #   # TODO: Initialize `metric`:
           #   metric = {}
           #   response = metrics_service_v2_client.update_log_metric(formatted_metric_name, metric)
 

--- a/google-cloud-logging/synth.py
+++ b/google-cloud-logging/synth.py
@@ -66,10 +66,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/alert_policy_service_client.rb
@@ -281,7 +281,7 @@ module Google
           #   filtering](/monitoring/api/v3/sorting-and-filtering).
           # @param order_by [String]
           #   A comma-separated list of fields by which to sort the result. Supports
-          #   the same set of field references as the +filter+ field. Entries can be
+          #   the same set of field references as the `filter` field. Entries can be
           #   prefixed with a minus sign to sort by the field in descending order.
           #
           #   For more details, see [sorting and
@@ -376,15 +376,15 @@ module Google
           #
           # @param name [String]
           #   The project in which to create the alerting policy. The format is
-          #   +projects/[PROJECT_ID]+.
+          #   `projects/[PROJECT_ID]`.
           #
           #   Note that this field names the parent container in which the alerting
           #   policy will be written, not the name of the created policy. The alerting
           #   policy that is returned will have a name that contains a normalized
           #   representation of this name as a prefix but adds a suffix of the form
-          #   +/alertPolicies/[POLICY_ID]+, identifying the policy in the container.
+          #   `/alertPolicies/[POLICY_ID]`, identifying the policy in the container.
           # @param alert_policy [Google::Monitoring::V3::AlertPolicy | Hash]
-          #   The requested alerting policy. You should omit the +name+ field in this
+          #   The requested alerting policy. You should omit the `name` field in this
           #   policy. The name will be returned in the new policy, including
           #   a new [ALERT_POLICY_ID] value.
           #   A hash of the same form as `Google::Monitoring::V3::AlertPolicy`
@@ -403,7 +403,7 @@ module Google
           #   alert_policy_service_client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::AlertPolicyServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +alert_policy+:
+          #   # TODO: Initialize `alert_policy`:
           #   alert_policy = {}
           #   response = alert_policy_service_client.create_alert_policy(formatted_name, alert_policy)
 
@@ -456,38 +456,38 @@ module Google
 
           # Updates an alerting policy. You can either replace the entire policy with
           # a new one or replace only certain fields in the current alerting policy by
-          # specifying the fields to be updated via +updateMask+. Returns the
+          # specifying the fields to be updated via `updateMask`. Returns the
           # updated alerting policy.
           #
           # @param alert_policy [Google::Monitoring::V3::AlertPolicy | Hash]
           #   Required. The updated alerting policy or the updated values for the
-          #   fields listed in +update_mask+.
-          #   If +update_mask+ is not empty, any fields in this policy that are
-          #   not in +update_mask+ are ignored.
+          #   fields listed in `update_mask`.
+          #   If `update_mask` is not empty, any fields in this policy that are
+          #   not in `update_mask` are ignored.
           #   A hash of the same form as `Google::Monitoring::V3::AlertPolicy`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
           #   Optional. A list of alerting policy field names. If this field is not
           #   empty, each listed field in the existing alerting policy is set to the
-          #   value of the corresponding field in the supplied policy (+alert_policy+),
+          #   value of the corresponding field in the supplied policy (`alert_policy`),
           #   or to the field's default value if the field is not in the supplied
           #   alerting policy.  Fields not listed retain their previous value.
           #
-          #   Examples of valid field masks include +display_name+, +documentation+,
-          #   +documentation.content+, +documentation.mime_type+, +user_labels+,
-          #   +user_label.nameofkey+, +enabled+, +conditions+, +combiner+, etc.
+          #   Examples of valid field masks include `display_name`, `documentation`,
+          #   `documentation.content`, `documentation.mime_type`, `user_labels`,
+          #   `user_label.nameofkey`, `enabled`, `conditions`, `combiner`, etc.
           #
           #   If this field is empty, then the supplied alerting policy replaces the
           #   existing policy. It is the same as deleting the existing policy and
           #   adding the supplied policy, except for the following:
           #
-          #   * The new policy will have the same +[ALERT_POLICY_ID]+ as the former
+          #   * The new policy will have the same `[ALERT_POLICY_ID]` as the former
           #     policy. This gives you continuity with the former policy in your
           #     notifications and incidents.
-          #   * Conditions in the new policy will keep their former +[CONDITION_ID]+ if
-          #     the supplied condition includes the +name+ field with that
-          #     +[CONDITION_ID]+. If the supplied condition omits the +name+ field,
-          #     then a new +[CONDITION_ID]+ is created.
+          #   * Conditions in the new policy will keep their former `[CONDITION_ID]` if
+          #     the supplied condition includes the `name` field with that
+          #     `[CONDITION_ID]`. If the supplied condition omits the `name` field,
+          #     then a new `[CONDITION_ID]` is created.
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -503,7 +503,7 @@ module Google
           #
           #   alert_policy_service_client = Google::Cloud::Monitoring::AlertPolicy.new(version: :v3)
           #
-          #   # TODO: Initialize +alert_policy+:
+          #   # TODO: Initialize `alert_policy`:
           #   alert_policy = {}
           #   response = alert_policy_service_client.update_alert_policy(alert_policy)
 

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/distribution.rb
@@ -29,13 +29,13 @@ module Google
     #
     # Although it is not forbidden, it is generally a bad idea to include
     # non-finite values (infinities or NaNs) in the population of values, as this
-    # will render the +mean+ and +sum_of_squared_deviation+ fields meaningless.
+    # will render the `mean` and `sum_of_squared_deviation` fields meaningless.
     # @!attribute [rw] count
     #   @return [Integer]
     #     The number of values in the population. Must be non-negative.
     # @!attribute [rw] mean
     #   @return [Float]
-    #     The arithmetic mean of the values in the population. If +count+ is zero
+    #     The arithmetic mean of the values in the population. If `count` is zero
     #     then this field must be zero.
     # @!attribute [rw] sum_of_squared_deviation
     #   @return [Float]
@@ -47,26 +47,26 @@ module Google
     #     Knuth, "The Art of Computer Programming", Vol. 2, page 323, 3rd edition
     #     describes Welford's method for accumulating this sum in one pass.
     #
-    #     If +count+ is zero then this field must be zero.
+    #     If `count` is zero then this field must be zero.
     # @!attribute [rw] range
     #   @return [Google::Api::Distribution::Range]
     #     If specified, contains the range of the population values. The field
-    #     must not be present if the +count+ is zero.
+    #     must not be present if the `count` is zero.
     # @!attribute [rw] bucket_options
     #   @return [Google::Api::Distribution::BucketOptions]
     #     Defines the histogram bucket boundaries.
     # @!attribute [rw] bucket_counts
     #   @return [Array<Integer>]
-    #     If +bucket_options+ is given, then the sum of the values in +bucket_counts+
-    #     must equal the value in +count+.  If +bucket_options+ is not given, no
-    #     +bucket_counts+ fields may be given.
+    #     If `bucket_options` is given, then the sum of the values in `bucket_counts`
+    #     must equal the value in `count`.  If `bucket_options` is not given, no
+    #     `bucket_counts` fields may be given.
     #
     #     Bucket counts are given in order under the numbering scheme described
     #     above (the underflow bucket has number 0; the finite buckets, if any,
     #     have numbers 1 through N-2; the overflow bucket has number N-1).
     #
-    #     The size of +bucket_counts+ must be no greater than N as defined in
-    #     +bucket_options+.
+    #     The size of `bucket_counts` must be no greater than N as defined in
+    #     `bucket_options`.
     #
     #     Any suffix of trailing zero bucket_count fields may be omitted.
     class Distribution
@@ -80,9 +80,9 @@ module Google
       class Range; end
 
       # A Distribution may optionally contain a histogram of the values in the
-      # population.  The histogram is given in +bucket_counts+ as counts of values
+      # population.  The histogram is given in `bucket_counts` as counts of values
       # that fall into one of a sequence of non-overlapping buckets.  The sequence
-      # of buckets is described by +bucket_options+.
+      # of buckets is described by `bucket_options`.
       #
       # A bucket specifies an inclusive lower bound and exclusive upper bound for
       # the values that are counted for that bucket.  The upper bound of a bucket
@@ -97,11 +97,11 @@ module Google
       # +infinity.  The finite buckets are so-called because both bounds are
       # finite.
       #
-      # +BucketOptions+ describes bucket boundaries in one of three ways.  Two
+      # `BucketOptions` describes bucket boundaries in one of three ways.  Two
       # describe the boundaries by giving parameters for a formula to generate
       # boundaries and one gives the bucket boundaries explicitly.
       #
-      # If +bucket_boundaries+ is not given, then no +bucket_counts+ may be given.
+      # If `bucket_boundaries` is not given, then no `bucket_counts` may be given.
       # @!attribute [rw] linear_buckets
       #   @return [Google::Api::Distribution::BucketOptions::Linear]
       #     The linear bucket.
@@ -116,8 +116,8 @@ module Google
         # overflow and underflow).  Each bucket represents a constant absolute
         # uncertainty on the specific value in the bucket.
         #
-        # Defines +num_finite_buckets + 2+ (= N) buckets with these boundaries for
-        # bucket +i+:
+        # Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
+        # bucket `i`:
         #
         #    Upper bound (0 <= i < N-1):     offset + (width * i).
         #    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
@@ -136,7 +136,7 @@ module Google
         # the value of the lower bound.  Each bucket represents a constant relative
         # uncertainty on a specific value in the bucket.
         #
-        # Defines +num_finite_buckets + 2+ (= N) buckets with these boundaries for
+        # Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
         # bucket i:
         #
         #    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
@@ -154,13 +154,13 @@ module Google
 
         # A set of buckets with arbitrary widths.
         #
-        # Defines +size(bounds) + 1+ (= N) buckets with these boundaries for
+        # Defines `size(bounds) + 1` (= N) buckets with these boundaries for
         # bucket i:
         #
         #    Upper bound (0 <= i < N-1):     bounds[i]
         #    Lower bound (1 <= i < N);       bounds[i - 1]
         #
-        # There must be at least one element in +bounds+.  If +bounds+ has only one
+        # There must be at least one element in `bounds`.  If `bounds` has only one
         # element, there are no finite buckets, and that single element is the
         # common boundary of the overflow and underflow buckets.
         # @!attribute [rw] bounds

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/metric.rb
@@ -25,7 +25,7 @@ module Google
     #   @return [String]
     #     The metric type, including its DNS name prefix. The type is not
     #     URL-encoded.  All user-defined custom metric types have the DNS name
-    #     +custom.googleapis.com+.  Metric types should use a natural hierarchical
+    #     `custom.googleapis.com`.  Metric types should use a natural hierarchical
     #     grouping. For example:
     #
     #         "custom.googleapis.com/invoice/paid/amount"
@@ -34,63 +34,63 @@ module Google
     #   @return [Array<Google::Api::LabelDescriptor>]
     #     The set of labels that can be used to describe a specific
     #     instance of this metric type. For example, the
-    #     +appengine.googleapis.com/http/server/response_latencies+ metric
-    #     type has a label for the HTTP response code, +response_code+, so
+    #     `appengine.googleapis.com/http/server/response_latencies` metric
+    #     type has a label for the HTTP response code, `response_code`, so
     #     you can look at latencies for successful responses or just
     #     for responses that failed.
     # @!attribute [rw] metric_kind
     #   @return [Google::Api::MetricDescriptor::MetricKind]
     #     Whether the metric records instantaneous values, changes to a value, etc.
-    #     Some combinations of +metric_kind+ and +value_type+ might not be supported.
+    #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] value_type
     #   @return [Google::Api::MetricDescriptor::ValueType]
     #     Whether the measurement is an integer, a floating-point number, etc.
-    #     Some combinations of +metric_kind+ and +value_type+ might not be supported.
+    #     Some combinations of `metric_kind` and `value_type` might not be supported.
     # @!attribute [rw] unit
     #   @return [String]
     #     The unit in which the metric value is reported. It is only applicable
-    #     if the +value_type+ is +INT64+, +DOUBLE+, or +DISTRIBUTION+. The
+    #     if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The
     #     supported units are a subset of [The Unified Code for Units of
     #     Measure](http://unitsofmeasure.org/ucum.html) standard:
     #
     #     **Basic units (UNIT)**
     #
-    #     * +bit+   bit
-    #     * +By+    byte
-    #     * +s+     second
-    #     * +min+   minute
-    #     * +h+     hour
-    #     * +d+     day
+    #     * `bit`   bit
+    #     * `By`    byte
+    #     * `s`     second
+    #     * `min`   minute
+    #     * `h`     hour
+    #     * `d`     day
     #
     #     **Prefixes (PREFIX)**
     #
-    #     * +k+     kilo    (10**3)
-    #     * +M+     mega    (10**6)
-    #     * +G+     giga    (10**9)
-    #     * +T+     tera    (10**12)
-    #     * +P+     peta    (10**15)
-    #     * +E+     exa     (10**18)
-    #     * +Z+     zetta   (10**21)
-    #     * +Y+     yotta   (10**24)
-    #     * +m+     milli   (10**-3)
-    #     * +u+     micro   (10**-6)
-    #     * +n+     nano    (10**-9)
-    #     * +p+     pico    (10**-12)
-    #     * +f+     femto   (10**-15)
-    #     * +a+     atto    (10**-18)
-    #     * +z+     zepto   (10**-21)
-    #     * +y+     yocto   (10**-24)
-    #     * +Ki+    kibi    (2**10)
-    #     * +Mi+    mebi    (2**20)
-    #     * +Gi+    gibi    (2**30)
-    #     * +Ti+    tebi    (2**40)
+    #     * `k`     kilo    (10**3)
+    #     * `M`     mega    (10**6)
+    #     * `G`     giga    (10**9)
+    #     * `T`     tera    (10**12)
+    #     * `P`     peta    (10**15)
+    #     * `E`     exa     (10**18)
+    #     * `Z`     zetta   (10**21)
+    #     * `Y`     yotta   (10**24)
+    #     * `m`     milli   (10**-3)
+    #     * `u`     micro   (10**-6)
+    #     * `n`     nano    (10**-9)
+    #     * `p`     pico    (10**-12)
+    #     * `f`     femto   (10**-15)
+    #     * `a`     atto    (10**-18)
+    #     * `z`     zepto   (10**-21)
+    #     * `y`     yocto   (10**-24)
+    #     * `Ki`    kibi    (2**10)
+    #     * `Mi`    mebi    (2**20)
+    #     * `Gi`    gibi    (2**30)
+    #     * `Ti`    tebi    (2**40)
     #
     #     **Grammar**
     #
     #     The grammar also includes these connectors:
     #
-    #     * +/+    division (as an infix operator, e.g. +1/s+).
-    #     * +.+    multiplication (as an infix operator, e.g. +GBy.d+)
+    #     * `/`    division (as an infix operator, e.g. `1/s`).
+    #     * `.`    multiplication (as an infix operator, e.g. `GBy.d`)
     #
     #     The grammar for a unit is as follows:
     #
@@ -105,13 +105,13 @@ module Google
     #
     #     Notes:
     #
-    #     * +Annotation+ is just a comment if it follows a +UNIT+ and is
-    #       equivalent to +1+ if it is used alone. For examples,
-    #       +\\{requests}/s == 1/s+, +By\\{transmitted}/s == By/s+.
-    #     * +NAME+ is a sequence of non-blank printable ASCII characters not
+    #     * `Annotation` is just a comment if it follows a `UNIT` and is
+    #       equivalent to `1` if it is used alone. For examples,
+    #       `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.
+    #     * `NAME` is a sequence of non-blank printable ASCII characters not
     #       containing '{' or '}'.
-    #     * +1+ represents dimensionless value 1, such as in +1/s+.
-    #     * +%+ represents dimensionless value 1/100, and annotates values giving
+    #     * `1` represents dimensionless value 1, such as in `1/s`.
+    #     * `%` represents dimensionless value 1/100, and annotates values giving
     #       a percentage.
     # @!attribute [rw] description
     #   @return [String]
@@ -148,7 +148,7 @@ module Google
         VALUE_TYPE_UNSPECIFIED = 0
 
         # The value is a boolean.
-        # This value type can be used only if the metric kind is +GAUGE+.
+        # This value type can be used only if the metric kind is `GAUGE`.
         BOOL = 1
 
         # The value is a signed 64-bit integer.
@@ -158,10 +158,10 @@ module Google
         DOUBLE = 3
 
         # The value is a text string.
-        # This value type can be used only if the metric kind is +GAUGE+.
+        # This value type can be used only if the metric kind is `GAUGE`.
         STRING = 4
 
-        # The value is a {Google::Api::Distribution +Distribution+}.
+        # The value is a {Google::Api::Distribution `Distribution`}.
         DISTRIBUTION = 5
 
         # The value is money.
@@ -170,15 +170,15 @@ module Google
     end
 
     # A specific metric, identified by specifying values for all of the
-    # labels of a {Google::Api::MetricDescriptor +MetricDescriptor+}.
+    # labels of a {Google::Api::MetricDescriptor `MetricDescriptor`}.
     # @!attribute [rw] type
     #   @return [String]
     #     An existing metric type, see {Google::Api::MetricDescriptor}.
-    #     For example, +custom.googleapis.com/invoice/paid/amount+.
+    #     For example, `custom.googleapis.com/invoice/paid/amount`.
     # @!attribute [rw] labels
     #   @return [Hash{String => String}]
     #     The set of label values that uniquely identify this metric. All
-    #     labels listed in the +MetricDescriptor+ must be assigned values.
+    #     labels listed in the `MetricDescriptor` must be assigned values.
     class Metric; end
   end
 end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/api/monitored_resource.rb
@@ -18,31 +18,31 @@ module Google
     # An object that describes the schema of a {Google::Api::MonitoredResource MonitoredResource} object using a
     # type name and a set of labels.  For example, the monitored resource
     # descriptor for Google Compute Engine VM instances has a type of
-    # +"gce_instance"+ and specifies the use of the labels +"instance_id"+ and
-    # +"zone"+ to identify particular VM instances.
+    # `"gce_instance"` and specifies the use of the labels `"instance_id"` and
+    # `"zone"` to identify particular VM instances.
     #
     # Different APIs can support different monitored resource types. APIs generally
-    # provide a +list+ method that returns the monitored resource descriptors used
+    # provide a `list` method that returns the monitored resource descriptors used
     # by the API.
     # @!attribute [rw] name
     #   @return [String]
     #     Optional. The resource name of the monitored resource descriptor:
-    #     +"projects/\\{project_id}/monitoredResourceDescriptors/\\{type}"+ where
-    #     \\{type} is the value of the +type+ field in this object and
+    #     `"projects/{project_id}/monitoredResourceDescriptors/{type}"` where
+    #     \\{type} is the value of the `type` field in this object and
     #     \\{project_id} is a project ID that provides API-specific context for
     #     accessing the type.  APIs that do not use project information can use the
-    #     resource name format +"monitoredResourceDescriptors/\\{type}"+.
+    #     resource name format `"monitoredResourceDescriptors/{type}"`.
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. For example, the type
-    #     +"cloudsql_database"+ represents databases in Google Cloud SQL.
+    #     `"cloudsql_database"` represents databases in Google Cloud SQL.
     #     The maximum length of this value is 256 characters.
     # @!attribute [rw] display_name
     #   @return [String]
     #     Optional. A concise name for the monitored resource type that might be
     #     displayed in user interfaces. It should be a Title Cased Noun Phrase,
     #     without any article or other determiners. For example,
-    #     +"Google Cloud SQL Database"+.
+    #     `"Google Cloud SQL Database"`.
     # @!attribute [rw] description
     #   @return [String]
     #     Optional. A detailed description of the monitored resource type that might
@@ -51,18 +51,18 @@ module Google
     #   @return [Array<Google::Api::LabelDescriptor>]
     #     Required. A set of labels used to describe instances of this monitored
     #     resource type. For example, an individual Google Cloud SQL database is
-    #     identified by values for the labels +"database_id"+ and +"zone"+.
+    #     identified by values for the labels `"database_id"` and `"zone"`.
     class MonitoredResourceDescriptor; end
 
     # An object representing a resource that can be used for monitoring, logging,
     # billing, or other purposes. Examples include virtual machine instances,
-    # databases, and storage devices such as disks. The +type+ field identifies a
+    # databases, and storage devices such as disks. The `type` field identifies a
     # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object that describes the resource's
-    # schema. Information in the +labels+ field identifies the actual resource and
+    # schema. Information in the `labels` field identifies the actual resource and
     # its attributes according to the schema. For example, a particular Compute
     # Engine VM instance could be represented by the following object, because the
-    # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} for +"gce_instance"+ has labels
-    # +"instance_id"+ and +"zone"+:
+    # {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} for `"gce_instance"` has labels
+    # `"instance_id"` and `"zone"`:
     #
     #     { "type": "gce_instance",
     #       "labels": { "instance_id": "12345678901234",
@@ -70,13 +70,13 @@ module Google
     # @!attribute [rw] type
     #   @return [String]
     #     Required. The monitored resource type. This field must match
-    #     the +type+ field of a {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object. For
-    #     example, the type of a Compute Engine VM instance is +gce_instance+.
+    #     the `type` field of a {Google::Api::MonitoredResourceDescriptor MonitoredResourceDescriptor} object. For
+    #     example, the type of a Compute Engine VM instance is `gce_instance`.
     # @!attribute [rw] labels
     #   @return [Hash{String => String}]
     #     Required. Values for all of the labels listed in the associated monitored
     #     resource descriptor. For example, Compute Engine VM instances use the
-    #     labels +"project_id"+, +"instance_id"+, and +"zone"+.
+    #     labels `"project_id"`, `"instance_id"`, and `"zone"`.
     class MonitoredResource; end
 
     # Auxiliary metadata for a {Google::Api::MonitoredResource MonitoredResource} object.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert.rb
@@ -27,10 +27,10 @@ module Google
       #
       #         projects/[PROJECT_ID]/alertPolicies/[ALERT_POLICY_ID]
       #
-      #     +[ALERT_POLICY_ID]+ is assigned by Stackdriver Monitoring when the policy
+      #     `[ALERT_POLICY_ID]` is assigned by Stackdriver Monitoring when the policy
       #     is created.  When calling the
       #     {Google::Monitoring::V3::AlertPolicyService::CreateAlertPolicy alertPolicies::create}
-      #     method, do not include the +name+ field in the alerting policy passed as
+      #     method, do not include the `name` field in the alerting policy passed as
       #     part of the request.
       # @!attribute [rw] display_name
       #   @return [String]
@@ -48,7 +48,7 @@ module Google
       # @!attribute [rw] user_labels
       #   @return [Hash{String => String}]
       #     User-supplied key/value data to be used for organizing and
-      #     identifying the +AlertPolicy+ objects.
+      #     identifying the `AlertPolicy` objects.
       #
       #     The field can contain up to 64 entries. Each key and value is limited to
       #     63 Unicode characters or 128 bytes, whichever is smaller. Labels and
@@ -57,7 +57,7 @@ module Google
       # @!attribute [rw] conditions
       #   @return [Array<Google::Monitoring::V3::AlertPolicy::Condition>]
       #     A list of conditions for the policy. The conditions are combined by AND or
-      #     OR according to the +combiner+ field. If the combined conditions evaluate
+      #     OR according to the `combiner` field. If the combined conditions evaluate
       #     to true, then an incident is created. A policy can have from one to six
       #     conditions.
       # @!attribute [rw] combiner
@@ -76,9 +76,9 @@ module Google
       #     Identifies the notification channels to which notifications should be sent
       #     when incidents are opened or closed or when new violations occur on
       #     an already opened incident. Each element of this array corresponds to
-      #     the +name+ field in each of the
-      #     {Google::Monitoring::V3::NotificationChannel +NotificationChannel+}
-      #     objects that are returned from the [+ListNotificationChannels+]
+      #     the `name` field in each of the
+      #     {Google::Monitoring::V3::NotificationChannel `NotificationChannel`}
+      #     objects that are returned from the [`ListNotificationChannels`]
       #     [google.monitoring.v3.NotificationChannelService.ListNotificationChannels]
       #     method. The syntax of the entries in this field is:
       #
@@ -96,14 +96,14 @@ module Google
         # format.
         # @!attribute [rw] content
         #   @return [String]
-        #     The text of the documentation, interpreted according to +mime_type+.
+        #     The text of the documentation, interpreted according to `mime_type`.
         #     The content may not exceed 8,192 Unicode characters and may not exceed
         #     more than 10,240 bytes when encoded in UTF-8 format, whichever is
         #     smaller.
         # @!attribute [rw] mime_type
         #   @return [String]
-        #     The format of the +content+ field. Presently, only the value
-        #     +"text/markdown"+ is supported. See
+        #     The format of the `content` field. Presently, only the value
+        #     `"text/markdown"` is supported. See
         #     [Markdown](https://en.wikipedia.org/wiki/Markdown) for more information.
         class Documentation; end
 
@@ -117,23 +117,23 @@ module Google
         #
         #         projects/[PROJECT_ID]/alertPolicies/[POLICY_ID]/conditions/[CONDITION_ID]
         #
-        #     +[CONDITION_ID]+ is assigned by Stackdriver Monitoring when the
+        #     `[CONDITION_ID]` is assigned by Stackdriver Monitoring when the
         #     condition is created as part of a new or updated alerting policy.
         #
         #     When calling the
         #     {Google::Monitoring::V3::AlertPolicyService::CreateAlertPolicy alertPolicies::create}
-        #     method, do not include the +name+ field in the conditions of the
+        #     method, do not include the `name` field in the conditions of the
         #     requested alerting policy. Stackdriver Monitoring creates the
         #     condition identifiers and includes them in the new policy.
         #
         #     When calling the
         #     {Google::Monitoring::V3::AlertPolicyService::UpdateAlertPolicy alertPolicies::update}
-        #     method to update a policy, including a condition +name+ causes the
+        #     method to update a policy, including a condition `name` causes the
         #     existing condition to be updated. Conditions without names are added to
         #     the updated policy. Existing conditions are deleted if they are not
         #     updated.
         #
-        #     Best practice is to preserve +[CONDITION_ID]+ if you make only small
+        #     Best practice is to preserve `[CONDITION_ID]` if you make only small
         #     changes, such as those to condition thresholds, durations, or trigger
         #     values.  Otherwise, treat the change as a new condition and let the
         #     existing condition be deleted.
@@ -151,7 +151,7 @@ module Google
         #     receive new data points.
         class Condition
           # Specifies how many time series must fail a predicate to trigger a
-          # condition. If not specified, then a +{count: 1}+ trigger is used.
+          # condition. If not specified, then a `{count: 1}` trigger is used.
           # @!attribute [rw] count
           #   @return [Integer]
           #     The absolute number of time series that must fail
@@ -170,7 +170,7 @@ module Google
           #     identifies which time series should be compared with the threshold.
           #
           #     The filter is similar to the one that is specified in the
-          #     [+MetricService.ListTimeSeries+
+          #     [`MetricService.ListTimeSeries`
           #     request](/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list) (that
           #     call is useful to verify the time series that will be retrieved /
           #     processed) and must specify the metric type and optionally may contain
@@ -186,18 +186,18 @@ module Google
           #     are applied in the order specified.
           #
           #     This field is similar to the one in the
-          #     [+MetricService.ListTimeSeries+ request](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).
-          #     It is advisable to use the +ListTimeSeries+ method when debugging this field.
+          #     [`MetricService.ListTimeSeries` request](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).
+          #     It is advisable to use the `ListTimeSeries` method when debugging this field.
           # @!attribute [rw] denominator_filter
           #   @return [String]
           #     A [filter](https://cloud.google.com/monitoring/api/v3/filters) that identifies a time
           #     series that should be used as the denominator of a ratio that will be
-          #     compared with the threshold. If a +denominator_filter+ is specified,
-          #     the time series specified by the +filter+ field will be used as the
+          #     compared with the threshold. If a `denominator_filter` is specified,
+          #     the time series specified by the `filter` field will be used as the
           #     numerator.
           #
           #     The filter is similar to the one that is specified in the
-          #     [+MetricService.ListTimeSeries+
+          #     [`MetricService.ListTimeSeries`
           #     request](/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list) (that
           #     call is useful to verify the time series that will be retrieved /
           #     processed) and must specify the metric type and optionally may contain
@@ -206,29 +206,29 @@ module Google
           # @!attribute [rw] denominator_aggregations
           #   @return [Array<Google::Monitoring::V3::Aggregation>]
           #     Specifies the alignment of data points in individual time series
-          #     selected by +denominatorFilter+ as
+          #     selected by `denominatorFilter` as
           #     well as how to combine the retrieved time series together (such as
           #     when aggregating multiple streams on each resource to a single
           #     stream for each resource or when aggregating streams across all
           #     members of a group of resources).
           #
-          #     When computing ratios, the +aggregations+ and
-          #     +denominator_aggregations+ fields must use the same alignment period
+          #     When computing ratios, the `aggregations` and
+          #     `denominator_aggregations` fields must use the same alignment period
           #     and produce time series that have the same periodicity and labels.
           #
           #     This field is similar to the one in the
-          #     [+MetricService.ListTimeSeries+
+          #     [`MetricService.ListTimeSeries`
           #     request](/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list). It
-          #     is advisable to use the +ListTimeSeries+ method when debugging this
+          #     is advisable to use the `ListTimeSeries` method when debugging this
           #     field.
           # @!attribute [rw] comparison
           #   @return [Google::Monitoring::V3::ComparisonType]
-          #     The comparison to apply between the time series (indicated by +filter+
-          #     and +aggregation+) and the threshold (indicated by +threshold_value+).
+          #     The comparison to apply between the time series (indicated by `filter`
+          #     and `aggregation`) and the threshold (indicated by `threshold_value`).
           #     The comparison is applied on each time series, with the time series
           #     on the left-hand side and the threshold on the right-hand side.
           #
-          #     Only +COMPARISON_LT+ and +COMPARISON_GT+ are supported currently.
+          #     Only `COMPARISON_LT` and `COMPARISON_GT` are supported currently.
           # @!attribute [rw] threshold_value
           #   @return [Float]
           #     A value against which to compare the time series.
@@ -241,7 +241,7 @@ module Google
           #     error will be returned. When choosing a duration, it is useful to
           #     keep in mind the frequency of the underlying time series data
           #     (which may also be affected by any alignments specified in the
-          #     +aggregations+ field); a good duration is long enough so that a single
+          #     `aggregations` field); a good duration is long enough so that a single
           #     outlier does not generate spurious alerts, but short enough that
           #     unhealthy states are detected and alerted on quickly.
           # @!attribute [rw] trigger
@@ -249,8 +249,8 @@ module Google
           #     The number/percent of time series for which the comparison must hold
           #     in order for the condition to trigger. If unspecified, then the
           #     condition will trigger if the comparison is true for any of the
-          #     time series that have been identified by +filter+ and +aggregations+,
-          #     or by the ratio, if +denominator_filter+ and +denominator_aggregations+
+          #     time series that have been identified by `filter` and `aggregations`,
+          #     or by the ratio, if `denominator_filter` and `denominator_aggregations`
           #     are specified.
           class MetricThreshold; end
 
@@ -258,14 +258,14 @@ module Google
           # are reporting data. The configuration defines a metric and
           # a set of monitored resources. The predicate is considered in violation
           # when a time series for the specified metric of a monitored
-          # resource does not include any data in the specified +duration+.
+          # resource does not include any data in the specified `duration`.
           # @!attribute [rw] filter
           #   @return [String]
           #     A [filter](https://cloud.google.com/monitoring/api/v3/filters) that
           #     identifies which time series should be compared with the threshold.
           #
           #     The filter is similar to the one that is specified in the
-          #     [+MetricService.ListTimeSeries+
+          #     [`MetricService.ListTimeSeries`
           #     request](/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list) (that
           #     call is useful to verify the time series that will be retrieved /
           #     processed) and must specify the metric type and optionally may contain
@@ -281,22 +281,22 @@ module Google
           #     are applied in the order specified.
           #
           #     This field is similar to the
-          #     one in the [+MetricService.ListTimeSeries+ request](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).
-          #     It is advisable to use the +ListTimeSeries+ method when debugging this field.
+          #     one in the [`MetricService.ListTimeSeries` request](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/list).
+          #     It is advisable to use the `ListTimeSeries` method when debugging this field.
           # @!attribute [rw] duration
           #   @return [Google::Protobuf::Duration]
           #     The amount of time that a time series must fail to report new
           #     data to be considered failing. Currently, only values that
           #     are a multiple of a minute--e.g.  60, 120, or 300
           #     seconds--are supported. If an invalid value is given, an
-          #     error will be returned. The +Duration.nanos+ field is
+          #     error will be returned. The `Duration.nanos` field is
           #     ignored.
           # @!attribute [rw] trigger
           #   @return [Google::Monitoring::V3::AlertPolicy::Condition::Trigger]
           #     The number/percent of time series for which the comparison must hold
           #     in order for the condition to trigger. If unspecified, then the
           #     condition will trigger if the comparison is true for any of the
-          #     time series that have been identified by +filter+ and +aggregations+.
+          #     time series that have been identified by `filter` and `aggregations`.
           class MetricAbsence; end
         end
 
@@ -305,18 +305,18 @@ module Google
           # An unspecified combiner.
           COMBINE_UNSPECIFIED = 0
 
-          # Combine conditions using the logical +AND+ operator. An
+          # Combine conditions using the logical `AND` operator. An
           # incident is created only if all conditions are met
           # simultaneously. This combiner is satisfied if all conditions are
           # met, even if they are met on completely different resources.
           AND = 1
 
-          # Combine conditions using the logical +OR+ operator. An incident
+          # Combine conditions using the logical `OR` operator. An incident
           # is created if any of the listed conditions is met.
           OR = 2
 
-          # Combine conditions using logical +AND+ operator, but unlike the regular
-          # +AND+ option, an incident is created only if all conditions are met
+          # Combine conditions using logical `AND` operator, but unlike the regular
+          # `AND` option, an incident is created only if all conditions are met
           # simultaneously on at least one resource.
           AND_WITH_MATCHING_RESOURCE = 3
         end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/alert_service.rb
@@ -16,25 +16,25 @@
 module Google
   module Monitoring
     module V3
-      # The protocol for the +CreateAlertPolicy+ request.
+      # The protocol for the `CreateAlertPolicy` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project in which to create the alerting policy. The format is
-      #     +projects/[PROJECT_ID]+.
+      #     `projects/[PROJECT_ID]`.
       #
       #     Note that this field names the parent container in which the alerting
       #     policy will be written, not the name of the created policy. The alerting
       #     policy that is returned will have a name that contains a normalized
       #     representation of this name as a prefix but adds a suffix of the form
-      #     +/alertPolicies/[POLICY_ID]+, identifying the policy in the container.
+      #     `/alertPolicies/[POLICY_ID]`, identifying the policy in the container.
       # @!attribute [rw] alert_policy
       #   @return [Google::Monitoring::V3::AlertPolicy]
-      #     The requested alerting policy. You should omit the +name+ field in this
+      #     The requested alerting policy. You should omit the `name` field in this
       #     policy. The name will be returned in the new policy, including
       #     a new [ALERT_POLICY_ID] value.
       class CreateAlertPolicyRequest; end
 
-      # The protocol for the +GetAlertPolicy+ request.
+      # The protocol for the `GetAlertPolicy` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The alerting policy to retrieve. The format is
@@ -42,7 +42,7 @@ module Google
       #         projects/[PROJECT_ID]/alertPolicies/[ALERT_POLICY_ID]
       class GetAlertPolicyRequest; end
 
-      # The protocol for the +ListAlertPolicies+ request.
+      # The protocol for the `ListAlertPolicies` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project whose alert policies are to be listed. The format is
@@ -64,7 +64,7 @@ module Google
       # @!attribute [rw] order_by
       #   @return [String]
       #     A comma-separated list of fields by which to sort the result. Supports
-      #     the same set of field references as the +filter+ field. Entries can be
+      #     the same set of field references as the `filter` field. Entries can be
       #     prefixed with a minus sign to sort by the field in descending order.
       #
       #     For more details, see [sorting and
@@ -74,12 +74,12 @@ module Google
       #     The maximum number of results to return in a single response.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return more results from the previous method call.
       class ListAlertPoliciesRequest; end
 
-      # The protocol for the +ListAlertPolicies+ response.
+      # The protocol for the `ListAlertPolicies` response.
       # @!attribute [rw] alert_policies
       #   @return [Array<Google::Monitoring::V3::AlertPolicy>]
       #     The returned alert policies.
@@ -87,42 +87,42 @@ module Google
       #   @return [String]
       #     If there might be more results than were returned, then this field is set
       #     to a non-empty value. To see the additional results,
-      #     use that value as +pageToken+ in the next call to this method.
+      #     use that value as `pageToken` in the next call to this method.
       class ListAlertPoliciesResponse; end
 
-      # The protocol for the +UpdateAlertPolicy+ request.
+      # The protocol for the `UpdateAlertPolicy` request.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     Optional. A list of alerting policy field names. If this field is not
       #     empty, each listed field in the existing alerting policy is set to the
-      #     value of the corresponding field in the supplied policy (+alert_policy+),
+      #     value of the corresponding field in the supplied policy (`alert_policy`),
       #     or to the field's default value if the field is not in the supplied
       #     alerting policy.  Fields not listed retain their previous value.
       #
-      #     Examples of valid field masks include +display_name+, +documentation+,
-      #     +documentation.content+, +documentation.mime_type+, +user_labels+,
-      #     +user_label.nameofkey+, +enabled+, +conditions+, +combiner+, etc.
+      #     Examples of valid field masks include `display_name`, `documentation`,
+      #     `documentation.content`, `documentation.mime_type`, `user_labels`,
+      #     `user_label.nameofkey`, `enabled`, `conditions`, `combiner`, etc.
       #
       #     If this field is empty, then the supplied alerting policy replaces the
       #     existing policy. It is the same as deleting the existing policy and
       #     adding the supplied policy, except for the following:
       #
-      #     * The new policy will have the same +[ALERT_POLICY_ID]+ as the former
+      #     * The new policy will have the same `[ALERT_POLICY_ID]` as the former
       #       policy. This gives you continuity with the former policy in your
       #       notifications and incidents.
-      #     * Conditions in the new policy will keep their former +[CONDITION_ID]+ if
-      #       the supplied condition includes the +name+ field with that
-      #       +[CONDITION_ID]+. If the supplied condition omits the +name+ field,
-      #       then a new +[CONDITION_ID]+ is created.
+      #     * Conditions in the new policy will keep their former `[CONDITION_ID]` if
+      #       the supplied condition includes the `name` field with that
+      #       `[CONDITION_ID]`. If the supplied condition omits the `name` field,
+      #       then a new `[CONDITION_ID]` is created.
       # @!attribute [rw] alert_policy
       #   @return [Google::Monitoring::V3::AlertPolicy]
       #     Required. The updated alerting policy or the updated values for the
-      #     fields listed in +update_mask+.
-      #     If +update_mask+ is not empty, any fields in this policy that are
-      #     not in +update_mask+ are ignored.
+      #     fields listed in `update_mask`.
+      #     If `update_mask` is not empty, any fields in this policy that are
+      #     not in `update_mask` are ignored.
       class UpdateAlertPolicyRequest; end
 
-      # The protocol for the +DeleteAlertPolicy+ request.
+      # The protocol for the `DeleteAlertPolicy` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The alerting policy to delete. The format is:

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/common.rb
@@ -19,7 +19,7 @@ module Google
       # A single strongly-typed value.
       # @!attribute [rw] bool_value
       #   @return [true, false]
-      #     A Boolean value: +true+ or +false+.
+      #     A Boolean value: `true` or `false`.
       # @!attribute [rw] int64_value
       #   @return [Integer]
       #     A 64-bit integer. Its range is approximately &plusmn;9.2x10<sup>18</sup>.
@@ -51,19 +51,19 @@ module Google
 
       # Describes how to combine multiple time series to provide different views of
       # the data.  Aggregation consists of an alignment step on individual time
-      # series (+alignment_period+ and +per_series_aligner+) followed by an optional
+      # series (`alignment_period` and `per_series_aligner`) followed by an optional
       # reduction step of the data across the aligned time series
-      # (+cross_series_reducer+ and +group_by_fields+).  For more details, see
+      # (`cross_series_reducer` and `group_by_fields`).  For more details, see
       # [Aggregation](https://cloud.google.com/monitoring/api/learn_more#aggregation).
       # @!attribute [rw] alignment_period
       #   @return [Google::Protobuf::Duration]
       #     The alignment period for per-{Google::Monitoring::V3::TimeSeries time series}
-      #     alignment. If present, +alignmentPeriod+ must be at least 60
+      #     alignment. If present, `alignmentPeriod` must be at least 60
       #     seconds.  After per-time series alignment, each time series will
       #     contain data points only on the period boundaries. If
-      #     +perSeriesAligner+ is not specified or equals +ALIGN_NONE+, then
-      #     this field is ignored. If +perSeriesAligner+ is specified and
-      #     does not equal +ALIGN_NONE+, then this field must be defined;
+      #     `perSeriesAligner` is not specified or equals `ALIGN_NONE`, then
+      #     this field is ignored. If `perSeriesAligner` is specified and
+      #     does not equal `ALIGN_NONE`, then this field must be defined;
       #     otherwise an error is returned.
       # @!attribute [rw] per_series_aligner
       #   @return [Google::Monitoring::V3::Aggregation::Aligner]
@@ -74,9 +74,9 @@ module Google
       #     the time series.
       #
       #     Time series data must be aligned in order to perform cross-time
-      #     series reduction. If +crossSeriesReducer+ is specified, then
-      #     +perSeriesAligner+ must be specified and not equal +ALIGN_NONE+
-      #     and +alignmentPeriod+ must be specified; otherwise, an error is
+      #     series reduction. If `crossSeriesReducer` is specified, then
+      #     `perSeriesAligner` must be specified and not equal `ALIGN_NONE`
+      #     and `alignmentPeriod` must be specified; otherwise, an error is
       #     returned.
       # @!attribute [rw] cross_series_reducer
       #   @return [Google::Monitoring::V3::Aggregation::Reducer]
@@ -87,25 +87,25 @@ module Google
       #     time series.
       #
       #     Time series data must be aligned in order to perform cross-time
-      #     series reduction. If +crossSeriesReducer+ is specified, then
-      #     +perSeriesAligner+ must be specified and not equal +ALIGN_NONE+
-      #     and +alignmentPeriod+ must be specified; otherwise, an error is
+      #     series reduction. If `crossSeriesReducer` is specified, then
+      #     `perSeriesAligner` must be specified and not equal `ALIGN_NONE`
+      #     and `alignmentPeriod` must be specified; otherwise, an error is
       #     returned.
       # @!attribute [rw] group_by_fields
       #   @return [Array<String>]
-      #     The set of fields to preserve when +crossSeriesReducer+ is
-      #     specified. The +groupByFields+ determine how the time series are
+      #     The set of fields to preserve when `crossSeriesReducer` is
+      #     specified. The `groupByFields` determine how the time series are
       #     partitioned into subsets prior to applying the aggregation
       #     function. Each subset contains time series that have the same
       #     value for each of the grouping fields. Each individual time
       #     series is a member of exactly one subset. The
-      #     +crossSeriesReducer+ is applied to each subset of time series.
+      #     `crossSeriesReducer` is applied to each subset of time series.
       #     It is not possible to reduce across different resource types, so
-      #     this field implicitly contains +resource.type+.  Fields not
-      #     specified in +groupByFields+ are aggregated away.  If
-      #     +groupByFields+ is not specified and all the time series have
+      #     this field implicitly contains `resource.type`.  Fields not
+      #     specified in `groupByFields` are aggregated away.  If
+      #     `groupByFields` is not specified and all the time series have
       #     the same resource type, then the time series are aggregated into
-      #     a single output time series. If +crossSeriesReducer+ is not
+      #     a single output time series. If `crossSeriesReducer` is not
       #     defined, this field is ignored.
       class Aggregation
         # The Aligner describes how to bring the data points in a single
@@ -137,7 +137,7 @@ module Google
           # and the output unit is one that has a "/time" dimension.
           #
           # If, by rate, you are looking for percentage change, see the
-          # +ALIGN_PERCENT_CHANGE+ aligner option.
+          # `ALIGN_PERCENT_CHANGE` aligner option.
           ALIGN_RATE = 2
 
           # Align by interpolating between adjacent points around the

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group.rb
@@ -23,7 +23,7 @@ module Google
       # monitored resources, and each monitored resource can be a member of any
       # number of groups.
       #
-      # Groups can be nested in parent-child hierarchies. The +parentName+ field
+      # Groups can be nested in parent-child hierarchies. The `parentName` field
       # identifies an optional parent for each group.  If a group has a parent, then
       # the only monitored resources available to be matched by the group's filter
       # are the resources contained in the parent group.  In other words, a group
@@ -32,9 +32,9 @@ module Google
       # resource.
       #
       # For example, consider an infrastructure running a set of instances with two
-      # user-defined tags: +"environment"+ and +"role"+. A parent group has a filter,
-      # +environment="production"+.  A child of that parent group has a filter,
-      # +role="transcoder"+.  The parent group contains all instances in the
+      # user-defined tags: `"environment"` and `"role"`. A parent group has a filter,
+      # `environment="production"`.  A child of that parent group has a filter,
+      # `role="transcoder"`.  The parent group contains all instances in the
       # production environment, regardless of their roles.  The child group contains
       # instances that have the transcoder role *and* are in the production
       # environment.
@@ -45,18 +45,18 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     Output only. The name of this group. The format is
-      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     `"projects/{project_id_or_number}/groups/{group_id}"`.
       #     When creating a group, this field is ignored and a new name is created
-      #     consisting of the project specified in the call to +CreateGroup+
-      #     and a unique +\\{group_id}+ that is generated automatically.
+      #     consisting of the project specified in the call to `CreateGroup`
+      #     and a unique `{group_id}` that is generated automatically.
       # @!attribute [rw] display_name
       #   @return [String]
       #     A user-assigned name for this group, used only for display purposes.
       # @!attribute [rw] parent_name
       #   @return [String]
       #     The name of the group's parent, if it has one.
-      #     The format is +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
-      #     For groups with no parent, +parentName+ is the empty string, +""+.
+      #     The format is `"projects/{project_id_or_number}/groups/{group_id}"`.
+      #     For groups with no parent, `parentName` is the empty string, `""`.
       # @!attribute [rw] filter
       #   @return [String]
       #     The filter used to determine which monitored resources belong to this group.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/group_service.rb
@@ -16,40 +16,40 @@
 module Google
   module Monitoring
     module V3
-      # The +ListGroup+ request.
+      # The `ListGroup` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project whose groups are to be listed. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] children_of_group
       #   @return [String]
-      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
-      #     Returns groups whose +parentName+ field contains the group
+      #     A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
+      #     Returns groups whose `parentName` field contains the group
       #     name.  If no groups have this parent, the results are empty.
       # @!attribute [rw] ancestors_of_group
       #   @return [String]
-      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
       #     Returns groups that are ancestors of the specified group.
       #     The groups are returned in order, starting with the immediate parent and
       #     ending with the most distant ancestor.  If the specified group has no
       #     immediate parent, the results are empty.
       # @!attribute [rw] descendants_of_group
       #   @return [String]
-      #     A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
       #     Returns the descendants of the specified group.  This is a superset of
-      #     the results returned by the +childrenOfGroup+ filter, and includes
+      #     the results returned by the `childrenOfGroup` filter, and includes
       #     children-of-children, and so forth.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     A positive number that is the maximum number of results to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return additional results from the previous method call.
       class ListGroupsRequest; end
 
-      # The +ListGroups+ response.
+      # The `ListGroups` response.
       # @!attribute [rw] group
       #   @return [Array<Google::Monitoring::V3::Group>]
       #     The groups that match the specified filters.
@@ -57,58 +57,58 @@ module Google
       #   @return [String]
       #     If there are more results than have been returned, then this field is set
       #     to a non-empty value.  To see the additional results,
-      #     use that value as +pageToken+ in the next call to this method.
+      #     use that value as `pageToken` in the next call to this method.
       class ListGroupsResponse; end
 
-      # The +GetGroup+ request.
+      # The `GetGroup` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The group to retrieve. The format is
-      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     `"projects/{project_id_or_number}/groups/{group_id}"`.
       class GetGroupRequest; end
 
-      # The +CreateGroup+ request.
+      # The `CreateGroup` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project in which to create the group. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] group
       #   @return [Google::Monitoring::V3::Group]
-      #     A group definition. It is an error to define the +name+ field because
+      #     A group definition. It is an error to define the `name` field because
       #     the system assigns the name.
       # @!attribute [rw] validate_only
       #   @return [true, false]
       #     If true, validate this request but do not create the group.
       class CreateGroupRequest; end
 
-      # The +UpdateGroup+ request.
+      # The `UpdateGroup` request.
       # @!attribute [rw] group
       #   @return [Google::Monitoring::V3::Group]
       #     The new definition of the group.  All fields of the existing group,
-      #     excepting +name+, are replaced with the corresponding fields of this group.
+      #     excepting `name`, are replaced with the corresponding fields of this group.
       # @!attribute [rw] validate_only
       #   @return [true, false]
       #     If true, validate this request but do not update the existing group.
       class UpdateGroupRequest; end
 
-      # The +DeleteGroup+ request. You can only delete a group if it has no children.
+      # The `DeleteGroup` request. You can only delete a group if it has no children.
       # @!attribute [rw] name
       #   @return [String]
       #     The group to delete. The format is
-      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     `"projects/{project_id_or_number}/groups/{group_id}"`.
       class DeleteGroupRequest; end
 
-      # The +ListGroupMembers+ request.
+      # The `ListGroupMembers` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The group whose members are listed. The format is
-      #     +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+      #     `"projects/{project_id_or_number}/groups/{group_id}"`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     A positive number that is the maximum number of results to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return additional results from the previous method call.
       # @!attribute [rw] filter
@@ -128,7 +128,7 @@ module Google
       #     membership over the last minute is returned.
       class ListGroupMembersRequest; end
 
-      # The +ListGroupMembers+ response.
+      # The `ListGroupMembers` response.
       # @!attribute [rw] members
       #   @return [Array<Google::Api::MonitoredResource>]
       #     A set of monitored resources in the group.
@@ -136,7 +136,7 @@ module Google
       #   @return [String]
       #     If there are more results than have been returned, then this field is
       #     set to a non-empty value.  To see the additional results, use that value as
-      #     +pageToken+ in the next call to this method.
+      #     `pageToken` in the next call to this method.
       # @!attribute [rw] total_size
       #   @return [Integer]
       #     The total number of elements matching this request.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric.rb
@@ -19,10 +19,10 @@ module Google
       # A single data point in a time series.
       # @!attribute [rw] interval
       #   @return [Google::Monitoring::V3::TimeInterval]
-      #     The time interval to which the data point applies.  For +GAUGE+ metrics,
-      #     only the end time of the interval is used.  For +DELTA+ metrics, the start
+      #     The time interval to which the data point applies.  For `GAUGE` metrics,
+      #     only the end time of the interval is used.  For `DELTA` metrics, the start
       #     and end time should specify a non-zero interval, with subsequent points
-      #     specifying contiguous and non-overlapping intervals.  For +CUMULATIVE+
+      #     specifying contiguous and non-overlapping intervals.  For `CUMULATIVE`
       #     metrics, the start and end time should specify a non-zero interval, with
       #     subsequent points specifying the same start time and increasing end times,
       #     until an event resets the cumulative value to zero and sets a new start
@@ -58,8 +58,8 @@ module Google
       #     When creating a time series, this field is optional. If present, it must be
       #     the same as the metric kind of the associated metric. If the associated
       #     metric's descriptor must be auto-created, then this field specifies the
-      #     metric kind of the new descriptor and must be either +GAUGE+ (the default)
-      #     or +CUMULATIVE+.
+      #     metric kind of the new descriptor and must be either `GAUGE` (the default)
+      #     or `CUMULATIVE`.
       # @!attribute [rw] value_type
       #   @return [Google::Api::MetricDescriptor::ValueType]
       #     The value type of the time series. When listing time series, this value
@@ -67,7 +67,7 @@ module Google
       #     this time series is an alignment or reduction of other time series.
       #
       #     When creating a time series, this field is optional. If present, it must be
-      #     the same as the type of the data in the +points+ field.
+      #     the same as the type of the data in the `points` field.
       # @!attribute [rw] points
       #   @return [Array<Google::Monitoring::V3::Point>]
       #     The data points of this time series. When listing time series, points are
@@ -77,7 +77,7 @@ module Google
       #     the point's type must be the same as the value type of the associated
       #     metric. If the associated metric's descriptor must be auto-created, then
       #     the value type of the descriptor is determined by the point's type, which
-      #     must be +BOOL+, +INT64+, +DOUBLE+, or +DISTRIBUTION+.
+      #     must be `BOOL`, `INT64`, `DOUBLE`, or `DISTRIBUTION`.
       class TimeSeries; end
     end
   end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/metric_service.rb
@@ -16,18 +16,18 @@
 module Google
   module Monitoring
     module V3
-      # The +ListMonitoredResourceDescriptors+ request.
+      # The `ListMonitoredResourceDescriptors` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] filter
       #   @return [String]
       #     An optional [filter](https://cloud.google.com/monitoring/api/v3/filters) describing
       #     the descriptors to be returned.  The filter can reference
       #     the descriptor's type and labels. For example, the
       #     following filter returns only Google Compute Engine descriptors
-      #     that have an +id+ label:
+      #     that have an `id` label:
       #
       #         resource.type = starts_with("gce_") AND resource.label:id
       # @!attribute [rw] page_size
@@ -35,37 +35,37 @@ module Google
       #     A positive number that is the maximum number of results to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return additional results from the previous method call.
       class ListMonitoredResourceDescriptorsRequest; end
 
-      # The +ListMonitoredResourceDescriptors+ response.
+      # The `ListMonitoredResourceDescriptors` response.
       # @!attribute [rw] resource_descriptors
       #   @return [Array<Google::Api::MonitoredResourceDescriptor>]
       #     The monitored resource descriptors that are available to this project
-      #     and that match +filter+, if present.
+      #     and that match `filter`, if present.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there are more results than have been returned, then this field is set
       #     to a non-empty value.  To see the additional results,
-      #     use that value as +pageToken+ in the next call to this method.
+      #     use that value as `pageToken` in the next call to this method.
       class ListMonitoredResourceDescriptorsResponse; end
 
-      # The +GetMonitoredResourceDescriptor+ request.
+      # The `GetMonitoredResourceDescriptor` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The monitored resource descriptor to get.  The format is
-      #     +"projects/\\{project_id_or_number}/monitoredResourceDescriptors/\\{resource_type}"+.
-      #     The +\\{resource_type}+ is a predefined type, such as
-      #     +cloudsql_database+.
+      #     `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+      #     The `{resource_type}` is a predefined type, such as
+      #     `cloudsql_database`.
       class GetMonitoredResourceDescriptorRequest; end
 
-      # The +ListMetricDescriptors+ request.
+      # The `ListMetricDescriptors` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] filter
       #   @return [String]
       #     If this field is empty, all custom and
@@ -81,53 +81,53 @@ module Google
       #     A positive number that is the maximum number of results to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return additional results from the previous method call.
       class ListMetricDescriptorsRequest; end
 
-      # The +ListMetricDescriptors+ response.
+      # The `ListMetricDescriptors` response.
       # @!attribute [rw] metric_descriptors
       #   @return [Array<Google::Api::MetricDescriptor>]
       #     The metric descriptors that are available to the project
-      #     and that match the value of +filter+, if present.
+      #     and that match the value of `filter`, if present.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If there are more results than have been returned, then this field is set
       #     to a non-empty value.  To see the additional results,
-      #     use that value as +pageToken+ in the next call to this method.
+      #     use that value as `pageToken` in the next call to this method.
       class ListMetricDescriptorsResponse; end
 
-      # The +GetMetricDescriptor+ request.
+      # The `GetMetricDescriptor` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The metric descriptor on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
-      #     An example value of +\\{metric_id}+ is
-      #     +"compute.googleapis.com/instance/disk/read_bytes_count"+.
+      #     `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+      #     An example value of `{metric_id}` is
+      #     `"compute.googleapis.com/instance/disk/read_bytes_count"`.
       class GetMetricDescriptorRequest; end
 
-      # The +CreateMetricDescriptor+ request.
+      # The `CreateMetricDescriptor` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] metric_descriptor
       #   @return [Google::Api::MetricDescriptor]
       #     The new [custom metric](https://cloud.google.com/monitoring/custom-metrics)
       #     descriptor.
       class CreateMetricDescriptorRequest; end
 
-      # The +DeleteMetricDescriptor+ request.
+      # The `DeleteMetricDescriptor` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The metric descriptor on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
-      #     An example of +\\{metric_id}+ is:
-      #     +"custom.googleapis.com/my_test_metric"+.
+      #     `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+      #     An example of `{metric_id}` is:
+      #     `"custom.googleapis.com/my_test_metric"`.
       class DeleteMetricDescriptorRequest; end
 
-      # The +ListTimeSeries+ request.
+      # The `ListTimeSeries` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
@@ -161,17 +161,17 @@ module Google
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     A positive number that is the maximum number of results to return. If
-      #     +page_size+ is empty or more than 100,000 results, the effective
-      #     +page_size+ is 100,000 results. If +view+ is set to +FULL+, this is the
-      #     maximum number of +Points+ returned. If +view+ is set to +HEADERS+, this is
-      #     the maximum number of +TimeSeries+ returned.
+      #     `page_size` is empty or more than 100,000 results, the effective
+      #     `page_size` is 100,000 results. If `view` is set to `FULL`, this is the
+      #     maximum number of `Points` returned. If `view` is set to `HEADERS`, this is
+      #     the maximum number of `TimeSeries` returned.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return additional results from the previous method call.
       class ListTimeSeriesRequest
-        # Controls which fields are returned by +ListTimeSeries+.
+        # Controls which fields are returned by `ListTimeSeries`.
         module TimeSeriesView
           # Returns the identity of the metric(s), the time series,
           # and the time series data.
@@ -183,7 +183,7 @@ module Google
         end
       end
 
-      # The +ListTimeSeries+ response.
+      # The `ListTimeSeries` response.
       # @!attribute [rw] time_series
       #   @return [Array<Google::Monitoring::V3::TimeSeries>]
       #     One or more time series that match the filter included in the request.
@@ -191,32 +191,32 @@ module Google
       #   @return [String]
       #     If there are more results than have been returned, then this field is set
       #     to a non-empty value.  To see the additional results,
-      #     use that value as +pageToken+ in the next call to this method.
+      #     use that value as `pageToken` in the next call to this method.
       # @!attribute [rw] execution_errors
       #   @return [Array<Google::Rpc::Status>]
       #     Query execution errors that may have caused the time series data returned
       #     to be incomplete.
       class ListTimeSeriesResponse; end
 
-      # The +CreateTimeSeries+ request.
+      # The `CreateTimeSeries` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +"projects/\\{project_id_or_number}"+.
+      #     `"projects/{project_id_or_number}"`.
       # @!attribute [rw] time_series
       #   @return [Array<Google::Monitoring::V3::TimeSeries>]
       #     The new data to be added to a list of time series.
       #     Adds at most one data point to each of several time series.  The new data
       #     point must be more recent than any other point in its time series.  Each
-      #     +TimeSeries+ value must fully specify a unique time series by supplying
+      #     `TimeSeries` value must fully specify a unique time series by supplying
       #     all label values for the metric and the monitored resource.
       class CreateTimeSeriesRequest; end
 
       # Describes the result of a failed request to write data to a time series.
       # @!attribute [rw] time_series
       #   @return [Google::Monitoring::V3::TimeSeries]
-      #     The time series, including the +Metric+, +MonitoredResource+,
-      #     and +Point+s (including timestamp and value) that resulted
+      #     The time series, including the `Metric`, `MonitoredResource`,
+      #     and `Point`s (including timestamp and value) that resulted
       #     in the error. This field provides all of the context that
       #     would be needed to retry the operation.
       # @!attribute [rw] status

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification.rb
@@ -25,7 +25,7 @@ module Google
       #
       #         projects/[PROJECT_ID]/notificationChannelDescriptors/[TYPE]
       #
-      #     In the above, +[TYPE]+ is the value of the +type+ field.
+      #     In the above, `[TYPE]` is the value of the `type` field.
       # @!attribute [rw] type
       #   @return [String]
       #     The type of notification channel, such as "email", "sms", etc.
@@ -50,7 +50,7 @@ module Google
       #     must be one of the supported_tiers.
       class NotificationChannelDescriptor; end
 
-      # A +NotificationChannel+ is a medium through which an alert is
+      # A `NotificationChannel` is a medium through which an alert is
       # delivered when a policy violation is detected. Examples of channels
       # include email, SMS, and third-party messaging applications. Fields
       # containing sensitive information like authentication tokens or
@@ -65,7 +65,7 @@ module Google
       #
       #         projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]
       #
-      #     The +[CHANNEL_ID]+ is automatically assigned by the server on creation.
+      #     The `[CHANNEL_ID]` is automatically assigned by the server on creation.
       # @!attribute [rw] display_name
       #   @return [String]
       #     An optional human-readable name for this notification channel. It is
@@ -82,13 +82,13 @@ module Google
       #     Configuration fields that define the channel and its behavior. The
       #     permissible and required labels are specified in the
       #     {Google::Monitoring::V3::NotificationChannelDescriptor#labels NotificationChannelDescriptor#labels} of the
-      #     +NotificationChannelDescriptor+ corresponding to the +type+ field.
+      #     `NotificationChannelDescriptor` corresponding to the `type` field.
       # @!attribute [rw] user_labels
       #   @return [Hash{String => String}]
       #     User-supplied key/value data that does not need to conform to
-      #     the corresponding +NotificationChannelDescriptor+'s schema, unlike
-      #     the +labels+ field. This field is intended to be used for organizing
-      #     and identifying the +NotificationChannel+ objects.
+      #     the corresponding `NotificationChannelDescriptor`'s schema, unlike
+      #     the `labels` field. This field is intended to be used for organizing
+      #     and identifying the `NotificationChannel` objects.
       #
       #     The field can contain up to 64 entries. Each key and value is limited to
       #     63 Unicode characters or 128 bytes, whichever is smaller. Labels and
@@ -97,24 +97,24 @@ module Google
       # @!attribute [rw] verification_status
       #   @return [Google::Monitoring::V3::NotificationChannel::VerificationStatus]
       #     Indicates whether this channel has been verified or not. On a
-      #     {Google::Monitoring::V3::NotificationChannelService::ListNotificationChannels +ListNotificationChannels+}
+      #     {Google::Monitoring::V3::NotificationChannelService::ListNotificationChannels `ListNotificationChannels`}
       #     or
-      #     {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel +GetNotificationChannel+}
+      #     {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel `GetNotificationChannel`}
       #     operation, this field is expected to be populated.
       #
-      #     If the value is +UNVERIFIED+, then it indicates that the channel is
+      #     If the value is `UNVERIFIED`, then it indicates that the channel is
       #     non-functioning (it both requires verification and lacks verification);
       #     otherwise, it is assumed that the channel works.
       #
-      #     If the channel is neither +VERIFIED+ nor +UNVERIFIED+, it implies that
+      #     If the channel is neither `VERIFIED` nor `UNVERIFIED`, it implies that
       #     the channel is of a type that does not require verification or that
       #     this specific channel has been exempted from verification because it was
       #     created prior to verification being required for channels of this type.
       #
       #     This field cannot be modified using a standard
-      #     {Google::Monitoring::V3::NotificationChannelService::UpdateNotificationChannel +UpdateNotificationChannel+}
+      #     {Google::Monitoring::V3::NotificationChannelService::UpdateNotificationChannel `UpdateNotificationChannel`}
       #     operation. To change the value of this field, you must call
-      #     {Google::Monitoring::V3::NotificationChannelService::VerifyNotificationChannel +VerifyNotificationChannel+}.
+      #     {Google::Monitoring::V3::NotificationChannelService::VerifyNotificationChannel `VerifyNotificationChannel`}.
       # @!attribute [rw] enabled
       #   @return [Google::Protobuf::BoolValue]
       #     Whether notifications are forwarded to the described channel. This makes
@@ -126,9 +126,9 @@ module Google
       class NotificationChannel
         # Indicates whether the channel has been verified or not. It is illegal
         # to specify this field in a
-        # {Google::Monitoring::V3::NotificationChannelService::CreateNotificationChannel +CreateNotificationChannel+}
+        # {Google::Monitoring::V3::NotificationChannelService::CreateNotificationChannel `CreateNotificationChannel`}
         # or an
-        # {Google::Monitoring::V3::NotificationChannelService::UpdateNotificationChannel +UpdateNotificationChannel+}
+        # {Google::Monitoring::V3::NotificationChannelService::UpdateNotificationChannel `UpdateNotificationChannel`}
         # operation.
         module VerificationStatus
           # Sentinel value used to indicate that the state is unknown, omitted, or

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/notification_service.rb
@@ -16,7 +16,7 @@
 module Google
   module Monitoring
     module V3
-      # The +ListNotificationChannelDescriptors+ request.
+      # The `ListNotificationChannelDescriptors` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The REST resource name of the parent from which to retrieve
@@ -35,12 +35,12 @@ module Google
       #     service.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If non-empty, +page_token+ must contain a value returned as the
-      #     +next_page_token+ in a previous response to request the next set
+      #     If non-empty, `page_token` must contain a value returned as the
+      #     `next_page_token` in a previous response to request the next set
       #     of results.
       class ListNotificationChannelDescriptorsRequest; end
 
-      # The +ListNotificationChannelDescriptors+ response.
+      # The `ListNotificationChannelDescriptors` response.
       # @!attribute [rw] channel_descriptors
       #   @return [Array<Google::Monitoring::V3::NotificationChannelDescriptor>]
       #     The monitored resource descriptors supported for the specified
@@ -48,19 +48,19 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If not empty, indicates that there may be more results that match
-      #     the request. Use the value in the +page_token+ field in a
+      #     the request. Use the value in the `page_token` field in a
       #     subsequent request to fetch the next set of results. If empty,
       #     all results have been returned.
       class ListNotificationChannelDescriptorsResponse; end
 
-      # The +GetNotificationChannelDescriptor+ response.
+      # The `GetNotificationChannelDescriptor` response.
       # @!attribute [rw] name
       #   @return [String]
       #     The channel type for which to execute the request. The format is
-      #     +projects/[PROJECT_ID]/notificationChannelDescriptors/\\{channel_type}+.
+      #     `projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}`.
       class GetNotificationChannelDescriptorRequest; end
 
-      # The +CreateNotificationChannel+ request.
+      # The `CreateNotificationChannel` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is:
@@ -70,21 +70,21 @@ module Google
       #     Note that this names the container into which the channel will be
       #     written. This does not name the newly created channel. The resulting
       #     channel's name will have a normalized version of this field as a prefix,
-      #     but will add +/notificationChannels/[CHANNEL_ID]+ to identify the channel.
+      #     but will add `/notificationChannels/[CHANNEL_ID]` to identify the channel.
       # @!attribute [rw] notification_channel
       #   @return [Google::Monitoring::V3::NotificationChannel]
-      #     The definition of the +NotificationChannel+ to create.
+      #     The definition of the `NotificationChannel` to create.
       class CreateNotificationChannelRequest; end
 
-      # The +ListNotificationChannels+ request.
+      # The `ListNotificationChannels` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The project on which to execute the request. The format is
-      #     +projects/[PROJECT_ID]+. That is, this names the container
+      #     `projects/[PROJECT_ID]`. That is, this names the container
       #     in which to look for the notification channels; it does not name a
       #     specific channel. To query a specific channel by REST resource name, use
       #     the
-      #     {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel +GetNotificationChannel+} operation.
+      #     {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel `GetNotificationChannel`} operation.
       # @!attribute [rw] filter
       #   @return [String]
       #     If provided, this field specifies the criteria that must be met by
@@ -95,7 +95,7 @@ module Google
       # @!attribute [rw] order_by
       #   @return [String]
       #     A comma-separated list of fields by which to sort the result. Supports
-      #     the same set of fields as in +filter+. Entries can be prefixed with
+      #     the same set of fields as in `filter`. Entries can be prefixed with
       #     a minus sign to sort in descending rather than ascending order.
       #
       #     For more details, see [sorting and
@@ -107,31 +107,31 @@ module Google
       #     service.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If non-empty, +page_token+ must contain a value returned as the
-      #     +next_page_token+ in a previous response to request the next set
+      #     If non-empty, `page_token` must contain a value returned as the
+      #     `next_page_token` in a previous response to request the next set
       #     of results.
       class ListNotificationChannelsRequest; end
 
-      # The +ListNotificationChannels+ response.
+      # The `ListNotificationChannels` response.
       # @!attribute [rw] notification_channels
       #   @return [Array<Google::Monitoring::V3::NotificationChannel>]
       #     The notification channels defined for the specified project.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If not empty, indicates that there may be more results that match
-      #     the request. Use the value in the +page_token+ field in a
+      #     the request. Use the value in the `page_token` field in a
       #     subsequent request to fetch the next set of results. If empty,
       #     all results have been returned.
       class ListNotificationChannelsResponse; end
 
-      # The +GetNotificationChannel+ request.
+      # The `GetNotificationChannel` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The channel for which to execute the request. The format is
-      #     +projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]+.
+      #     `projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]`.
       class GetNotificationChannelRequest; end
 
-      # The +UpdateNotificationChannel+ request.
+      # The `UpdateNotificationChannel` request.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     The fields to update.
@@ -140,14 +140,14 @@ module Google
       #     A description of the changes to be applied to the specified
       #     notification channel. The description must provide a definition for
       #     fields to be updated; the names of these fields should also be
-      #     included in the +update_mask+.
+      #     included in the `update_mask`.
       class UpdateNotificationChannelRequest; end
 
-      # The +DeleteNotificationChannel+ request.
+      # The `DeleteNotificationChannel` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The channel for which to execute the request. The format is
-      #     +projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]+.
+      #     `projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]`.
       # @!attribute [rw] force
       #   @return [true, false]
       #     If true, the notification channel will be deleted regardless of its
@@ -156,13 +156,13 @@ module Google
       #     alerting policy will fail to be deleted in a delete operation.
       class DeleteNotificationChannelRequest; end
 
-      # The +SendNotificationChannelVerificationCode+ request.
+      # The `SendNotificationChannelVerificationCode` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The notification channel to which to send a verification code.
       class SendNotificationChannelVerificationCodeRequest; end
 
-      # The +GetNotificationChannelVerificationCode+ request.
+      # The `GetNotificationChannelVerificationCode` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The notification channel for which a verification code is to be generated
@@ -181,7 +181,7 @@ module Google
       #     impose an upper limit on the maximum expiration that is permitted).
       class GetNotificationChannelVerificationCodeRequest; end
 
-      # The +GetNotificationChannelVerificationCode+ request.
+      # The `GetNotificationChannelVerificationCode` request.
       # @!attribute [rw] code
       #   @return [String]
       #     The verification code, which may be used to verify other channels
@@ -195,16 +195,16 @@ module Google
       #     requested expiration in the request and the max permitted expiration.
       class GetNotificationChannelVerificationCodeResponse; end
 
-      # The +VerifyNotificationChannel+ request.
+      # The `VerifyNotificationChannel` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The notification channel to verify.
       # @!attribute [rw] code
       #   @return [String]
       #     The verification code that was delivered to the channel as
-      #     a result of invoking the +SendNotificationChannelVerificationCode+ API
+      #     a result of invoking the `SendNotificationChannelVerificationCode` API
       #     method or that was retrieved from a verified channel via
-      #     +GetNotificationChannelVerificationCode+. For example, one might have
+      #     `GetNotificationChannelVerificationCode`. For example, one might have
       #     "G-123456" or "TKNZGhhd2EyN3I1MnRnMjRv" (in general, one is only
       #     guaranteed that the code is valid UTF-8; one should not
       #     make any assumptions regarding the structure or format of the code).

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime.rb
@@ -43,7 +43,7 @@ module Google
       #     A unique resource name for this UptimeCheckConfig. The format is:
       #
       #
-      #       +projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]+.
+      #       `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
       #
       #     This field should be omitted when creating the uptime check configuration;
       #     on create, the resource name is assigned by the server and included in the
@@ -76,9 +76,9 @@ module Google
       # @!attribute [rw] period
       #   @return [Google::Protobuf::Duration]
       #     How often, in seconds, the uptime check is performed.
-      #     Currently, the only supported values are +60s+ (1 minute), +300s+
-      #     (5 minutes), +600s+ (10 minutes), and +900s+ (15 minutes). Optional,
-      #     defaults to +300s+.
+      #     Currently, the only supported values are `60s` (1 minute), `300s`
+      #     (5 minutes), `600s` (10 minutes), and `900s` (15 minutes). Optional,
+      #     defaults to `300s`.
       # @!attribute [rw] timeout
       #   @return [Google::Protobuf::Duration]
       #     The maximum amount of time to wait for the request to complete (must be
@@ -102,7 +102,7 @@ module Google
       #     Denotes whether this is a check that egresses from InternalCheckers.
       # @!attribute [rw] internal_checkers
       #   @return [Array<Google::Monitoring::V3::InternalChecker>]
-      #     The internal checkers that this check will egress from. If +is_internal+ is
+      #     The internal checkers that this check will egress from. If `is_internal` is
       #     true and this list is empty, the check will egress from all
       #     InternalCheckers configured for the project that owns this CheckConfig.
       class UptimeCheckConfig
@@ -224,9 +224,9 @@ module Google
       end
 
       # The supported resource types that can be used as values of
-      # +group_resource.resource_type+.
-      # +INSTANCE+ includes +gce_instance+ and +aws_ec2_instance+ resource types.
-      # The resource types +gae_app+ and +uptime_url+ are not valid here because
+      # `group_resource.resource_type`.
+      # `INSTANCE` includes `gce_instance` and `aws_ec2_instance` resource types.
+      # The resource types `gae_app` and `uptime_url` are not valid here because
       # group checks on App Engine modules and URLs are not allowed.
       module GroupResourceType
         # Default value (not valid).

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime_service.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/monitoring/v3/uptime_service.rb
@@ -16,11 +16,11 @@
 module Google
   module Monitoring
     module V3
-      # The protocol for the +ListUptimeCheckConfigs+ request.
+      # The protocol for the `ListUptimeCheckConfigs` request.
       # @!attribute [rw] parent
       #   @return [String]
       #     The project whose uptime check configurations are listed. The format
-      #       is +projects/[PROJECT_ID]+.
+      #       is `projects/[PROJECT_ID]`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of results to return in a single response. The server
@@ -29,12 +29,12 @@ module Google
       #     to be returned.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return more results from the previous method call.
       class ListUptimeCheckConfigsRequest; end
 
-      # The protocol for the +ListUptimeCheckConfigs+ response.
+      # The protocol for the `ListUptimeCheckConfigs` response.
       # @!attribute [rw] uptime_check_configs
       #   @return [Array<Google::Monitoring::V3::UptimeCheckConfig>]
       #     The returned uptime check configurations.
@@ -51,24 +51,24 @@ module Google
       #     irrespective of any pagination.
       class ListUptimeCheckConfigsResponse; end
 
-      # The protocol for the +GetUptimeCheckConfig+ request.
+      # The protocol for the `GetUptimeCheckConfig` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The uptime check configuration to retrieve. The format
-      #       is +projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]+.
+      #       is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
       class GetUptimeCheckConfigRequest; end
 
-      # The protocol for the +CreateUptimeCheckConfig+ request.
+      # The protocol for the `CreateUptimeCheckConfig` request.
       # @!attribute [rw] parent
       #   @return [String]
       #     The project in which to create the uptime check. The format
-      #       is +projects/[PROJECT_ID]+.
+      #       is `projects/[PROJECT_ID]`.
       # @!attribute [rw] uptime_check_config
       #   @return [Google::Monitoring::V3::UptimeCheckConfig]
       #     The new uptime check configuration.
       class CreateUptimeCheckConfigRequest; end
 
-      # The protocol for the +UpdateUptimeCheckConfig+ request.
+      # The protocol for the `UpdateUptimeCheckConfig` request.
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     Optional. If present, only the listed fields in the current uptime check
@@ -77,27 +77,27 @@ module Google
       #     the new configuration.
       # @!attribute [rw] uptime_check_config
       #   @return [Google::Monitoring::V3::UptimeCheckConfig]
-      #     Required. If an +"updateMask"+ has been specified, this field gives
-      #     the values for the set of fields mentioned in the +"updateMask"+. If an
-      #     +"updateMask"+ has not been given, this uptime check configuration replaces
-      #     the current configuration. If a field is mentioned in +"updateMask"+ but
+      #     Required. If an `"updateMask"` has been specified, this field gives
+      #     the values for the set of fields mentioned in the `"updateMask"`. If an
+      #     `"updateMask"` has not been given, this uptime check configuration replaces
+      #     the current configuration. If a field is mentioned in `"updateMask"` but
       #     the corresonding field is omitted in this partial uptime check
       #     configuration, it has the effect of deleting/clearing the field from the
       #     configuration on the server.
       #
-      #     The following fields can be updated: +display_name+,
-      #     +http_check+, +tcp_check+, +timeout+, +content_matchers+, and
-      #     +selected_regions+.
+      #     The following fields can be updated: `display_name`,
+      #     `http_check`, `tcp_check`, `timeout`, `content_matchers`, and
+      #     `selected_regions`.
       class UpdateUptimeCheckConfigRequest; end
 
-      # The protocol for the +DeleteUptimeCheckConfig+ request.
+      # The protocol for the `DeleteUptimeCheckConfig` request.
       # @!attribute [rw] name
       #   @return [String]
       #     The uptime check configuration to delete. The format
-      #       is +projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]+.
+      #       is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
       class DeleteUptimeCheckConfigRequest; end
 
-      # The protocol for the +ListUptimeCheckIps+ request.
+      # The protocol for the `ListUptimeCheckIps` request.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     The maximum number of results to return in a single response. The server
@@ -107,13 +107,13 @@ module Google
       #     NOTE: this field is not yet implemented
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If this field is not empty then it must contain the +nextPageToken+ value
+      #     If this field is not empty then it must contain the `nextPageToken` value
       #     returned by a previous call to this method.  Using this field causes the
       #     method to return more results from the previous method call.
       #     NOTE: this field is not yet implemented
       class ListUptimeCheckIpsRequest; end
 
-      # The protocol for the +ListUptimeCheckIps+ response.
+      # The protocol for the `ListUptimeCheckIps` response.
       # @!attribute [rw] uptime_check_ips
       #   @return [Array<Google::Monitoring::V3::UptimeCheckIp>]
       #     The returned list of IP addresses (including region and location) that the

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/any.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/empty.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/struct.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/rpc/status.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/group_service_client.rb
@@ -258,21 +258,21 @@ module Google
           #
           # @param name [String]
           #   The project whose groups are to be listed. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param children_of_group [String]
-          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
-          #   Returns groups whose +parentName+ field contains the group
+          #   A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
+          #   Returns groups whose `parentName` field contains the group
           #   name.  If no groups have this parent, the results are empty.
           # @param ancestors_of_group [String]
-          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+          #   A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
           #   Returns groups that are ancestors of the specified group.
           #   The groups are returned in order, starting with the immediate parent and
           #   ending with the most distant ancestor.  If the specified group has no
           #   immediate parent, the results are empty.
           # @param descendants_of_group [String]
-          #   A group name: +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+          #   A group name: `"projects/{project_id_or_number}/groups/{group_id}"`.
           #   Returns the descendants of the specified group.  This is a superset of
-          #   the results returned by the +childrenOfGroup+ filter, and includes
+          #   the results returned by the `childrenOfGroup` filter, and includes
           #   children-of-children, and so forth.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
@@ -334,7 +334,7 @@ module Google
           #
           # @param name [String]
           #   The group to retrieve. The format is
-          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+          #   `"projects/{project_id_or_number}/groups/{group_id}"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -365,9 +365,9 @@ module Google
           #
           # @param name [String]
           #   The project in which to create the group. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param group [Google::Monitoring::V3::Group | Hash]
-          #   A group definition. It is an error to define the +name+ field because
+          #   A group definition. It is an error to define the `name` field because
           #   the system assigns the name.
           #   A hash of the same form as `Google::Monitoring::V3::Group`
           #   can also be provided.
@@ -387,7 +387,7 @@ module Google
           #   group_service_client = Google::Cloud::Monitoring::Group.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::GroupServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +group+:
+          #   # TODO: Initialize `group`:
           #   group = {}
           #   response = group_service_client.create_group(formatted_name, group)
 
@@ -407,11 +407,11 @@ module Google
           end
 
           # Updates an existing group.
-          # You can change any group attributes except +name+.
+          # You can change any group attributes except `name`.
           #
           # @param group [Google::Monitoring::V3::Group | Hash]
           #   The new definition of the group.  All fields of the existing group,
-          #   excepting +name+, are replaced with the corresponding fields of this group.
+          #   excepting `name`, are replaced with the corresponding fields of this group.
           #   A hash of the same form as `Google::Monitoring::V3::Group`
           #   can also be provided.
           # @param validate_only [true, false]
@@ -429,7 +429,7 @@ module Google
           #
           #   group_service_client = Google::Cloud::Monitoring::Group.new(version: :v3)
           #
-          #   # TODO: Initialize +group+:
+          #   # TODO: Initialize `group`:
           #   group = {}
           #   response = group_service_client.update_group(group)
 
@@ -450,7 +450,7 @@ module Google
           #
           # @param name [String]
           #   The group to delete. The format is
-          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+          #   `"projects/{project_id_or_number}/groups/{group_id}"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -481,7 +481,7 @@ module Google
           #
           # @param name [String]
           #   The group whose members are listed. The format is
-          #   +"projects/\\{project_id_or_number}/groups/\\{group_id}"+.
+          #   `"projects/{project_id_or_number}/groups/{group_id}"`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/metric_service_client.rb
@@ -279,13 +279,13 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param filter [String]
           #   An optional [filter](https://cloud.google.com/monitoring/api/v3/filters) describing
           #   the descriptors to be returned.  The filter can reference
           #   the descriptor's type and labels. For example, the
           #   following filter returns only Google Compute Engine descriptors
-          #   that have an +id+ label:
+          #   that have an `id` label:
           #
           #       resource.type = starts_with("gce_") AND resource.label:id
           # @param page_size [Integer]
@@ -344,9 +344,9 @@ module Google
           #
           # @param name [String]
           #   The monitored resource descriptor to get.  The format is
-          #   +"projects/\\{project_id_or_number}/monitoredResourceDescriptors/\\{resource_type}"+.
-          #   The +\\{resource_type}+ is a predefined type, such as
-          #   +cloudsql_database+.
+          #   `"projects/{project_id_or_number}/monitoredResourceDescriptors/{resource_type}"`.
+          #   The `{resource_type}` is a predefined type, such as
+          #   `cloudsql_database`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -377,7 +377,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param filter [String]
           #   If this field is empty, all custom and
           #   system-defined metric descriptors are returned.
@@ -443,9 +443,9 @@ module Google
           #
           # @param name [String]
           #   The metric descriptor on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
-          #   An example value of +\\{metric_id}+ is
-          #   +"compute.googleapis.com/instance/disk/read_bytes_count"+.
+          #   `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+          #   An example value of `{metric_id}` is
+          #   `"compute.googleapis.com/instance/disk/read_bytes_count"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -478,7 +478,7 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param metric_descriptor [Google::Api::MetricDescriptor | Hash]
           #   The new [custom metric](https://cloud.google.com/monitoring/custom-metrics)
           #   descriptor.
@@ -498,7 +498,7 @@ module Google
           #   metric_service_client = Google::Cloud::Monitoring::Metric.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +metric_descriptor+:
+          #   # TODO: Initialize `metric_descriptor`:
           #   metric_descriptor = {}
           #   response = metric_service_client.create_metric_descriptor(formatted_name, metric_descriptor)
 
@@ -520,9 +520,9 @@ module Google
           #
           # @param name [String]
           #   The metric descriptor on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}/metricDescriptors/\\{metric_id}"+.
-          #   An example of +\\{metric_id}+ is:
-          #   +"custom.googleapis.com/my_test_metric"+.
+          #   `"projects/{project_id_or_number}/metricDescriptors/{metric_id}"`.
+          #   An example of `{metric_id}` is:
+          #   `"custom.googleapis.com/my_test_metric"`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -603,13 +603,13 @@ module Google
           #   metric_service_client = Google::Cloud::Monitoring::Metric.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +filter+:
+          #   # TODO: Initialize `filter`:
           #   filter = ''
           #
-          #   # TODO: Initialize +interval+:
+          #   # TODO: Initialize `interval`:
           #   interval = {}
           #
-          #   # TODO: Initialize +view+:
+          #   # TODO: Initialize `view`:
           #   view = :FULL
           #
           #   # Iterate over all results.
@@ -655,12 +655,12 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +"projects/\\{project_id_or_number}"+.
+          #   `"projects/{project_id_or_number}"`.
           # @param time_series [Array<Google::Monitoring::V3::TimeSeries | Hash>]
           #   The new data to be added to a list of time series.
           #   Adds at most one data point to each of several time series.  The new data
           #   point must be more recent than any other point in its time series.  Each
-          #   +TimeSeries+ value must fully specify a unique time series by supplying
+          #   `TimeSeries` value must fully specify a unique time series by supplying
           #   all label values for the metric and the monitored resource.
           #   A hash of the same form as `Google::Monitoring::V3::TimeSeries`
           #   can also be provided.
@@ -677,7 +677,7 @@ module Google
           #   metric_service_client = Google::Cloud::Monitoring::Metric.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::MetricServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +time_series+:
+          #   # TODO: Initialize `time_series`:
           #   time_series = []
           #   metric_service_client.create_time_series(formatted_name, time_series)
 

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/notification_channel_service_client.rb
@@ -334,7 +334,7 @@ module Google
           #
           # @param name [String]
           #   The channel type for which to execute the request. The format is
-          #   +projects/[PROJECT_ID]/notificationChannelDescriptors/\\{channel_type}+.
+          #   `projects/[PROJECT_ID]/notificationChannelDescriptors/{channel_type}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -365,11 +365,11 @@ module Google
           #
           # @param name [String]
           #   The project on which to execute the request. The format is
-          #   +projects/[PROJECT_ID]+. That is, this names the container
+          #   `projects/[PROJECT_ID]`. That is, this names the container
           #   in which to look for the notification channels; it does not name a
           #   specific channel. To query a specific channel by REST resource name, use
           #   the
-          #   {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel +GetNotificationChannel+} operation.
+          #   {Google::Monitoring::V3::NotificationChannelService::GetNotificationChannel `GetNotificationChannel`} operation.
           # @param filter [String]
           #   If provided, this field specifies the criteria that must be met by
           #   notification channels to be included in the response.
@@ -378,7 +378,7 @@ module Google
           #   filtering](/monitoring/api/v3/sorting-and-filtering).
           # @param order_by [String]
           #   A comma-separated list of fields by which to sort the result. Supports
-          #   the same set of fields as in +filter+. Entries can be prefixed with
+          #   the same set of fields as in `filter`. Entries can be prefixed with
           #   a minus sign to sort in descending rather than ascending order.
           #
           #   For more details, see [sorting and
@@ -445,7 +445,7 @@ module Google
           #
           # @param name [String]
           #   The channel for which to execute the request. The format is
-          #   +projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]+.
+          #   `projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -483,9 +483,9 @@ module Google
           #   Note that this names the container into which the channel will be
           #   written. This does not name the newly created channel. The resulting
           #   channel's name will have a normalized version of this field as a prefix,
-          #   but will add +/notificationChannels/[CHANNEL_ID]+ to identify the channel.
+          #   but will add `/notificationChannels/[CHANNEL_ID]` to identify the channel.
           # @param notification_channel [Google::Monitoring::V3::NotificationChannel | Hash]
-          #   The definition of the +NotificationChannel+ to create.
+          #   The definition of the `NotificationChannel` to create.
           #   A hash of the same form as `Google::Monitoring::V3::NotificationChannel`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -502,7 +502,7 @@ module Google
           #   notification_channel_service_client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
           #   formatted_name = Google::Cloud::Monitoring::V3::NotificationChannelServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +notification_channel+:
+          #   # TODO: Initialize `notification_channel`:
           #   notification_channel = {}
           #   response = notification_channel_service_client.create_notification_channel(formatted_name, notification_channel)
 
@@ -526,7 +526,7 @@ module Google
           #   A description of the changes to be applied to the specified
           #   notification channel. The description must provide a definition for
           #   fields to be updated; the names of these fields should also be
-          #   included in the +update_mask+.
+          #   included in the `update_mask`.
           #   A hash of the same form as `Google::Monitoring::V3::NotificationChannel`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -546,7 +546,7 @@ module Google
           #
           #   notification_channel_service_client = Google::Cloud::Monitoring::NotificationChannel.new(version: :v3)
           #
-          #   # TODO: Initialize +notification_channel+:
+          #   # TODO: Initialize `notification_channel`:
           #   notification_channel = {}
           #   response = notification_channel_service_client.update_notification_channel(notification_channel)
 
@@ -567,7 +567,7 @@ module Google
           #
           # @param name [String]
           #   The channel for which to execute the request. The format is
-          #   +projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]+.
+          #   `projects/[PROJECT_ID]/notificationChannels/[CHANNEL_ID]`.
           # @param force [true, false]
           #   If true, the notification channel will be deleted regardless of its
           #   use in alert policies (the policies will be updated to remove the

--- a/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
+++ b/google-cloud-monitoring/lib/google/cloud/monitoring/v3/uptime_check_service_client.rb
@@ -255,7 +255,7 @@ module Google
           #
           # @param parent [String]
           #   The project whose uptime check configurations are listed. The format
-          #     is +projects/[PROJECT_ID]+.
+          #     is `projects/[PROJECT_ID]`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -310,7 +310,7 @@ module Google
           #
           # @param name [String]
           #   The uptime check configuration to retrieve. The format
-          #     is +projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]+.
+          #     is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -341,7 +341,7 @@ module Google
           #
           # @param parent [String]
           #   The project in which to create the uptime check. The format
-          #     is +projects/[PROJECT_ID]+.
+          #     is `projects/[PROJECT_ID]`.
           # @param uptime_check_config [Google::Monitoring::V3::UptimeCheckConfig | Hash]
           #   The new uptime check configuration.
           #   A hash of the same form as `Google::Monitoring::V3::UptimeCheckConfig`
@@ -360,7 +360,7 @@ module Google
           #   uptime_check_service_client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
           #   formatted_parent = Google::Cloud::Monitoring::V3::UptimeCheckServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +uptime_check_config+:
+          #   # TODO: Initialize `uptime_check_config`:
           #   uptime_check_config = {}
           #   response = uptime_check_service_client.create_uptime_check_config(formatted_parent, uptime_check_config)
 
@@ -379,21 +379,21 @@ module Google
 
           # Updates an uptime check configuration. You can either replace the entire
           # configuration with a new one or replace only certain fields in the current
-          # configuration by specifying the fields to be updated via +"updateMask"+.
+          # configuration by specifying the fields to be updated via `"updateMask"`.
           # Returns the updated configuration.
           #
           # @param uptime_check_config [Google::Monitoring::V3::UptimeCheckConfig | Hash]
-          #   Required. If an +"updateMask"+ has been specified, this field gives
-          #   the values for the set of fields mentioned in the +"updateMask"+. If an
-          #   +"updateMask"+ has not been given, this uptime check configuration replaces
-          #   the current configuration. If a field is mentioned in +"updateMask"+ but
+          #   Required. If an `"updateMask"` has been specified, this field gives
+          #   the values for the set of fields mentioned in the `"updateMask"`. If an
+          #   `"updateMask"` has not been given, this uptime check configuration replaces
+          #   the current configuration. If a field is mentioned in `"updateMask"` but
           #   the corresonding field is omitted in this partial uptime check
           #   configuration, it has the effect of deleting/clearing the field from the
           #   configuration on the server.
           #
-          #   The following fields can be updated: +display_name+,
-          #   +http_check+, +tcp_check+, +timeout+, +content_matchers+, and
-          #   +selected_regions+.
+          #   The following fields can be updated: `display_name`,
+          #   `http_check`, `tcp_check`, `timeout`, `content_matchers`, and
+          #   `selected_regions`.
           #   A hash of the same form as `Google::Monitoring::V3::UptimeCheckConfig`
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
@@ -416,7 +416,7 @@ module Google
           #
           #   uptime_check_service_client = Google::Cloud::Monitoring::UptimeCheck.new(version: :v3)
           #
-          #   # TODO: Initialize +uptime_check_config+:
+          #   # TODO: Initialize `uptime_check_config`:
           #   uptime_check_config = {}
           #   response = uptime_check_service_client.update_uptime_check_config(uptime_check_config)
 
@@ -439,7 +439,7 @@ module Google
           #
           # @param name [String]
           #   The uptime check configuration to delete. The format
-          #     is +projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]+.
+          #     is `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-monitoring/synth.py
+++ b/google-cloud-monitoring/synth.py
@@ -47,10 +47,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/cloud/oslogin/v1/oslogin.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/cloud/oslogin/v1/oslogin.rb
@@ -39,7 +39,7 @@ module Google
         #   @return [String]
         #     A reference to the POSIX account to update. POSIX accounts are identified
         #     by the project ID they are associated with. A reference to the POSIX
-        #     account is in format +users/\\{user}/projects/\\{project}+.
+        #     account is in format `users/{user}/projects/{project}`.
         class DeletePosixAccountRequest; end
 
         # A request message for deleting an SSH public key.
@@ -47,13 +47,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     `users/{user}/sshPublicKeys/{fingerprint}`.
         class DeleteSshPublicKeyRequest; end
 
         # A request message for retrieving the login profile information for a user.
         # @!attribute [rw] name
         #   @return [String]
-        #     The unique ID for the user in format +users/\\{user}+.
+        #     The unique ID for the user in format `users/{user}`.
         class GetLoginProfileRequest; end
 
         # A request message for retrieving an SSH public key.
@@ -61,13 +61,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to retrieve. Public keys are identified
         #     by their SHA-256 fingerprint. The fingerprint of the public key is in
-        #     format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     format `users/{user}/sshPublicKeys/{fingerprint}`.
         class GetSshPublicKeyRequest; end
 
         # A request message for importing an SSH public key.
         # @!attribute [rw] parent
         #   @return [String]
-        #     The unique ID for the user in format +users/\\{user}+.
+        #     The unique ID for the user in format `users/{user}`.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.
@@ -87,7 +87,7 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     `users/{user}/sshPublicKeys/{fingerprint}`.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1/os_login_service_client.rb
@@ -254,7 +254,7 @@ module Google
           # @param name [String]
           #   A reference to the POSIX account to update. POSIX accounts are identified
           #   by the project ID they are associated with. A reference to the POSIX
-          #   account is in format +users/\\{user}/projects/\\{project}+.
+          #   account is in format `users/{user}/projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -286,7 +286,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -317,7 +317,7 @@ module Google
           # on Google Compute Engine.
           #
           # @param name [String]
-          #   The unique ID for the user in format +users/\\{user}+.
+          #   The unique ID for the user in format `users/{user}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -349,7 +349,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to retrieve. Public keys are identified
           #   by their SHA-256 fingerprint. The fingerprint of the public key is in
-          #   format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   format `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -381,7 +381,7 @@ module Google
           # login profile.
           #
           # @param parent [String]
-          #   The unique ID for the user in format +users/\\{user}+.
+          #   The unique ID for the user in format `users/{user}`.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -402,7 +402,7 @@ module Google
           #   os_login_service_client = Google::Cloud::OsLogin.new(version: :v1)
           #   formatted_parent = Google::Cloud::OsLogin::V1::OsLoginServiceClient.user_path("[USER]")
           #
-          #   # TODO: Initialize +ssh_public_key+:
+          #   # TODO: Initialize `ssh_public_key`:
           #   ssh_public_key = {}
           #   response = os_login_service_client.import_ssh_public_key(formatted_parent, ssh_public_key)
 
@@ -427,7 +427,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -450,7 +450,7 @@ module Google
           #   os_login_service_client = Google::Cloud::OsLogin.new(version: :v1)
           #   formatted_name = Google::Cloud::OsLogin::V1::OsLoginServiceClient.fingerprint_path("[USER]", "[FINGERPRINT]")
           #
-          #   # TODO: Initialize +ssh_public_key+:
+          #   # TODO: Initialize `ssh_public_key`:
           #   ssh_public_key = {}
           #   response = os_login_service_client.update_ssh_public_key(formatted_name, ssh_public_key)
 

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/cloud/oslogin/v1beta/oslogin.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/cloud/oslogin/v1beta/oslogin.rb
@@ -39,7 +39,7 @@ module Google
         #   @return [String]
         #     A reference to the POSIX account to update. POSIX accounts are identified
         #     by the project ID they are associated with. A reference to the POSIX
-        #     account is in format +users/\\{user}/projects/\\{project}+.
+        #     account is in format `users/{user}/projects/{project}`.
         class DeletePosixAccountRequest; end
 
         # A request message for deleting an SSH public key.
@@ -47,13 +47,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     `users/{user}/sshPublicKeys/{fingerprint}`.
         class DeleteSshPublicKeyRequest; end
 
         # A request message for retrieving the login profile information for a user.
         # @!attribute [rw] name
         #   @return [String]
-        #     The unique ID for the user in format +users/\\{user}+.
+        #     The unique ID for the user in format `users/{user}`.
         class GetLoginProfileRequest; end
 
         # A request message for retrieving an SSH public key.
@@ -61,13 +61,13 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to retrieve. Public keys are identified
         #     by their SHA-256 fingerprint. The fingerprint of the public key is in
-        #     format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     format `users/{user}/sshPublicKeys/{fingerprint}`.
         class GetSshPublicKeyRequest; end
 
         # A request message for importing an SSH public key.
         # @!attribute [rw] parent
         #   @return [String]
-        #     The unique ID for the user in format +users/\\{user}+.
+        #     The unique ID for the user in format `users/{user}`.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.
@@ -87,7 +87,7 @@ module Google
         #   @return [String]
         #     The fingerprint of the public key to update. Public keys are identified by
         #     their SHA-256 fingerprint. The fingerprint of the public key is in format
-        #     +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+        #     `users/{user}/sshPublicKeys/{fingerprint}`.
         # @!attribute [rw] ssh_public_key
         #   @return [Google::Cloud::Oslogin::Common::SshPublicKey]
         #     The SSH public key and expiration time.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/protobuf/empty.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
+++ b/google-cloud-os_login/lib/google/cloud/os_login/v1beta/os_login_service_client.rb
@@ -254,7 +254,7 @@ module Google
           # @param name [String]
           #   A reference to the POSIX account to update. POSIX accounts are identified
           #   by the project ID they are associated with. A reference to the POSIX
-          #   account is in format +users/\\{user}/projects/\\{project}+.
+          #   account is in format `users/{user}/projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -286,7 +286,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -317,7 +317,7 @@ module Google
           # on Google Compute Engine.
           #
           # @param name [String]
-          #   The unique ID for the user in format +users/\\{user}+.
+          #   The unique ID for the user in format `users/{user}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -349,7 +349,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to retrieve. Public keys are identified
           #   by their SHA-256 fingerprint. The fingerprint of the public key is in
-          #   format +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   format `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -381,7 +381,7 @@ module Google
           # login profile.
           #
           # @param parent [String]
-          #   The unique ID for the user in format +users/\\{user}+.
+          #   The unique ID for the user in format `users/{user}`.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -402,7 +402,7 @@ module Google
           #   os_login_service_client = Google::Cloud::OsLogin::V1beta.new(version: :v1beta)
           #   formatted_parent = Google::Cloud::OsLogin::V1beta::OsLoginServiceClient.user_path("[USER]")
           #
-          #   # TODO: Initialize +ssh_public_key+:
+          #   # TODO: Initialize `ssh_public_key`:
           #   ssh_public_key = {}
           #   response = os_login_service_client.import_ssh_public_key(formatted_parent, ssh_public_key)
 
@@ -427,7 +427,7 @@ module Google
           # @param name [String]
           #   The fingerprint of the public key to update. Public keys are identified by
           #   their SHA-256 fingerprint. The fingerprint of the public key is in format
-          #   +users/\\{user}/sshPublicKeys/\\{fingerprint}+.
+          #   `users/{user}/sshPublicKeys/{fingerprint}`.
           # @param ssh_public_key [Google::Cloud::Oslogin::Common::SshPublicKey | Hash]
           #   The SSH public key and expiration time.
           #   A hash of the same form as `Google::Cloud::Oslogin::Common::SshPublicKey`
@@ -450,7 +450,7 @@ module Google
           #   os_login_service_client = Google::Cloud::OsLogin::V1beta.new(version: :v1beta)
           #   formatted_name = Google::Cloud::OsLogin::V1beta::OsLoginServiceClient.fingerprint_path("[USER]", "[FINGERPRINT]")
           #
-          #   # TODO: Initialize +ssh_public_key+:
+          #   # TODO: Initialize `ssh_public_key`:
           #   ssh_public_key = {}
           #   response = os_login_service_client.update_ssh_public_key(formatted_name, ssh_public_key)
 

--- a/google-cloud-os_login/synth.py
+++ b/google-cloud-os_login/synth.py
@@ -75,10 +75,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/doc/google/pubsub/v1/pubsub.rb
@@ -30,11 +30,11 @@ module Google
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the topic. It must have the format
-      #     +"projects/\\{project}/topics/\\{topic}"+. +\\{topic}+ must start with a letter,
-      #     and contain only letters (+[A-Za-z]+), numbers (+[0-9]+), dashes (+-+),
-      #     underscores (+_+), periods (+.+), tildes (+~+), plus (+++) or percent
-      #     signs (+%+). It must be between 3 and 255 characters in length, and it
-      #     must not start with +"goog"+.
+      #     `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
+      #     and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
+      #     underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
+      #     signs (`%`). It must be between 3 and 255 characters in length, and it
+      #     must not start with `"goog"`.
       # @!attribute [rw] labels
       #   @return [Hash{String => String}]
       #     User labels.
@@ -60,20 +60,20 @@ module Google
       #   @return [String]
       #     ID of this message, assigned by the server when the message is published.
       #     Guaranteed to be unique within the topic. This value may be read by a
-      #     subscriber that receives a +PubsubMessage+ via a +Pull+ call or a push
-      #     delivery. It must not be populated by the publisher in a +Publish+ call.
+      #     subscriber that receives a `PubsubMessage` via a `Pull` call or a push
+      #     delivery. It must not be populated by the publisher in a `Publish` call.
       # @!attribute [rw] publish_time
       #   @return [Google::Protobuf::Timestamp]
       #     The time at which the message was published, populated by the server when
-      #     it receives the +Publish+ call. It must not be populated by the
-      #     publisher in a +Publish+ call.
+      #     it receives the `Publish` call. It must not be populated by the
+      #     publisher in a `Publish` call.
       class PubsubMessage; end
 
       # Request for the GetTopic method.
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic to get.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
+      #     Format is `projects/{project}/topics/{topic}`.
       class GetTopicRequest; end
 
       # Request for the UpdateTopic method.
@@ -83,23 +83,23 @@ module Google
       # @!attribute [rw] update_mask
       #   @return [Google::Protobuf::FieldMask]
       #     Indicates which fields in the provided topic to update. Must be specified
-      #     and non-empty. Note that if +update_mask+ contains
+      #     and non-empty. Note that if `update_mask` contains
       #     "message_storage_policy" then the new value will be determined based on the
       #     policy configured at the project or organization level. The
-      #     +message_storage_policy+ must not be set in the +topic+ provided above.
+      #     `message_storage_policy` must not be set in the `topic` provided above.
       class UpdateTopicRequest; end
 
       # Request for the Publish method.
       # @!attribute [rw] topic
       #   @return [String]
       #     The messages in the request will be published on this topic.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
+      #     Format is `projects/{project}/topics/{topic}`.
       # @!attribute [rw] messages
       #   @return [Array<Google::Pubsub::V1::PubsubMessage>]
       #     The messages to publish.
       class PublishRequest; end
 
-      # Response for the +Publish+ method.
+      # Response for the `Publish` method.
       # @!attribute [rw] message_ids
       #   @return [Array<String>]
       #     The server-assigned ID of each published message, in the same order as
@@ -107,47 +107,47 @@ module Google
       #     the topic.
       class PublishResponse; end
 
-      # Request for the +ListTopics+ method.
+      # Request for the `ListTopics` method.
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that topics belong to.
-      #     Format is +projects/\\{project}+.
+      #     Format is `projects/{project}`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of topics to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The value returned by the last +ListTopicsResponse+; indicates that this is
-      #     a continuation of a prior +ListTopics+ call, and that the system should
+      #     The value returned by the last `ListTopicsResponse`; indicates that this is
+      #     a continuation of a prior `ListTopics` call, and that the system should
       #     return the next page of data.
       class ListTopicsRequest; end
 
-      # Response for the +ListTopics+ method.
+      # Response for the `ListTopics` method.
       # @!attribute [rw] topics
       #   @return [Array<Google::Pubsub::V1::Topic>]
       #     The resulting topics.
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If not empty, indicates that there may be more topics that match the
-      #     request; this value should be passed in a new +ListTopicsRequest+.
+      #     request; this value should be passed in a new `ListTopicsRequest`.
       class ListTopicsResponse; end
 
-      # Request for the +ListTopicSubscriptions+ method.
+      # Request for the `ListTopicSubscriptions` method.
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic that subscriptions are attached to.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
+      #     Format is `projects/{project}/topics/{topic}`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of subscription names to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The value returned by the last +ListTopicSubscriptionsResponse+; indicates
-      #     that this is a continuation of a prior +ListTopicSubscriptions+ call, and
+      #     The value returned by the last `ListTopicSubscriptionsResponse`; indicates
+      #     that this is a continuation of a prior `ListTopicSubscriptions` call, and
       #     that the system should return the next page of data.
       class ListTopicSubscriptionsRequest; end
 
-      # Response for the +ListTopicSubscriptions+ method.
+      # Response for the `ListTopicSubscriptions` method.
       # @!attribute [rw] subscriptions
       #   @return [Array<String>]
       #     The names of the subscriptions that match the request.
@@ -155,28 +155,28 @@ module Google
       #   @return [String]
       #     If not empty, indicates that there may be more subscriptions that match
       #     the request; this value should be passed in a new
-      #     +ListTopicSubscriptionsRequest+ to get more subscriptions.
+      #     `ListTopicSubscriptionsRequest` to get more subscriptions.
       class ListTopicSubscriptionsResponse; end
 
-      # Request for the +ListTopicSnapshots+ method.<br><br>
+      # Request for the `ListTopicSnapshots` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic that snapshots are attached to.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
+      #     Format is `projects/{project}/topics/{topic}`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of snapshot names to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The value returned by the last +ListTopicSnapshotsResponse+; indicates
-      #     that this is a continuation of a prior +ListTopicSnapshots+ call, and
+      #     The value returned by the last `ListTopicSnapshotsResponse`; indicates
+      #     that this is a continuation of a prior `ListTopicSnapshots` call, and
       #     that the system should return the next page of data.
       class ListTopicSnapshotsRequest; end
 
-      # Response for the +ListTopicSnapshots+ method.<br><br>
+      # Response for the `ListTopicSnapshots` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
@@ -187,35 +187,35 @@ module Google
       #   @return [String]
       #     If not empty, indicates that there may be more snapshots that match
       #     the request; this value should be passed in a new
-      #     +ListTopicSnapshotsRequest+ to get more snapshots.
+      #     `ListTopicSnapshotsRequest` to get more snapshots.
       class ListTopicSnapshotsResponse; end
 
-      # Request for the +DeleteTopic+ method.
+      # Request for the `DeleteTopic` method.
       # @!attribute [rw] topic
       #   @return [String]
       #     Name of the topic to delete.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
+      #     Format is `projects/{project}/topics/{topic}`.
       class DeleteTopicRequest; end
 
       # A subscription resource.
       # @!attribute [rw] name
       #   @return [String]
       #     The name of the subscription. It must have the format
-      #     +"projects/\\{project}/subscriptions/\\{subscription}"+. +\\{subscription}+ must
-      #     start with a letter, and contain only letters (+[A-Za-z]+), numbers
-      #     (+[0-9]+), dashes (+-+), underscores (+_+), periods (+.+), tildes (+~+),
-      #     plus (+++) or percent signs (+%+). It must be between 3 and 255 characters
-      #     in length, and it must not start with +"goog"+
+      #     `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
+      #     start with a letter, and contain only letters (`[A-Za-z]`), numbers
+      #     (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
+      #     plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
+      #     in length, and it must not start with `"goog"`
       # @!attribute [rw] topic
       #   @return [String]
       #     The name of the topic from which this subscription is receiving messages.
-      #     Format is +projects/\\{project}/topics/\\{topic}+.
-      #     The value of this field will be +_deleted-topic_+ if the topic has been
+      #     Format is `projects/{project}/topics/{topic}`.
+      #     The value of this field will be `_deleted-topic_` if the topic has been
       #     deleted.
       # @!attribute [rw] push_config
       #   @return [Google::Pubsub::V1::PushConfig]
       #     If push delivery is used with this subscription, this field is
-      #     used to configure it. An empty +pushConfig+ signifies that the subscriber
+      #     used to configure it. An empty `pushConfig` signifies that the subscriber
       #     will pull and ack messages using API methods.
       # @!attribute [rw] ack_deadline_seconds
       #   @return [Integer]
@@ -227,9 +227,9 @@ module Google
       #
       #     For pull subscriptions, this value is used as the initial value for the ack
       #     deadline. To override this value for a given message, call
-      #     +ModifyAckDeadline+ with the corresponding +ack_id+ if using
-      #     non-streaming pull or send the +ack_id+ in a
-      #     +StreamingModifyAckDeadlineRequest+ if using streaming pull.
+      #     `ModifyAckDeadline` with the corresponding `ack_id` if using
+      #     non-streaming pull or send the `ack_id` in a
+      #     `StreamingModifyAckDeadlineRequest` if using streaming pull.
       #     The minimum custom deadline you can specify is 10 seconds.
       #     The maximum custom deadline you can specify is 600 seconds (10 minutes).
       #     If this parameter is 0, a default value of 10 seconds is used.
@@ -243,7 +243,7 @@ module Google
       #   @return [true, false]
       #     Indicates whether to retain acknowledged messages. If true, then
       #     messages are not expunged from the subscription's backlog, even if they are
-      #     acknowledged, until they fall out of the +message_retention_duration+
+      #     acknowledged, until they fall out of the `message_retention_duration`
       #     window.<br><br>
       #     <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       #     changed in backward-incompatible ways and is not recommended for production
@@ -252,8 +252,8 @@ module Google
       #   @return [Google::Protobuf::Duration]
       #     How long to retain unacknowledged messages in the subscription's backlog,
       #     from the moment a message is published.
-      #     If +retain_acked_messages+ is true, then this also configures the retention
-      #     of acknowledged messages, and thus configures how far back in time a +Seek+
+      #     If `retain_acked_messages` is true, then this also configures the retention
+      #     of acknowledged messages, and thus configures how far back in time a `Seek`
       #     can be done. Defaults to 7 days. Cannot be more than 7 days or less than 10
       #     minutes.<br><br>
       #     <b>ALPHA:</b> This feature is part of an alpha release. This API might be
@@ -276,22 +276,22 @@ module Google
       #     Every endpoint has a set of API supported attributes that can be used to
       #     control different aspects of the message delivery.
       #
-      #     The currently supported attribute is +x-goog-version+, which you can
+      #     The currently supported attribute is `x-goog-version`, which you can
       #     use to change the format of the pushed message. This attribute
       #     indicates the version of the data expected by the endpoint. This
       #     controls the shape of the pushed message (i.e., its fields and metadata).
       #     The endpoint version is based on the version of the Pub/Sub API.
       #
-      #     If not present during the +CreateSubscription+ call, it will default to
+      #     If not present during the `CreateSubscription` call, it will default to
       #     the version of the API used to make such call. If not present during a
-      #     +ModifyPushConfig+ call, its value will not be changed. +GetSubscription+
+      #     `ModifyPushConfig` call, its value will not be changed. `GetSubscription`
       #     calls will always return a valid version, even if the subscription was
       #     created without this attribute.
       #
       #     The possible values for this attribute are:
       #
-      #     * +v1beta1+: uses the push format defined in the v1beta1 Pub/Sub API.
-      #     * +v1+ or +v1beta2+: uses the push format defined in the v1 Pub/Sub API.
+      #     * `v1beta1`: uses the push format defined in the v1beta1 Pub/Sub API.
+      #     * `v1` or `v1beta2`: uses the push format defined in the v1 Pub/Sub API.
       class PushConfig; end
 
       # A message and its corresponding acknowledgment ID.
@@ -307,7 +307,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription to get.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       class GetSubscriptionRequest; end
 
       # Request for the UpdateSubscription method.
@@ -320,22 +320,22 @@ module Google
       #     Must be specified and non-empty.
       class UpdateSubscriptionRequest; end
 
-      # Request for the +ListSubscriptions+ method.
+      # Request for the `ListSubscriptions` method.
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that subscriptions belong to.
-      #     Format is +projects/\\{project}+.
+      #     Format is `projects/{project}`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of subscriptions to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The value returned by the last +ListSubscriptionsResponse+; indicates that
-      #     this is a continuation of a prior +ListSubscriptions+ call, and that the
+      #     The value returned by the last `ListSubscriptionsResponse`; indicates that
+      #     this is a continuation of a prior `ListSubscriptions` call, and that the
       #     system should return the next page of data.
       class ListSubscriptionsRequest; end
 
-      # Response for the +ListSubscriptions+ method.
+      # Response for the `ListSubscriptions` method.
       # @!attribute [rw] subscriptions
       #   @return [Array<Google::Pubsub::V1::Subscription>]
       #     The subscriptions that match the request.
@@ -343,40 +343,40 @@ module Google
       #   @return [String]
       #     If not empty, indicates that there may be more subscriptions that match
       #     the request; this value should be passed in a new
-      #     +ListSubscriptionsRequest+ to get more subscriptions.
+      #     `ListSubscriptionsRequest` to get more subscriptions.
       class ListSubscriptionsResponse; end
 
       # Request for the DeleteSubscription method.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription to delete.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       class DeleteSubscriptionRequest; end
 
       # Request for the ModifyPushConfig method.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] push_config
       #   @return [Google::Pubsub::V1::PushConfig]
       #     The push configuration for future deliveries.
       #
-      #     An empty +pushConfig+ indicates that the Pub/Sub system should
+      #     An empty `pushConfig` indicates that the Pub/Sub system should
       #     stop pushing messages from the given subscription and allow
       #     messages to be pulled and acknowledged - effectively pausing
-      #     the subscription if +Pull+ or +StreamingPull+ is not called.
+      #     the subscription if `Pull` or `StreamingPull` is not called.
       class ModifyPushConfigRequest; end
 
-      # Request for the +Pull+ method.
+      # Request for the `Pull` method.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription from which messages should be pulled.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] return_immediately
       #   @return [true, false]
       #     If this field set to true, the system will respond immediately even if
-      #     it there are no messages available to return in the +Pull+ response.
+      #     it there are no messages available to return in the `Pull` response.
       #     Otherwise, the system may wait (for a bounded amount of time) until at
       #     least one message is available, rather than returning no messages. The
       #     client may cancel the request if it does not wish to wait any longer for
@@ -387,12 +387,12 @@ module Google
       #     system may return fewer than the number specified.
       class PullRequest; end
 
-      # Response for the +Pull+ method.
+      # Response for the `Pull` method.
       # @!attribute [rw] received_messages
       #   @return [Array<Google::Pubsub::V1::ReceivedMessage>]
       #     Received Pub/Sub messages. The Pub/Sub system will return zero messages if
       #     there are no more available in the backlog. The Pub/Sub system may return
-      #     fewer than the +maxMessages+ requested even if there are more messages
+      #     fewer than the `maxMessages` requested even if there are more messages
       #     available in the backlog.
       class PullResponse; end
 
@@ -400,7 +400,7 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The name of the subscription.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     List of acknowledgment IDs.
@@ -408,7 +408,7 @@ module Google
       #   @return [Integer]
       #     The new ack deadline with respect to the time this request was sent to
       #     the Pub/Sub system. For example, if the value is 10, the new
-      #     ack deadline will expire 10 seconds after the +ModifyAckDeadline+ call
+      #     ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
       #     was made. Specifying zero may immediately make the message available for
       #     another pull request.
       #     The minimum deadline you can specify is 0 seconds.
@@ -419,14 +419,14 @@ module Google
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription whose message is being acknowledged.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     The acknowledgment ID for the messages being acknowledged that was returned
-      #     by the Pub/Sub system in the +Pull+ response. Must not be empty.
+      #     by the Pub/Sub system in the `Pull` response. Must not be empty.
       class AcknowledgeRequest; end
 
-      # Request for the +StreamingPull+ streaming RPC method. This request is used to
+      # Request for the `StreamingPull` streaming RPC method. This request is used to
       # establish the initial stream as well as to stream acknowledgements and ack
       # deadline modifications from the client to the server.
       # @!attribute [rw] subscription
@@ -434,31 +434,31 @@ module Google
       #     The subscription for which to initialize the new stream. This must be
       #     provided in the first request on the stream, and must not be set in
       #     subsequent requests from client to server.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] ack_ids
       #   @return [Array<String>]
       #     List of acknowledgement IDs for acknowledging previously received messages
       #     (received on this stream or a different stream). If an ack ID has expired,
       #     the corresponding message may be redelivered later. Acknowledging a message
       #     more than once will not result in an error. If the acknowledgement ID is
-      #     malformed, the stream will be aborted with status +INVALID_ARGUMENT+.
+      #     malformed, the stream will be aborted with status `INVALID_ARGUMENT`.
       # @!attribute [rw] modify_deadline_seconds
       #   @return [Array<Integer>]
       #     The list of new ack deadlines for the IDs listed in
-      #     +modify_deadline_ack_ids+. The size of this list must be the same as the
-      #     size of +modify_deadline_ack_ids+. If it differs the stream will be aborted
-      #     with +INVALID_ARGUMENT+. Each element in this list is applied to the
-      #     element in the same position in +modify_deadline_ack_ids+. The new ack
+      #     `modify_deadline_ack_ids`. The size of this list must be the same as the
+      #     size of `modify_deadline_ack_ids`. If it differs the stream will be aborted
+      #     with `INVALID_ARGUMENT`. Each element in this list is applied to the
+      #     element in the same position in `modify_deadline_ack_ids`. The new ack
       #     deadline is with respect to the time this request was sent to the Pub/Sub
       #     system. Must be >= 0. For example, if the value is 10, the new ack deadline
       #     will expire 10 seconds after this request is received. If the value is 0,
       #     the message is immediately made available for another streaming or
       #     non-streaming pull request. If the value is < 0 (an error), the stream will
-      #     be aborted with status +INVALID_ARGUMENT+.
+      #     be aborted with status `INVALID_ARGUMENT`.
       # @!attribute [rw] modify_deadline_ack_ids
       #   @return [Array<String>]
       #     List of acknowledgement IDs whose deadline will be modified based on the
-      #     corresponding element in +modify_deadline_seconds+. This field can be used
+      #     corresponding element in `modify_deadline_seconds`. This field can be used
       #     to indicate that more time is needed to process a message by the
       #     subscriber, or to make the message available for redelivery if the
       #     processing was interrupted.
@@ -470,14 +470,14 @@ module Google
       #     seconds. The maximum deadline you can specify is 600 seconds (10 minutes).
       class StreamingPullRequest; end
 
-      # Response for the +StreamingPull+ method. This response is used to stream
+      # Response for the `StreamingPull` method. This response is used to stream
       # messages from the server to the client.
       # @!attribute [rw] received_messages
       #   @return [Array<Google::Pubsub::V1::ReceivedMessage>]
       #     Received Pub/Sub messages. This will not be empty.
       class StreamingPullResponse; end
 
-      # Request for the +CreateSnapshot+ method.<br><br>
+      # Request for the `CreateSnapshot` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be changed in
       # backward-incompatible ways and is not recommended for production use.
       # It is not subject to any SLA or deprecation policy.
@@ -487,7 +487,7 @@ module Google
       #     If the name is not provided in the request, the server will assign a random
       #     name for this snapshot on the same project as the subscription.
       #     Note that for REST API requests, you must specify a name.
-      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
+      #     Format is `projects/{project}/snapshots/{snap}`.
       # @!attribute [rw] subscription
       #   @return [String]
       #     The subscription whose backlog the snapshot retains.
@@ -495,10 +495,10 @@ module Google
       #      (a) The existing backlog on the subscription. More precisely, this is
       #          defined as the messages in the subscription's backlog that are
       #          unacknowledged upon the successful completion of the
-      #          +CreateSnapshot+ request; as well as:
+      #          `CreateSnapshot` request; as well as:
       #      (b) Any messages published to the subscription's topic following the
       #          successful completion of the CreateSnapshot request.
-      #     Format is +projects/\\{project}/subscriptions/\\{sub}+.
+      #     Format is `projects/{project}/subscriptions/{sub}`.
       # @!attribute [rw] labels
       #   @return [Hash{String => String}]
       #     User labels.
@@ -533,7 +533,7 @@ module Google
       #     A newly-created snapshot expires no later than 7 days from the time of its
       #     creation. Its exact lifetime is determined at creation by the existing
       #     backlog in the source subscription. Specifically, the lifetime of the
-      #     snapshot is +7 days - (age of oldest unacked message in the subscription)+.
+      #     snapshot is `7 days - (age of oldest unacked message in the subscription)`.
       #     For example, consider a subscription whose oldest unacked message is 3 days
       #     old. If a snapshot is created from this subscription, the snapshot -- which
       #     will always capture this 3-day-old backlog as long as the snapshot
@@ -551,28 +551,28 @@ module Google
       # @!attribute [rw] snapshot
       #   @return [String]
       #     The name of the snapshot to get.
-      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
+      #     Format is `projects/{project}/snapshots/{snap}`.
       class GetSnapshotRequest; end
 
-      # Request for the +ListSnapshots+ method.<br><br>
+      # Request for the `ListSnapshots` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
       # @!attribute [rw] project
       #   @return [String]
       #     The name of the cloud project that snapshots belong to.
-      #     Format is +projects/\\{project}+.
+      #     Format is `projects/{project}`.
       # @!attribute [rw] page_size
       #   @return [Integer]
       #     Maximum number of snapshots to return.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     The value returned by the last +ListSnapshotsResponse+; indicates that this
-      #     is a continuation of a prior +ListSnapshots+ call, and that the system
+      #     The value returned by the last `ListSnapshotsResponse`; indicates that this
+      #     is a continuation of a prior `ListSnapshots` call, and that the system
       #     should return the next page of data.
       class ListSnapshotsRequest; end
 
-      # Response for the +ListSnapshots+ method.<br><br>
+      # Response for the `ListSnapshots` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
@@ -582,20 +582,20 @@ module Google
       # @!attribute [rw] next_page_token
       #   @return [String]
       #     If not empty, indicates that there may be more snapshot that match the
-      #     request; this value should be passed in a new +ListSnapshotsRequest+.
+      #     request; this value should be passed in a new `ListSnapshotsRequest`.
       class ListSnapshotsResponse; end
 
-      # Request for the +DeleteSnapshot+ method.<br><br>
+      # Request for the `DeleteSnapshot` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
       # @!attribute [rw] snapshot
       #   @return [String]
       #     The name of the snapshot to delete.
-      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
+      #     Format is `projects/{project}/snapshots/{snap}`.
       class DeleteSnapshotRequest; end
 
-      # Request for the +Seek+ method.<br><br>
+      # Request for the `Seek` method.<br><br>
       # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
       # changed in backward-incompatible ways and is not recommended for production
       # use. It is not subject to any SLA or deprecation policy.
@@ -610,8 +610,8 @@ module Google
       #     subscription that were published after this time are marked as
       #     unacknowledged. Note that this operation affects only those messages
       #     retained in the subscription (configured by the combination of
-      #     +message_retention_duration+ and +retain_acked_messages+). For example,
-      #     if +time+ corresponds to a point before the message retention
+      #     `message_retention_duration` and `retain_acked_messages`). For example,
+      #     if `time` corresponds to a point before the message retention
       #     window (or to a point before the system's notion of the subscription
       #     creation time), only retained messages will be marked as unacknowledged,
       #     and already-expunged messages will not be restored.
@@ -619,7 +619,7 @@ module Google
       #   @return [String]
       #     The snapshot to seek to. The snapshot's topic must be the same as that of
       #     the provided subscription.
-      #     Format is +projects/\\{project}/snapshots/\\{snap}+.
+      #     Format is `projects/{project}/snapshots/{snap}`.
       class SeekRequest; end
 
       class SeekResponse; end

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/publisher_client.rb
@@ -293,11 +293,11 @@ module Google
           #
           # @param name [String]
           #   The name of the topic. It must have the format
-          #   +"projects/\\{project}/topics/\\{topic}"+. +\\{topic}+ must start with a letter,
-          #   and contain only letters (+[A-Za-z]+), numbers (+[0-9]+), dashes (+-+),
-          #   underscores (+_+), periods (+.+), tildes (+~+), plus (+++) or percent
-          #   signs (+%+). It must be between 3 and 255 characters in length, and it
-          #   must not start with +"goog"+.
+          #   `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter,
+          #   and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
+          #   underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
+          #   signs (`%`). It must be between 3 and 255 characters in length, and it
+          #   must not start with `"goog"`.
           # @param labels [Hash{String => String}]
           #   User labels.
           # @param message_storage_policy [Google::Pubsub::V1::MessageStoragePolicy | Hash]
@@ -348,10 +348,10 @@ module Google
           #   can also be provided.
           # @param update_mask [Google::Protobuf::FieldMask | Hash]
           #   Indicates which fields in the provided topic to update. Must be specified
-          #   and non-empty. Note that if +update_mask+ contains
+          #   and non-empty. Note that if `update_mask` contains
           #   "message_storage_policy" then the new value will be determined based on the
           #   policy configured at the project or organization level. The
-          #   +message_storage_policy+ must not be set in the +topic+ provided above.
+          #   `message_storage_policy` must not be set in the `topic` provided above.
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -367,10 +367,10 @@ module Google
           #
           #   publisher_client = Google::Cloud::Pubsub::Publisher.new(version: :v1)
           #
-          #   # TODO: Initialize +topic+:
+          #   # TODO: Initialize `topic`:
           #   topic = {}
           #
-          #   # TODO: Initialize +update_mask+:
+          #   # TODO: Initialize `update_mask`:
           #   update_mask = {}
           #   response = publisher_client.update_topic(topic, update_mask)
 
@@ -387,13 +387,13 @@ module Google
             @update_topic.call(req, options, &block)
           end
 
-          # Adds one or more messages to the topic. Returns +NOT_FOUND+ if the topic
+          # Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
           # does not exist. The message payload must not be empty; it must contain
           #  either a non-empty data field, or at least one attribute.
           #
           # @param topic [String]
           #   The messages in the request will be published on this topic.
-          #   Format is +projects/\\{project}/topics/\\{topic}+.
+          #   Format is `projects/{project}/topics/{topic}`.
           # @param messages [Array<Google::Pubsub::V1::PubsubMessage | Hash>]
           #   The messages to publish.
           #   A hash of the same form as `Google::Pubsub::V1::PubsubMessage`
@@ -433,7 +433,7 @@ module Google
           #
           # @param topic [String]
           #   The name of the topic to get.
-          #   Format is +projects/\\{project}/topics/\\{topic}+.
+          #   Format is `projects/{project}/topics/{topic}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -464,7 +464,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that topics belong to.
-          #   Format is +projects/\\{project}+.
+          #   Format is `projects/{project}`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -519,7 +519,7 @@ module Google
           #
           # @param topic [String]
           #   The name of the topic that subscriptions are attached to.
-          #   Format is +projects/\\{project}/topics/\\{topic}+.
+          #   Format is `projects/{project}/topics/{topic}`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -570,15 +570,15 @@ module Google
             @list_topic_subscriptions.call(req, options, &block)
           end
 
-          # Deletes the topic with the given name. Returns +NOT_FOUND+ if the topic
+          # Deletes the topic with the given name. Returns `NOT_FOUND` if the topic
           # does not exist. After a topic is deleted, a new topic may be created with
           # the same name; this is an entirely new topic with none of the old
           # configuration or subscriptions. Existing subscriptions to this topic are
-          # not deleted, but their +topic+ field is set to +_deleted-topic_+.
+          # not deleted, but their `topic` field is set to `_deleted-topic_`.
           #
           # @param topic [String]
           #   Name of the topic to delete.
-          #   Format is +projects/\\{project}/topics/\\{topic}+.
+          #   Format is `projects/{project}/topics/{topic}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -610,10 +610,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param policy [Google::Iam::V1::Policy | Hash]
-          #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+          #   REQUIRED: The complete policy to be applied to the `resource`. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
           #   valid policy but certain Cloud Platform services (such as Projects)
           #   might reject them.
@@ -633,7 +633,7 @@ module Google
           #   publisher_client = Google::Cloud::Pubsub::Publisher.new(version: :v1)
           #   formatted_resource = Google::Cloud::Pubsub::V1::PublisherClient.topic_path("[PROJECT]", "[TOPIC]")
           #
-          #   # TODO: Initialize +policy+:
+          #   # TODO: Initialize `policy`:
           #   policy = {}
           #   response = publisher_client.set_iam_policy(formatted_resource, policy)
 
@@ -656,8 +656,8 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -690,10 +690,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param permissions [Array<String>]
-          #   The set of permissions to check for the +resource+. Permissions with
+          #   The set of permissions to check for the `resource`. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more
           #   information see
           #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -711,7 +711,7 @@ module Google
           #   publisher_client = Google::Cloud::Pubsub::Publisher.new(version: :v1)
           #   formatted_resource = Google::Cloud::Pubsub::V1::PublisherClient.topic_path("[PROJECT]", "[TOPIC]")
           #
-          #   # TODO: Initialize +permissions+:
+          #   # TODO: Initialize `permissions`:
           #   permissions = []
           #   response = publisher_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/v1/subscriber_client.rb
@@ -34,8 +34,8 @@ module Google
     module Pubsub
       module V1
         # The service that an application uses to manipulate subscriptions and to
-        # consume messages from a subscription via the +Pull+ method or by
-        # establishing a bi-directional stream using the +StreamingPull+ method.
+        # consume messages from a subscription via the `Pull` method or by
+        # establishing a bi-directional stream using the `StreamingPull` method.
         #
         # @!attribute [r] iam_policy_stub
         #   @return [Google::Iam::V1::IAMPolicy::Stub]
@@ -353,8 +353,8 @@ module Google
 
           # Creates a subscription to a given topic. See the
           # <a href="/pubsub/docs/admin#resource_names"> resource name rules</a>.
-          # If the subscription already exists, returns +ALREADY_EXISTS+.
-          # If the corresponding topic doesn't exist, returns +NOT_FOUND+.
+          # If the subscription already exists, returns `ALREADY_EXISTS`.
+          # If the corresponding topic doesn't exist, returns `NOT_FOUND`.
           #
           # If the name is not provided in the request, the server will assign a random
           # name for this subscription on the same project as the topic, conforming
@@ -365,19 +365,19 @@ module Google
           #
           # @param name [String]
           #   The name of the subscription. It must have the format
-          #   +"projects/\\{project}/subscriptions/\\{subscription}"+. +\\{subscription}+ must
-          #   start with a letter, and contain only letters (+[A-Za-z]+), numbers
-          #   (+[0-9]+), dashes (+-+), underscores (+_+), periods (+.+), tildes (+~+),
-          #   plus (+++) or percent signs (+%+). It must be between 3 and 255 characters
-          #   in length, and it must not start with +"goog"+
+          #   `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must
+          #   start with a letter, and contain only letters (`[A-Za-z]`), numbers
+          #   (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
+          #   plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
+          #   in length, and it must not start with `"goog"`
           # @param topic [String]
           #   The name of the topic from which this subscription is receiving messages.
-          #   Format is +projects/\\{project}/topics/\\{topic}+.
-          #   The value of this field will be +_deleted-topic_+ if the topic has been
+          #   Format is `projects/{project}/topics/{topic}`.
+          #   The value of this field will be `_deleted-topic_` if the topic has been
           #   deleted.
           # @param push_config [Google::Pubsub::V1::PushConfig | Hash]
           #   If push delivery is used with this subscription, this field is
-          #   used to configure it. An empty +pushConfig+ signifies that the subscriber
+          #   used to configure it. An empty `pushConfig` signifies that the subscriber
           #   will pull and ack messages using API methods.
           #   A hash of the same form as `Google::Pubsub::V1::PushConfig`
           #   can also be provided.
@@ -390,9 +390,9 @@ module Google
           #
           #   For pull subscriptions, this value is used as the initial value for the ack
           #   deadline. To override this value for a given message, call
-          #   +ModifyAckDeadline+ with the corresponding +ack_id+ if using
-          #   non-streaming pull or send the +ack_id+ in a
-          #   +StreamingModifyAckDeadlineRequest+ if using streaming pull.
+          #   `ModifyAckDeadline` with the corresponding `ack_id` if using
+          #   non-streaming pull or send the `ack_id` in a
+          #   `StreamingModifyAckDeadlineRequest` if using streaming pull.
           #   The minimum custom deadline you can specify is 10 seconds.
           #   The maximum custom deadline you can specify is 600 seconds (10 minutes).
           #   If this parameter is 0, a default value of 10 seconds is used.
@@ -405,7 +405,7 @@ module Google
           # @param retain_acked_messages [true, false]
           #   Indicates whether to retain acknowledged messages. If true, then
           #   messages are not expunged from the subscription's backlog, even if they are
-          #   acknowledged, until they fall out of the +message_retention_duration+
+          #   acknowledged, until they fall out of the `message_retention_duration`
           #   window.<br><br>
           #   <b>ALPHA:</b> This feature is part of an alpha release. This API might be
           #   changed in backward-incompatible ways and is not recommended for production
@@ -413,8 +413,8 @@ module Google
           # @param message_retention_duration [Google::Protobuf::Duration | Hash]
           #   How long to retain unacknowledged messages in the subscription's backlog,
           #   from the moment a message is published.
-          #   If +retain_acked_messages+ is true, then this also configures the retention
-          #   of acknowledged messages, and thus configures how far back in time a +Seek+
+          #   If `retain_acked_messages` is true, then this also configures the retention
+          #   of acknowledged messages, and thus configures how far back in time a `Seek`
           #   can be done. Defaults to 7 days. Cannot be more than 7 days or less than 10
           #   minutes.<br><br>
           #   <b>ALPHA:</b> This feature is part of an alpha release. This API might be
@@ -467,7 +467,7 @@ module Google
           #
           # @param subscription [String]
           #   The name of the subscription to get.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -542,7 +542,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that subscriptions belong to.
-          #   Format is +projects/\\{project}+.
+          #   Format is `projects/{project}`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -594,14 +594,14 @@ module Google
           end
 
           # Deletes an existing subscription. All messages retained in the subscription
-          # are immediately dropped. Calls to +Pull+ after deletion will return
-          # +NOT_FOUND+. After a subscription is deleted, a new one may be created with
+          # are immediately dropped. Calls to `Pull` after deletion will return
+          # `NOT_FOUND`. After a subscription is deleted, a new one may be created with
           # the same name, but the new one has no association with the old
           # subscription or its topic unless the same topic is specified.
           #
           # @param subscription [String]
           #   The subscription to delete.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -632,17 +632,17 @@ module Google
           # to indicate that more time is needed to process a message by the
           # subscriber, or to make the message available for redelivery if the
           # processing was interrupted. Note that this does not modify the
-          # subscription-level +ackDeadlineSeconds+ used for subsequent messages.
+          # subscription-level `ackDeadlineSeconds` used for subsequent messages.
           #
           # @param subscription [String]
           #   The name of the subscription.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param ack_ids [Array<String>]
           #   List of acknowledgment IDs.
           # @param ack_deadline_seconds [Integer]
           #   The new ack deadline with respect to the time this request was sent to
           #   the Pub/Sub system. For example, if the value is 10, the new
-          #   ack deadline will expire 10 seconds after the +ModifyAckDeadline+ call
+          #   ack deadline will expire 10 seconds after the `ModifyAckDeadline` call
           #   was made. Specifying zero may immediately make the message available for
           #   another pull request.
           #   The minimum deadline you can specify is 0 seconds.
@@ -660,10 +660,10 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_subscription = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +ack_ids+:
+          #   # TODO: Initialize `ack_ids`:
           #   ack_ids = []
           #
-          #   # TODO: Initialize +ack_deadline_seconds+:
+          #   # TODO: Initialize `ack_deadline_seconds`:
           #   ack_deadline_seconds = 0
           #   subscriber_client.modify_ack_deadline(formatted_subscription, ack_ids, ack_deadline_seconds)
 
@@ -683,8 +683,8 @@ module Google
             nil
           end
 
-          # Acknowledges the messages associated with the +ack_ids+ in the
-          # +AcknowledgeRequest+. The Pub/Sub system can remove the relevant messages
+          # Acknowledges the messages associated with the `ack_ids` in the
+          # `AcknowledgeRequest`. The Pub/Sub system can remove the relevant messages
           # from the subscription.
           #
           # Acknowledging a message whose ack deadline has expired may succeed,
@@ -693,10 +693,10 @@ module Google
           #
           # @param subscription [String]
           #   The subscription whose message is being acknowledged.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param ack_ids [Array<String>]
           #   The acknowledgment ID for the messages being acknowledged that was returned
-          #   by the Pub/Sub system in the +Pull+ response. Must not be empty.
+          #   by the Pub/Sub system in the `Pull` response. Must not be empty.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -710,7 +710,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_subscription = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +ack_ids+:
+          #   # TODO: Initialize `ack_ids`:
           #   ack_ids = []
           #   subscriber_client.acknowledge(formatted_subscription, ack_ids)
 
@@ -729,19 +729,19 @@ module Google
           end
 
           # Pulls messages from the server. Returns an empty list if there are no
-          # messages available in the backlog. The server may return +UNAVAILABLE+ if
+          # messages available in the backlog. The server may return `UNAVAILABLE` if
           # there are too many concurrent pull requests pending for the given
           # subscription.
           #
           # @param subscription [String]
           #   The subscription from which messages should be pulled.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param max_messages [Integer]
           #   The maximum number of messages returned for this request. The Pub/Sub
           #   system may return fewer than the number specified.
           # @param return_immediately [true, false]
           #   If this field set to true, the system will respond immediately even if
-          #   it there are no messages available to return in the +Pull+ response.
+          #   it there are no messages available to return in the `Pull` response.
           #   Otherwise, the system may wait (for a bounded amount of time) until at
           #   least one message is available, rather than returning no messages. The
           #   client may cancel the request if it does not wish to wait any longer for
@@ -760,7 +760,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_subscription = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +max_messages+:
+          #   # TODO: Initialize `max_messages`:
           #   max_messages = 0
           #   response = subscriber_client.pull(formatted_subscription, max_messages)
 
@@ -782,7 +782,7 @@ module Google
           # Establishes a stream with the server, which sends messages down to the
           # client. The client streams acknowledgements and ack deadline modifications
           # back to the server. The server will close the stream and return the status
-          # on any error. The server may close the stream with status +UNAVAILABLE+ to
+          # on any error. The server may close the stream with status `UNAVAILABLE` to
           # reassign server-side resources, in which case, the client should
           # re-establish the stream. Flow control can be achieved by configuring the
           # underlying RPC channel.
@@ -808,7 +808,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_subscription = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +stream_ack_deadline_seconds+:
+          #   # TODO: Initialize `stream_ack_deadline_seconds`:
           #   stream_ack_deadline_seconds = 0
           #   request = { subscription: formatted_subscription, stream_ack_deadline_seconds: stream_ack_deadline_seconds }
           #   requests = [request]
@@ -823,23 +823,23 @@ module Google
             @streaming_pull.call(request_protos, options)
           end
 
-          # Modifies the +PushConfig+ for a specified subscription.
+          # Modifies the `PushConfig` for a specified subscription.
           #
           # This may be used to change a push subscription to a pull one (signified by
-          # an empty +PushConfig+) or vice versa, or change the endpoint URL and other
+          # an empty `PushConfig`) or vice versa, or change the endpoint URL and other
           # attributes of a push subscription. Messages will accumulate for delivery
-          # continuously through the call regardless of changes to the +PushConfig+.
+          # continuously through the call regardless of changes to the `PushConfig`.
           #
           # @param subscription [String]
           #   The name of the subscription.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param push_config [Google::Pubsub::V1::PushConfig | Hash]
           #   The push configuration for future deliveries.
           #
-          #   An empty +pushConfig+ indicates that the Pub/Sub system should
+          #   An empty `pushConfig` indicates that the Pub/Sub system should
           #   stop pushing messages from the given subscription and allow
           #   messages to be pulled and acknowledged - effectively pausing
-          #   the subscription if +Pull+ or +StreamingPull+ is not called.
+          #   the subscription if `Pull` or `StreamingPull` is not called.
           #   A hash of the same form as `Google::Pubsub::V1::PushConfig`
           #   can also be provided.
           # @param options [Google::Gax::CallOptions]
@@ -855,7 +855,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_subscription = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +push_config+:
+          #   # TODO: Initialize `push_config`:
           #   push_config = {}
           #   subscriber_client.modify_push_config(formatted_subscription, push_config)
 
@@ -880,7 +880,7 @@ module Google
           #
           # @param project [String]
           #   The name of the cloud project that snapshots belong to.
-          #   Format is +projects/\\{project}+.
+          #   Format is `projects/{project}`.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -935,11 +935,11 @@ module Google
           # <b>ALPHA:</b> This feature is part of an alpha release. This API might be
           # changed in backward-incompatible ways and is not recommended for production
           # use. It is not subject to any SLA or deprecation policy.
-          # If the snapshot already exists, returns +ALREADY_EXISTS+.
-          # If the requested subscription doesn't exist, returns +NOT_FOUND+.
+          # If the snapshot already exists, returns `ALREADY_EXISTS`.
+          # If the requested subscription doesn't exist, returns `NOT_FOUND`.
           # If the backlog in the subscription is too old -- and the resulting snapshot
-          # would expire in less than 1 hour -- then +FAILED_PRECONDITION+ is returned.
-          # See also the +Snapshot.expire_time+ field. If the name is not provided in
+          # would expire in less than 1 hour -- then `FAILED_PRECONDITION` is returned.
+          # See also the `Snapshot.expire_time` field. If the name is not provided in
           # the request, the server will assign a random
           # name for this snapshot on the same project as the subscription, conforming
           # to the [resource name format](https://cloud.google.com/pubsub/docs/overview#names).
@@ -952,17 +952,17 @@ module Google
           #   If the name is not provided in the request, the server will assign a random
           #   name for this snapshot on the same project as the subscription.
           #   Note that for REST API requests, you must specify a name.
-          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
+          #   Format is `projects/{project}/snapshots/{snap}`.
           # @param subscription [String]
           #   The subscription whose backlog the snapshot retains.
           #   Specifically, the created snapshot is guaranteed to retain:
           #    (a) The existing backlog on the subscription. More precisely, this is
           #        defined as the messages in the subscription's backlog that are
           #        unacknowledged upon the successful completion of the
-          #        +CreateSnapshot+ request; as well as:
+          #        `CreateSnapshot` request; as well as:
           #    (b) Any messages published to the subscription's topic following the
           #        successful completion of the CreateSnapshot request.
-          #   Format is +projects/\\{project}/subscriptions/\\{sub}+.
+          #   Format is `projects/{project}/subscriptions/{sub}`.
           # @param labels [Hash{String => String}]
           #   User labels.
           # @param options [Google::Gax::CallOptions]
@@ -1055,7 +1055,7 @@ module Google
           #
           # @param snapshot [String]
           #   The name of the snapshot to delete.
-          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
+          #   Format is `projects/{project}/snapshots/{snap}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1097,8 +1097,8 @@ module Google
           #   subscription that were published after this time are marked as
           #   unacknowledged. Note that this operation affects only those messages
           #   retained in the subscription (configured by the combination of
-          #   +message_retention_duration+ and +retain_acked_messages+). For example,
-          #   if +time+ corresponds to a point before the message retention
+          #   `message_retention_duration` and `retain_acked_messages`). For example,
+          #   if `time` corresponds to a point before the message retention
           #   window (or to a point before the system's notion of the subscription
           #   creation time), only retained messages will be marked as unacknowledged,
           #   and already-expunged messages will not be restored.
@@ -1107,7 +1107,7 @@ module Google
           # @param snapshot [String]
           #   The snapshot to seek to. The snapshot's topic must be the same as that of
           #   the provided subscription.
-          #   Format is +projects/\\{project}/snapshots/\\{snap}+.
+          #   Format is `projects/{project}/snapshots/{snap}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1143,10 +1143,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param policy [Google::Iam::V1::Policy | Hash]
-          #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+          #   REQUIRED: The complete policy to be applied to the `resource`. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
           #   valid policy but certain Cloud Platform services (such as Projects)
           #   might reject them.
@@ -1166,7 +1166,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_resource = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +policy+:
+          #   # TODO: Initialize `policy`:
           #   policy = {}
           #   response = subscriber_client.set_iam_policy(formatted_resource, policy)
 
@@ -1189,8 +1189,8 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1223,10 +1223,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param permissions [Array<String>]
-          #   The set of permissions to check for the +resource+. Permissions with
+          #   The set of permissions to check for the `resource`. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more
           #   information see
           #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -1244,7 +1244,7 @@ module Google
           #   subscriber_client = Google::Cloud::Pubsub::Subscriber.new(version: :v1)
           #   formatted_resource = Google::Cloud::Pubsub::V1::SubscriberClient.subscription_path("[PROJECT]", "[SUBSCRIPTION]")
           #
-          #   # TODO: Initialize +permissions+:
+          #   # TODO: Initialize `permissions`:
           #   permissions = []
           #   response = subscriber_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-pubsub/synth.py
+++ b/google-cloud-pubsub/synth.py
@@ -42,10 +42,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-redis/lib/google/cloud/redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis.rb
@@ -92,17 +92,17 @@ module Google
       #
       # Google Cloud Memorystore for Redis v1
       #
-      # The +redis.googleapis.com+ service implements the Google Cloud Memorystore
+      # The `redis.googleapis.com` service implements the Google Cloud Memorystore
       # for Redis API and defines the following resource model for managing Redis
       # instances:
-      # * The service works with a collection of cloud projects, named: +/projects/*+
-      # * Each project has a collection of available locations, named: +/locations/*+
-      # * Each location has a collection of Redis instances, named: +/instances/*+
+      # * The service works with a collection of cloud projects, named: `/projects/*`
+      # * Each project has a collection of available locations, named: `/locations/*`
+      # * Each location has a collection of Redis instances, named: `/instances/*`
       # * As such, Redis instances are resources of the form:
-      #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+      #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
       #
-      # Note that location_id must be refering to a GCP +region+; for example:
-      # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
+      # Note that location_id must be refering to a GCP `region`; for example:
+      # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
       #
       # @param version [Symbol, String]
       #   The major version of the service to be used. By default :v1

--- a/google-cloud-redis/lib/google/cloud/redis/v1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1.rb
@@ -85,17 +85,17 @@ module Google
         #
         # Google Cloud Memorystore for Redis v1
         #
-        # The +redis.googleapis.com+ service implements the Google Cloud Memorystore
+        # The `redis.googleapis.com` service implements the Google Cloud Memorystore
         # for Redis API and defines the following resource model for managing Redis
         # instances:
-        # * The service works with a collection of cloud projects, named: +/projects/*+
-        # * Each project has a collection of available locations, named: +/locations/*+
-        # * Each location has a collection of Redis instances, named: +/instances/*+
+        # * The service works with a collection of cloud projects, named: `/projects/*`
+        # * Each project has a collection of available locations, named: `/locations/*`
+        # * Each location has a collection of Redis instances, named: `/instances/*`
         # * As such, Redis instances are resources of the form:
-        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
-        # Note that location_id must be refering to a GCP +region+; for example:
-        # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
+        # Note that location_id must be refering to a GCP `region`; for example:
+        # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
         #
         # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can

--- a/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_client.rb
@@ -38,17 +38,17 @@ module Google
         #
         # Google Cloud Memorystore for Redis v1
         #
-        # The +redis.googleapis.com+ service implements the Google Cloud Memorystore
+        # The `redis.googleapis.com` service implements the Google Cloud Memorystore
         # for Redis API and defines the following resource model for managing Redis
         # instances:
-        # * The service works with a collection of cloud projects, named: +/projects/*+
-        # * Each project has a collection of available locations, named: +/locations/*+
-        # * Each location has a collection of Redis instances, named: +/instances/*+
+        # * The service works with a collection of cloud projects, named: `/projects/*`
+        # * Each project has a collection of available locations, named: `/locations/*`
+        # * Each location has a collection of Redis instances, named: `/instances/*`
         # * As such, Redis instances are resources of the form:
-        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
-        # Note that location_id must be refering to a GCP +region+; for example:
-        # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
+        # Note that location_id must be refering to a GCP `region`; for example:
+        # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
         #
         # @!attribute [r] cloud_redis_stub
         #   @return [Google::Cloud::Redis::V1::CloudRedis::Stub]
@@ -269,15 +269,15 @@ module Google
           # location (region) or all locations.
           #
           # The location should have the following format:
-          # * +projects/\\{project_id}/locations/\\{location_id}+
+          # * `projects/{project_id}/locations/{location_id}`
           #
-          # If +location_id+ is specified as +-+ (wildcard), then all regions
+          # If `location_id` is specified as `-` (wildcard), then all regions
           # available to the project are queried, and the results are aggregated.
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}`
+          #   where `location_id` refers to a GCP region
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -332,8 +332,8 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+          #   where `location_id` refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -375,8 +375,8 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}`
+          #   where `location_id` refers to a GCP region
           # @param instance_id [String]
           #   Required. The logical name of the Redis instance in the customer project
           #   with the following restrictions:
@@ -465,10 +465,10 @@ module Google
           #   this field. The elements of the repeated paths field may only include these
           #   fields from {CloudRedis::Instance Instance}:
           #
-          #   * +displayName+
-          #     * +labels+
-          #   * +memorySizeGb+
-          #     * +redisConfig+
+          #   * `displayName`
+          #     * `labels`
+          #   * `memorySizeGb`
+          #     * `redisConfig`
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param instance [Google::Cloud::Redis::V1::Instance | Hash]
@@ -545,8 +545,8 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+          #   where `location_id` refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_services_pb.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/cloud_redis_services_pb.rb
@@ -36,7 +36,7 @@ module Google
           # * Each project has a collection of available locations, named: `/locations/*`
           # * Each location has a collection of Redis instances, named: `/instances/*`
           # * As such, Redis instances are resources of the form:
-          #   `/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}`
+          #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
           #
           # Note that location_id must be refering to a GCP `region`; for example:
           # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
@@ -52,7 +52,7 @@ module Google
             # location (region) or all locations.
             #
             # The location should have the following format:
-            # * `projects/\\{project_id}/locations/\\{location_id}`
+            # * `projects/{project_id}/locations/{location_id}`
             #
             # If `location_id` is specified as `-` (wildcard), then all regions
             # available to the project are queried, and the results are aggregated.

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/cloud/redis/v1/cloud_redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/cloud/redis/v1/cloud_redis.rb
@@ -22,7 +22,7 @@ module Google
         #   @return [String]
         #     Required. Unique name of the resource in this scope including project and
         #     location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
         #     Note: Redis instances are managed and addressed at regional level so
         #     location_id here refers to a GCP region; however, users may choose which
@@ -52,7 +52,7 @@ module Google
         #     Optional. The version of Redis software.
         #     If not provided, latest supported version will be used. Updating the
         #     version will perform an upgrade/downgrade to the new version. Currently,
-        #     the supported values are +REDIS_3_2+ for Redis 3.2.
+        #     the supported values are `REDIS_3_2` for Redis 3.2.
         # @!attribute [rw] reserved_ip_range
         #   @return [String]
         #     Optional. The CIDR range of internal addresses that are reserved for this
@@ -101,7 +101,7 @@ module Google
         #   @return [String]
         #     Optional. The full name of the Google Compute Engine
         #     [network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks) to which the
-        #     instance is connected. If left unspecified, the +default+ network
+        #     instance is connected. If left unspecified, the `default` network
         #     will be used.
         class Instance
           # Represents the different states of a Redis instance.
@@ -124,7 +124,7 @@ module Google
             DELETING = 4
 
             # Redis instance is being repaired and may be unusable. Details can be
-            # found in the +status_message+ field.
+            # found in the `status_message` field.
             REPAIRING = 5
 
             # Maintenance is being performed on this Redis instance.
@@ -148,8 +148,8 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}`
+        #     where `location_id` refers to a GCP region
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return.
@@ -171,7 +171,7 @@ module Google
         #     A list of Redis instances in the project in the specified location,
         #     or across all locations.
         #
-        #     If the +location_id+ in the parent field of the request is "-", all regions
+        #     If the `location_id` in the parent field of the request is "-", all regions
         #     available to the project are queried, and the results aggregated.
         #     If in such an aggregated query a location is unavailable, a dummy Redis
         #     entry is included in the response with the "name" field set to a value of
@@ -188,16 +188,16 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+        #     where `location_id` refers to a GCP region
         class GetInstanceRequest; end
 
         # Request for {Google::Cloud::Redis::V1::CloudRedis::CreateInstance CreateInstance}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}`
+        #     where `location_id` refers to a GCP region
         # @!attribute [rw] instance_id
         #   @return [String]
         #     Required. The logical name of the Redis instance in the customer project
@@ -220,10 +220,10 @@ module Google
         #     this field. The elements of the repeated paths field may only include these
         #     fields from {CloudRedis::Instance Instance}:
         #
-        #     * +displayName+
-        #       * +labels+
-        #     * +memorySizeGb+
-        #       * +redisConfig+
+        #     * `displayName`
+        #       * `labels`
+        #     * `memorySizeGb`
+        #       * `redisConfig`
         # @!attribute [rw] instance
         #   @return [Google::Cloud::Redis::V1::Instance]
         #     Required. Update description.
@@ -234,8 +234,8 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+        #     where `location_id` refers to a GCP region
         class DeleteInstanceRequest; end
 
         # Represents the v1 metadata of the long-running operation.
@@ -265,12 +265,12 @@ module Google
         # This location metadata represents additional configuration options for a
         # given location where a Redis instance may be created. All fields are output
         # only. It is returned as content of the
-        # +google.cloud.location.Location.metadata+ field.
+        # `google.cloud.location.Location.metadata` field.
         # @!attribute [rw] available_zones
         #   @return [Hash{String => Google::Cloud::Redis::V1::ZoneMetadata}]
         #     Output only. The set of available zones in the location. The map is keyed
         #     by the lowercase ID of each zone, as defined by GCE. These keys can be
-        #     specified in +location_id+ or +alternative_location_id+ fields when
+        #     specified in `location_id` or `alternative_location_id` fields when
         #     creating a Redis instance.
         class LocationMetadata; end
 

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/rpc/status.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1.rb
@@ -85,17 +85,17 @@ module Google
         #
         # Google Cloud Memorystore for Redis v1beta1
         #
-        # The +redis.googleapis.com+ service implements the Google Cloud Memorystore
+        # The `redis.googleapis.com` service implements the Google Cloud Memorystore
         # for Redis API and defines the following resource model for managing Redis
         # instances:
-        # * The service works with a collection of cloud projects, named: +/projects/*+
-        # * Each project has a collection of available locations, named: +/locations/*+
-        # * Each location has a collection of Redis instances, named: +/instances/*+
+        # * The service works with a collection of cloud projects, named: `/projects/*`
+        # * Each project has a collection of available locations, named: `/locations/*`
+        # * Each location has a collection of Redis instances, named: `/instances/*`
         # * As such, Redis instances are resources of the form:
-        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
-        # Note that location_id must be refering to a GCP +region+; for example:
-        # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
+        # Note that location_id must be refering to a GCP `region`; for example:
+        # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
         #
         # @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_client.rb
@@ -38,17 +38,17 @@ module Google
         #
         # Google Cloud Memorystore for Redis v1beta1
         #
-        # The +redis.googleapis.com+ service implements the Google Cloud Memorystore
+        # The `redis.googleapis.com` service implements the Google Cloud Memorystore
         # for Redis API and defines the following resource model for managing Redis
         # instances:
-        # * The service works with a collection of cloud projects, named: +/projects/*+
-        # * Each project has a collection of available locations, named: +/locations/*+
-        # * Each location has a collection of Redis instances, named: +/instances/*+
+        # * The service works with a collection of cloud projects, named: `/projects/*`
+        # * Each project has a collection of available locations, named: `/locations/*`
+        # * Each location has a collection of Redis instances, named: `/instances/*`
         # * As such, Redis instances are resources of the form:
-        #   +/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
-        # Note that location_id must be refering to a GCP +region+; for example:
-        # * +projects/redpepper-1290/locations/us-central1/instances/my-redis+
+        # Note that location_id must be refering to a GCP `region`; for example:
+        # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
         #
         # @!attribute [r] cloud_redis_stub
         #   @return [Google::Cloud::Redis::V1beta1::CloudRedis::Stub]
@@ -269,15 +269,15 @@ module Google
           # location (region) or all locations.
           #
           # The location should have the following format:
-          # * +projects/\\{project_id}/locations/\\{location_id}+
+          # * `projects/{project_id}/locations/{location_id}`
           #
-          # If +location_id+ is specified as +-+ (wildcard), then all regions
+          # If `location_id` is specified as `-` (wildcard), then all regions
           # available to the project are queried, and the results are aggregated.
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}`
+          #   where `location_id` refers to a GCP region
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
           #   response. If page streaming is performed per-resource, this
@@ -332,8 +332,8 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+          #   where `location_id` refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -375,8 +375,8 @@ module Google
           #
           # @param parent [String]
           #   Required. The resource name of the instance location using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}`
+          #   where `location_id` refers to a GCP region
           # @param instance_id [String]
           #   Required. The logical name of the Redis instance in the customer project
           #   with the following restrictions:
@@ -464,10 +464,10 @@ module Google
           #   Required. Mask of fields to update. At least one path must be supplied in
           #   this field. The elements of the repeated paths field may only include these
           #   fields from {CloudRedis::Instance Instance}:
-          #   * +display_name+
-          #   * +labels+
-          #   * +memory_size_gb+
-          #   * +redis_config+
+          #   * `display_name`
+          #   * `labels`
+          #   * `memory_size_gb`
+          #   * `redis_config`
           #   A hash of the same form as `Google::Protobuf::FieldMask`
           #   can also be provided.
           # @param instance [Google::Cloud::Redis::V1beta1::Instance | Hash]
@@ -544,8 +544,8 @@ module Google
           #
           # @param name [String]
           #   Required. Redis instance resource name using the form:
-          #       +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-          #   where +location_id+ refers to a GCP region
+          #       `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+          #   where `location_id` refers to a GCP region
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_services_pb.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/cloud_redis_services_pb.rb
@@ -36,7 +36,7 @@ module Google
           # * Each project has a collection of available locations, named: `/locations/*`
           # * Each location has a collection of Redis instances, named: `/instances/*`
           # * As such, Redis instances are resources of the form:
-          #   `/projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}`
+          #   `/projects/{project_id}/locations/{location_id}/instances/{instance_id}`
           #
           # Note that location_id must be refering to a GCP `region`; for example:
           # * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
@@ -52,7 +52,7 @@ module Google
             # location (region) or all locations.
             #
             # The location should have the following format:
-            # * `projects/\\{project_id}/locations/\\{location_id}`
+            # * `projects/{project_id}/locations/{location_id}`
             #
             # If `location_id` is specified as `-` (wildcard), then all regions
             # available to the project are queried, and the results are aggregated.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/cloud/redis/v1beta1/cloud_redis.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/cloud/redis/v1beta1/cloud_redis.rb
@@ -22,7 +22,7 @@ module Google
         #   @return [String]
         #     Required. Unique name of the resource in this scope including project and
         #     location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
         #
         #     Note: Redis instances are managed and addressed at regional level so
         #     location_id here refers to a GCP region; however, users get to choose which
@@ -98,7 +98,7 @@ module Google
         #   @return [String]
         #     Optional. The full name of the Google Compute Engine
         #     [network](https://cloud.google.com/compute/docs/networks-and-firewalls#networks) to which the
-        #     instance is connected. If left unspecified, the +default+ network
+        #     instance is connected. If left unspecified, the `default` network
         #     will be used.
         class Instance
           # Represents the different states of a Redis instance.
@@ -121,7 +121,7 @@ module Google
             DELETING = 4
 
             # Redis instance is being repaired and may be unusable. Details can be
-            # found in the +status_message+ field.
+            # found in the `status_message` field.
             REPAIRING = 5
 
             # Maintenance is being performed on this Redis instance.
@@ -145,8 +145,8 @@ module Google
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}`
+        #     where `location_id` refers to a GCP region
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     The maximum number of items to return.
@@ -168,7 +168,7 @@ module Google
         #     A list of Redis instances in the project in the specified location,
         #     or across all locations.
         #
-        #     If the +location_id+ in the parent field of the request is "-", all regions
+        #     If the `location_id` in the parent field of the request is "-", all regions
         #     available to the project are queried, and the results aggregated.
         #     If in such an aggregated query a location is unavailable, a dummy Redis
         #     entry is included in the response with the "name" field set to a value of
@@ -185,16 +185,16 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+        #     where `location_id` refers to a GCP region
         class GetInstanceRequest; end
 
         # Request for {Google::Cloud::Redis::V1beta1::CloudRedis::CreateInstance CreateInstance}.
         # @!attribute [rw] parent
         #   @return [String]
         #     Required. The resource name of the instance location using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}`
+        #     where `location_id` refers to a GCP region
         # @!attribute [rw] instance_id
         #   @return [String]
         #     Required. The logical name of the Redis instance in the customer project
@@ -216,10 +216,10 @@ module Google
         #     Required. Mask of fields to update. At least one path must be supplied in
         #     this field. The elements of the repeated paths field may only include these
         #     fields from {CloudRedis::Instance Instance}:
-        #     * +display_name+
-        #     * +labels+
-        #     * +memory_size_gb+
-        #     * +redis_config+
+        #     * `display_name`
+        #     * `labels`
+        #     * `memory_size_gb`
+        #     * `redis_config`
         # @!attribute [rw] instance
         #   @return [Google::Cloud::Redis::V1beta1::Instance]
         #     Required. Update description.
@@ -230,19 +230,19 @@ module Google
         # @!attribute [rw] name
         #   @return [String]
         #     Required. Redis instance resource name using the form:
-        #         +projects/\\{project_id}/locations/\\{location_id}/instances/\\{instance_id}+
-        #     where +location_id+ refers to a GCP region
+        #         `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
+        #     where `location_id` refers to a GCP region
         class DeleteInstanceRequest; end
 
         # This location metadata represents additional configuration options for a
         # given location where a Redis instance may be created. All fields are output
         # only. It is returned as content of the
-        # +google.cloud.location.Location.metadata+ field.
+        # `google.cloud.location.Location.metadata` field.
         # @!attribute [rw] available_zones
         #   @return [Hash{String => Google::Cloud::Redis::V1beta1::ZoneMetadata}]
         #     Output only. The set of available zones in the location. The map is keyed
         #     by the lowercase ID of each zone, as defined by GCE. These keys can be
-        #     specified in +location_id+ or +alternative_location_id+ fields when
+        #     specified in `location_id` or `alternative_location_id` fields when
         #     creating a Redis instance.
         class LocationMetadata; end
 

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/longrunning/operations.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-redis/lib/google/cloud/redis/v1beta1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-redis/synth.py
+++ b/google-cloud-redis/synth.py
@@ -69,10 +69,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/database_admin_client.rb
@@ -282,7 +282,7 @@ module Google
               #
               # @param parent [String]
               #   Required. The instance whose databases should be listed.
-              #   Values are of the form +projects/<project>/instances/<instance>+.
+              #   Values are of the form `projects/<project>/instances/<instance>`.
               # @param page_size [Integer]
               #   The maximum number of resources contained in the underlying API
               #   response. If page streaming is performed per-resource, this
@@ -335,7 +335,7 @@ module Google
 
               # Creates a new Cloud Spanner database and starts to prepare it for serving.
               # The returned {Google::Longrunning::Operation long-running operation} will
-              # have a name of the format +<database_name>/operations/<operation_id>+ and
+              # have a name of the format `<database_name>/operations/<operation_id>` and
               # can be used to track preparation of the database. The
               # {Google::Longrunning::Operation#metadata metadata} field type is
               # {Google::Spanner::Admin::Database::V1::CreateDatabaseMetadata CreateDatabaseMetadata}. The
@@ -344,13 +344,13 @@ module Google
               #
               # @param parent [String]
               #   Required. The name of the instance that will serve the new database.
-              #   Values are of the form +projects/<project>/instances/<instance>+.
+              #   Values are of the form `projects/<project>/instances/<instance>`.
               # @param create_statement [String]
-              #   Required. A +CREATE DATABASE+ statement, which specifies the ID of the
+              #   Required. A `CREATE DATABASE` statement, which specifies the ID of the
               #   new database.  The database ID must conform to the regular expression
-              #   +[a-z][a-z0-9_\-]*[a-z0-9]+ and be between 2 and 30 characters in length.
+              #   `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
               #   If the database ID is a reserved word or if it contains a hyphen, the
-              #   database ID must be enclosed in backticks (+ + +).
+              #   database ID must be enclosed in backticks (`` ` ``).
               # @param extra_statements [Array<String>]
               #   An optional list of DDL statements to run inside the newly created
               #   database. Statements can create tables, indexes, etc. These
@@ -367,7 +367,7 @@ module Google
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
               #   formatted_parent = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
               #
-              #   # TODO: Initialize +create_statement+:
+              #   # TODO: Initialize `create_statement`:
               #   create_statement = ''
               #
               #   # Register a callback during the method call.
@@ -423,7 +423,7 @@ module Google
               #
               # @param name [String]
               #   Required. The name of the requested database. Values are of the form
-              #   +projects/<project>/instances/<instance>/databases/<database>+.
+              #   `projects/<project>/instances/<instance>/databases/<database>`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -453,7 +453,7 @@ module Google
               # Updates the schema of a Cloud Spanner database by
               # creating/altering/dropping tables, columns, indexes, etc. The returned
               # {Google::Longrunning::Operation long-running operation} will have a name of
-              # the format +<database_name>/operations/<operation_id>+ and can be used to
+              # the format `<database_name>/operations/<operation_id>` and can be used to
               # track execution of the schema change(s). The
               # {Google::Longrunning::Operation#metadata metadata} field type is
               # {Google::Spanner::Admin::Database::V1::UpdateDatabaseDdlMetadata UpdateDatabaseDdlMetadata}.  The operation has no response.
@@ -464,7 +464,7 @@ module Google
               #   DDL statements to be applied to the database.
               # @param operation_id [String]
               #   If empty, the new update request is assigned an
-              #   automatically-generated operation ID. Otherwise, +operation_id+
+              #   automatically-generated operation ID. Otherwise, `operation_id`
               #   is used to construct the name of the resulting
               #   {Google::Longrunning::Operation Operation}.
               #
@@ -472,16 +472,16 @@ module Google
               #   whether the statements were executed in the event that the
               #   {Google::Spanner::Admin::Database::V1::DatabaseAdmin::UpdateDatabaseDdl UpdateDatabaseDdl} call is replayed,
               #   or the return value is otherwise lost: the {Google::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest#database database} and
-              #   +operation_id+ fields can be combined to form the
+              #   `operation_id` fields can be combined to form the
               #   {Google::Longrunning::Operation#name name} of the resulting
-              #   {Google::Longrunning::Operation longrunning::Operation}: +<database>/operations/<operation_id>+.
+              #   {Google::Longrunning::Operation longrunning::Operation}: `<database>/operations/<operation_id>`.
               #
-              #   +operation_id+ should be unique within the database, and must be
-              #   a valid identifier: +[a-z][a-z0-9_]*+. Note that
+              #   `operation_id` should be unique within the database, and must be
+              #   a valid identifier: `[a-z][a-z0-9_]*`. Note that
               #   automatically-generated operation IDs always begin with an
               #   underscore. If the named operation already exists,
               #   {Google::Spanner::Admin::Database::V1::DatabaseAdmin::UpdateDatabaseDdl UpdateDatabaseDdl} returns
-              #   +ALREADY_EXISTS+.
+              #   `ALREADY_EXISTS`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -493,7 +493,7 @@ module Google
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
               #   formatted_database = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
               #
-              #   # TODO: Initialize +statements+:
+              #   # TODO: Initialize `statements`:
               #   statements = []
               #
               #   # Register a callback during the method call.
@@ -610,15 +610,15 @@ module Google
               # Sets the access control policy on a database resource. Replaces any
               # existing policy.
               #
-              # Authorization requires +spanner.databases.setIamPolicy+ permission on
+              # Authorization requires `spanner.databases.setIamPolicy` permission on
               # {Google::Iam::V1::SetIamPolicyRequest#resource resource}.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param policy [Google::Iam::V1::Policy | Hash]
-              #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+              #   REQUIRED: The complete policy to be applied to the `resource`. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
               #   valid policy but certain Cloud Platform services (such as Projects)
               #   might reject them.
@@ -638,7 +638,7 @@ module Google
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
               #   formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
               #
-              #   # TODO: Initialize +policy+:
+              #   # TODO: Initialize `policy`:
               #   policy = {}
               #   response = database_admin_client.set_iam_policy(formatted_resource, policy)
 
@@ -658,13 +658,13 @@ module Google
               # Gets the access control policy for a database resource. Returns an empty
               # policy if a database exists but does not have a policy set.
               #
-              # Authorization requires +spanner.databases.getIamPolicy+ permission on
+              # Authorization requires `spanner.databases.getIamPolicy` permission on
               # {Google::Iam::V1::GetIamPolicyRequest#resource resource}.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -694,16 +694,16 @@ module Google
               # Returns permissions that the caller has on the specified database resource.
               #
               # Attempting this RPC on a non-existent Cloud Spanner database will result in
-              # a NOT_FOUND error if the user has +spanner.databases.list+ permission on
+              # a NOT_FOUND error if the user has `spanner.databases.list` permission on
               # the containing Cloud Spanner instance. Otherwise returns an empty set of
               # permissions.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param permissions [Array<String>]
-              #   The set of permissions to check for the +resource+. Permissions with
+              #   The set of permissions to check for the `resource`. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more
               #   information see
               #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -721,7 +721,7 @@ module Google
               #   database_admin_client = Google::Cloud::Spanner::Admin::Database.new(version: :v1)
               #   formatted_resource = Google::Cloud::Spanner::Admin::Database::V1::DatabaseAdminClient.database_path("[PROJECT]", "[INSTANCE]", "[DATABASE]")
               #
-              #   # TODO: Initialize +permissions+:
+              #   # TODO: Initialize `permissions`:
               #   permissions = []
               #   response = database_admin_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/database/v1/doc/google/spanner/admin/database/v1/spanner_database_admin.rb
@@ -22,8 +22,8 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the database. Values are of the form
-          #     +projects/<project>/instances/<instance>/databases/<database>+,
-          #     where +<database>+ is as specified in the +CREATE DATABASE+
+          #     `projects/<project>/instances/<instance>/databases/<database>`,
+          #     where `<database>` is as specified in the `CREATE DATABASE`
           #     statement. This name can be passed to other API methods to
           #     identify the database.
           # @!attribute [rw] state
@@ -36,7 +36,7 @@ module Google
               STATE_UNSPECIFIED = 0
 
               # The database is still being created. Operations on the database may fail
-              # with +FAILED_PRECONDITION+ in this state.
+              # with `FAILED_PRECONDITION` in this state.
               CREATING = 1
 
               # The database is fully created and ready for use.
@@ -48,14 +48,14 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The instance whose databases should be listed.
-          #     Values are of the form +projects/<project>/instances/<instance>+.
+          #     Values are of the form `projects/<project>/instances/<instance>`.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Number of databases to be returned in the response. If 0 or less,
           #     defaults to the server's maximum allowed page size.
           # @!attribute [rw] page_token
           #   @return [String]
-          #     If non-empty, +page_token+ should contain a
+          #     If non-empty, `page_token` should contain a
           #     {Google::Spanner::Admin::Database::V1::ListDatabasesResponse#next_page_token next_page_token} from a
           #     previous {Google::Spanner::Admin::Database::V1::ListDatabasesResponse ListDatabasesResponse}.
           class ListDatabasesRequest; end
@@ -66,7 +66,7 @@ module Google
           #     Databases that matched the request.
           # @!attribute [rw] next_page_token
           #   @return [String]
-          #     +next_page_token+ can be sent in a subsequent
+          #     `next_page_token` can be sent in a subsequent
           #     {Google::Spanner::Admin::Database::V1::DatabaseAdmin::ListDatabases ListDatabases} call to fetch more
           #     of the matching databases.
           class ListDatabasesResponse; end
@@ -75,14 +75,14 @@ module Google
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the instance that will serve the new database.
-          #     Values are of the form +projects/<project>/instances/<instance>+.
+          #     Values are of the form `projects/<project>/instances/<instance>`.
           # @!attribute [rw] create_statement
           #   @return [String]
-          #     Required. A +CREATE DATABASE+ statement, which specifies the ID of the
+          #     Required. A `CREATE DATABASE` statement, which specifies the ID of the
           #     new database.  The database ID must conform to the regular expression
-          #     +[a-z][a-z0-9_\-]*[a-z0-9]+ and be between 2 and 30 characters in length.
+          #     `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
           #     If the database ID is a reserved word or if it contains a hyphen, the
-          #     database ID must be enclosed in backticks (+ + +).
+          #     database ID must be enclosed in backticks (`` ` ``).
           # @!attribute [rw] extra_statements
           #   @return [Array<String>]
           #     An optional list of DDL statements to run inside the newly created
@@ -102,7 +102,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the requested database. Values are of the form
-          #     +projects/<project>/instances/<instance>/databases/<database>+.
+          #     `projects/<project>/instances/<instance>/databases/<database>`.
           class GetDatabaseRequest; end
 
           # Enqueues the given DDL statements to be applied, in order but not
@@ -112,8 +112,8 @@ module Google
           # before enqueueing them, but they may still fail upon
           # later execution (e.g., if a statement from another batch of
           # statements is applied first and it conflicts in some way, or if
-          # there is some data-related problem like a +NULL+ value in a column to
-          # which +NOT NULL+ would be added). If a statement fails, all
+          # there is some data-related problem like a `NULL` value in a column to
+          # which `NOT NULL` would be added). If a statement fails, all
           # subsequent statements in the batch are automatically cancelled.
           #
           # Each batch of statements is assigned a name which can be used with
@@ -130,7 +130,7 @@ module Google
           # @!attribute [rw] operation_id
           #   @return [String]
           #     If empty, the new update request is assigned an
-          #     automatically-generated operation ID. Otherwise, +operation_id+
+          #     automatically-generated operation ID. Otherwise, `operation_id`
           #     is used to construct the name of the resulting
           #     {Google::Longrunning::Operation Operation}.
           #
@@ -138,16 +138,16 @@ module Google
           #     whether the statements were executed in the event that the
           #     {Google::Spanner::Admin::Database::V1::DatabaseAdmin::UpdateDatabaseDdl UpdateDatabaseDdl} call is replayed,
           #     or the return value is otherwise lost: the {Google::Spanner::Admin::Database::V1::UpdateDatabaseDdlRequest#database database} and
-          #     +operation_id+ fields can be combined to form the
+          #     `operation_id` fields can be combined to form the
           #     {Google::Longrunning::Operation#name name} of the resulting
-          #     {Google::Longrunning::Operation longrunning::Operation}: +<database>/operations/<operation_id>+.
+          #     {Google::Longrunning::Operation longrunning::Operation}: `<database>/operations/<operation_id>`.
           #
-          #     +operation_id+ should be unique within the database, and must be
-          #     a valid identifier: +[a-z][a-z0-9_]*+. Note that
+          #     `operation_id` should be unique within the database, and must be
+          #     a valid identifier: `[a-z][a-z0-9_]*`. Note that
           #     automatically-generated operation IDs always begin with an
           #     underscore. If the named operation already exists,
           #     {Google::Spanner::Admin::Database::V1::DatabaseAdmin::UpdateDatabaseDdl UpdateDatabaseDdl} returns
-          #     +ALREADY_EXISTS+.
+          #     `ALREADY_EXISTS`.
           class UpdateDatabaseDdlRequest; end
 
           # Metadata type for the operation returned by
@@ -162,8 +162,8 @@ module Google
           # @!attribute [rw] commit_timestamps
           #   @return [Array<Google::Protobuf::Timestamp>]
           #     Reports the commit timestamps of all statements that have
-          #     succeeded so far, where +commit_timestamps[i]+ is the commit
-          #     timestamp for the statement +statements[i]+.
+          #     succeeded so far, where `commit_timestamps[i]` is the commit
+          #     timestamp for the statement `statements[i]`.
           class UpdateDatabaseDdlMetadata; end
 
           # The request for {Google::Spanner::Admin::Database::V1::DatabaseAdmin::DropDatabase DropDatabase}.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/doc/google/spanner/admin/instance/v1/spanner_instance_admin.rb
@@ -24,7 +24,7 @@ module Google
           #   @return [String]
           #     A unique identifier for the instance configuration.  Values
           #     are of the form
-          #     +projects/<project>/instanceConfigs/[a-z][-a-z0-9]*+
+          #     `projects/<project>/instanceConfigs/[a-z][-a-z0-9]*`
           # @!attribute [rw] display_name
           #   @return [String]
           #     The name of this instance configuration as it appears in UIs.
@@ -35,12 +35,12 @@ module Google
           #   @return [String]
           #     Required. A unique identifier for the instance, which cannot be changed
           #     after the instance is created. Values are of the form
-          #     +projects/<project>/instances/[a-z][-a-z0-9]*[a-z0-9]+. The final
+          #     `projects/<project>/instances/[a-z][-a-z0-9]*[a-z0-9]`. The final
           #     segment of the name must be between 6 and 30 characters in length.
           # @!attribute [rw] config
           #   @return [String]
           #     Required. The name of the instance's configuration. Values are of the form
-          #     +projects/<project>/instanceConfigs/<configuration>+. See
+          #     `projects/<project>/instanceConfigs/<configuration>`. See
           #     also {Google::Spanner::Admin::Instance::V1::InstanceConfig InstanceConfig} and
           #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs}.
           # @!attribute [rw] display_name
@@ -50,7 +50,7 @@ module Google
           # @!attribute [rw] node_count
           #   @return [Integer]
           #     Required. The number of nodes allocated to this instance. This may be zero
-          #     in API responses for instances that are not yet in state +READY+.
+          #     in API responses for instances that are not yet in state `READY`.
           #
           #     See [the documentation](https://cloud.google.com/spanner/docs/instances#node_count)
           #     for more information about nodes.
@@ -58,9 +58,9 @@ module Google
           #   @return [Google::Spanner::Admin::Instance::V1::Instance::State]
           #     Output only. The current instance state. For
           #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}, the state must be
-          #     either omitted or set to +CREATING+. For
+          #     either omitted or set to `CREATING`. For
           #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::UpdateInstance UpdateInstance}, the state must be
-          #     either omitted or set to +READY+.
+          #     either omitted or set to `READY`.
           # @!attribute [rw] labels
           #   @return [Hash{String => String}]
           #     Cloud Labels are a flexible and lightweight mechanism for organizing cloud
@@ -71,9 +71,9 @@ module Google
           #     firewall, load balancing, etc.).
           #
           #     * Label keys must be between 1 and 63 characters long and must conform to
-          #       the following regular expression: +[a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?+.
+          #       the following regular expression: `[a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?`.
           #     * Label values must be between 0 and 63 characters long and must conform
-          #       to the regular expression +([a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?)?+.
+          #       to the regular expression `([a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?)?`.
           #     * No more than 64 labels can be associated with a given resource.
           #
           #     See https://goo.gl/xmQnxf for more information on and examples of labels.
@@ -106,14 +106,14 @@ module Google
           #   @return [String]
           #     Required. The name of the project for which a list of supported instance
           #     configurations is requested. Values are of the form
-          #     +projects/<project>+.
+          #     `projects/<project>`.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Number of instance configurations to be returned in the response. If 0 or
           #     less, defaults to the server's maximum allowed page size.
           # @!attribute [rw] page_token
           #   @return [String]
-          #     If non-empty, +page_token+ should contain a
+          #     If non-empty, `page_token` should contain a
           #     {Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse#next_page_token next_page_token}
           #     from a previous {Google::Spanner::Admin::Instance::V1::ListInstanceConfigsResponse ListInstanceConfigsResponse}.
           class ListInstanceConfigsRequest; end
@@ -124,7 +124,7 @@ module Google
           #     The list of requested instance configurations.
           # @!attribute [rw] next_page_token
           #   @return [String]
-          #     +next_page_token+ can be sent in a subsequent
+          #     `next_page_token` can be sent in a subsequent
           #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstanceConfigs ListInstanceConfigs} call to
           #     fetch more of the matching instance configurations.
           class ListInstanceConfigsResponse; end
@@ -134,44 +134,44 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the requested instance configuration. Values are of
-          #     the form +projects/<project>/instanceConfigs/<config>+.
+          #     the form `projects/<project>/instanceConfigs/<config>`.
           class GetInstanceConfigRequest; end
 
           # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::GetInstance GetInstance}.
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the requested instance. Values are of the form
-          #     +projects/<project>/instances/<instance>+.
+          #     `projects/<project>/instances/<instance>`.
           class GetInstanceRequest; end
 
           # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::CreateInstance CreateInstance}.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the project in which to create the instance. Values
-          #     are of the form +projects/<project>+.
+          #     are of the form `projects/<project>`.
           # @!attribute [rw] instance_id
           #   @return [String]
           #     Required. The ID of the instance to create.  Valid identifiers are of the
-          #     form +[a-z][-a-z0-9]*[a-z0-9]+ and must be between 6 and 30 characters in
+          #     form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 6 and 30 characters in
           #     length.
           # @!attribute [rw] instance
           #   @return [Google::Spanner::Admin::Instance::V1::Instance]
           #     Required. The instance to create.  The name may be omitted, but if
-          #     specified must be +<parent>/instances/<instance_id>+.
+          #     specified must be `<parent>/instances/<instance_id>`.
           class CreateInstanceRequest; end
 
           # The request for {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances}.
           # @!attribute [rw] parent
           #   @return [String]
           #     Required. The name of the project for which a list of instances is
-          #     requested. Values are of the form +projects/<project>+.
+          #     requested. Values are of the form `projects/<project>`.
           # @!attribute [rw] page_size
           #   @return [Integer]
           #     Number of instances to be returned in the response. If 0 or less, defaults
           #     to the server's maximum allowed page size.
           # @!attribute [rw] page_token
           #   @return [String]
-          #     If non-empty, +page_token+ should contain a
+          #     If non-empty, `page_token` should contain a
           #     {Google::Spanner::Admin::Instance::V1::ListInstancesResponse#next_page_token next_page_token} from a
           #     previous {Google::Spanner::Admin::Instance::V1::ListInstancesResponse ListInstancesResponse}.
           # @!attribute [rw] filter
@@ -179,20 +179,20 @@ module Google
           #     An expression for filtering the results of the request. Filter rules are
           #     case insensitive. The fields eligible for filtering are:
           #
-          #     * +name+
-          #       * +display_name+
-          #       * +labels.key+ where key is the name of a label
+          #     * `name`
+          #       * `display_name`
+          #       * `labels.key` where key is the name of a label
           #
           #       Some examples of using filters are:
           #
-          #       * +name:*+ --> The instance has a name.
-          #       * +name:Howl+ --> The instance's name contains the string "howl".
-          #       * +name:HOWL+ --> Equivalent to above.
-          #       * +NAME:howl+ --> Equivalent to above.
-          #       * +labels.env:*+ --> The instance has the label "env".
-          #       * +labels.env:dev+ --> The instance has the label "env" and the value of
+          #       * `name:*` --> The instance has a name.
+          #       * `name:Howl` --> The instance's name contains the string "howl".
+          #       * `name:HOWL` --> Equivalent to above.
+          #       * `NAME:howl` --> Equivalent to above.
+          #       * `labels.env:*` --> The instance has the label "env".
+          #       * `labels.env:dev` --> The instance has the label "env" and the value of
           #         the label contains the string "dev".
-          #       * +name:howl labels.env:dev+ --> The instance's name contains "howl" and
+          #       * `name:howl labels.env:dev` --> The instance's name contains "howl" and
           #         it has the label "env" with its value
           #         containing "dev".
           class ListInstancesRequest; end
@@ -203,7 +203,7 @@ module Google
           #     The list of requested instances.
           # @!attribute [rw] next_page_token
           #   @return [String]
-          #     +next_page_token+ can be sent in a subsequent
+          #     `next_page_token` can be sent in a subsequent
           #     {Google::Spanner::Admin::Instance::V1::InstanceAdmin::ListInstances ListInstances} call to fetch more
           #     of the matching instances.
           class ListInstancesResponse; end
@@ -225,7 +225,7 @@ module Google
           # @!attribute [rw] name
           #   @return [String]
           #     Required. The name of the instance to be deleted. Values are of the form
-          #     +projects/<project>/instances/<instance>+
+          #     `projects/<project>/instances/<instance>`
           class DeleteInstanceRequest; end
 
           # Metadata type for the operation returned by

--- a/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/admin/instance/v1/instance_admin_client.rb
@@ -321,7 +321,7 @@ module Google
               # @param parent [String]
               #   Required. The name of the project for which a list of supported instance
               #   configurations is requested. Values are of the form
-              #   +projects/<project>+.
+              #   `projects/<project>`.
               # @param page_size [Integer]
               #   The maximum number of resources contained in the underlying API
               #   response. If page streaming is performed per-resource, this
@@ -376,7 +376,7 @@ module Google
               #
               # @param name [String]
               #   Required. The name of the requested instance configuration. Values are of
-              #   the form +projects/<project>/instanceConfigs/<config>+.
+              #   the form `projects/<project>/instanceConfigs/<config>`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -407,7 +407,7 @@ module Google
               #
               # @param parent [String]
               #   Required. The name of the project for which a list of instances is
-              #   requested. Values are of the form +projects/<project>+.
+              #   requested. Values are of the form `projects/<project>`.
               # @param page_size [Integer]
               #   The maximum number of resources contained in the underlying API
               #   response. If page streaming is performed per-resource, this
@@ -418,20 +418,20 @@ module Google
               #   An expression for filtering the results of the request. Filter rules are
               #   case insensitive. The fields eligible for filtering are:
               #
-              #   * +name+
-              #     * +display_name+
-              #     * +labels.key+ where key is the name of a label
+              #   * `name`
+              #     * `display_name`
+              #     * `labels.key` where key is the name of a label
               #
               #     Some examples of using filters are:
               #
-              #     * +name:*+ --> The instance has a name.
-              #     * +name:Howl+ --> The instance's name contains the string "howl".
-              #     * +name:HOWL+ --> Equivalent to above.
-              #     * +NAME:howl+ --> Equivalent to above.
-              #     * +labels.env:*+ --> The instance has the label "env".
-              #     * +labels.env:dev+ --> The instance has the label "env" and the value of
+              #     * `name:*` --> The instance has a name.
+              #     * `name:Howl` --> The instance's name contains the string "howl".
+              #     * `name:HOWL` --> Equivalent to above.
+              #     * `NAME:howl` --> Equivalent to above.
+              #     * `labels.env:*` --> The instance has the label "env".
+              #     * `labels.env:dev` --> The instance has the label "env" and the value of
               #       the label contains the string "dev".
-              #     * +name:howl labels.env:dev+ --> The instance's name contains "howl" and
+              #     * `name:howl labels.env:dev` --> The instance's name contains "howl" and
               #       it has the label "env" with its value
               #       containing "dev".
               # @param options [Google::Gax::CallOptions]
@@ -484,7 +484,7 @@ module Google
               #
               # @param name [String]
               #   Required. The name of the requested instance. Values are of the form
-              #   +projects/<project>/instances/<instance>+.
+              #   `projects/<project>/instances/<instance>`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -515,13 +515,13 @@ module Google
               # returned {Google::Longrunning::Operation long-running operation}
               # can be used to track the progress of preparing the new
               # instance. The instance name is assigned by the caller. If the
-              # named instance already exists, +CreateInstance+ returns
-              # +ALREADY_EXISTS+.
+              # named instance already exists, `CreateInstance` returns
+              # `ALREADY_EXISTS`.
               #
               # Immediately upon completion of this request:
               #
               # * The instance is readable via the API, with all requested attributes
-              #   but no allocated resources. Its state is +CREATING+.
+              #   but no allocated resources. Its state is `CREATING`.
               #
               # Until completion of the returned operation:
               #
@@ -536,10 +536,10 @@ module Google
               #     may have lower than the requested levels).
               #   * Databases can be created in the instance.
               #   * The instance's allocated resource levels are readable via the API.
-              #   * The instance's state becomes +READY+.
+              #   * The instance's state becomes `READY`.
               #
               #   The returned {Google::Longrunning::Operation long-running operation} will
-              #   have a name of the format +<instance_name>/operations/<operation_id>+ and
+              #   have a name of the format `<instance_name>/operations/<operation_id>` and
               #   can be used to track creation of the instance.  The
               #   {Google::Longrunning::Operation#metadata metadata} field type is
               #   {Google::Spanner::Admin::Instance::V1::CreateInstanceMetadata CreateInstanceMetadata}.
@@ -548,14 +548,14 @@ module Google
               #
               # @param parent [String]
               #   Required. The name of the project in which to create the instance. Values
-              #   are of the form +projects/<project>+.
+              #   are of the form `projects/<project>`.
               # @param instance_id [String]
               #   Required. The ID of the instance to create.  Valid identifiers are of the
-              #   form +[a-z][-a-z0-9]*[a-z0-9]+ and must be between 6 and 30 characters in
+              #   form `[a-z][-a-z0-9]*[a-z0-9]` and must be between 6 and 30 characters in
               #   length.
               # @param instance [Google::Spanner::Admin::Instance::V1::Instance | Hash]
               #   Required. The instance to create.  The name may be omitted, but if
-              #   specified must be +<parent>/instances/<instance_id>+.
+              #   specified must be `<parent>/instances/<instance_id>`.
               #   A hash of the same form as `Google::Spanner::Admin::Instance::V1::Instance`
               #   can also be provided.
               # @param options [Google::Gax::CallOptions]
@@ -569,10 +569,10 @@ module Google
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
               #   formatted_parent = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.project_path("[PROJECT]")
               #
-              #   # TODO: Initialize +instance_id+:
+              #   # TODO: Initialize `instance_id`:
               #   instance_id = ''
               #
-              #   # TODO: Initialize +instance+:
+              #   # TODO: Initialize `instance`:
               #   instance = {}
               #
               #   # Register a callback during the method call.
@@ -628,7 +628,7 @@ module Google
               # as requested. The returned [long-running
               # operation][google.longrunning.Operation] can be used to track the
               # progress of updating the instance. If the named instance does not
-              # exist, returns +NOT_FOUND+.
+              # exist, returns `NOT_FOUND`.
               #
               # Immediately upon completion of this request:
               #
@@ -641,7 +641,7 @@ module Google
               #   {Google::Spanner::Admin::Instance::V1::UpdateInstanceMetadata#cancel_time cancel_time}, and begins
               #   restoring resources to their pre-request values. The operation
               #   is guaranteed to succeed at undoing all resource changes,
-              #   after which point it terminates with a +CANCELLED+ status.
+              #   after which point it terminates with a `CANCELLED` status.
               #   * All other attempts to modify the instance are rejected.
               #   * Reading the instance via the API continues to give the pre-request
               #     resource levels.
@@ -655,14 +655,14 @@ module Google
               #   * The instance's new resource levels are readable via the API.
               #
               #   The returned {Google::Longrunning::Operation long-running operation} will
-              #   have a name of the format +<instance_name>/operations/<operation_id>+ and
+              #   have a name of the format `<instance_name>/operations/<operation_id>` and
               #   can be used to track the instance modification.  The
               #   {Google::Longrunning::Operation#metadata metadata} field type is
               #   {Google::Spanner::Admin::Instance::V1::UpdateInstanceMetadata UpdateInstanceMetadata}.
               #   The {Google::Longrunning::Operation#response response} field type is
               #   {Google::Spanner::Admin::Instance::V1::Instance Instance}, if successful.
               #
-              # Authorization requires +spanner.instances.update+ permission on
+              # Authorization requires `spanner.instances.update` permission on
               # resource {Google::Spanner::Admin::Instance::V1::Instance#name name}.
               #
               # @param instance [Google::Spanner::Admin::Instance::V1::Instance | Hash]
@@ -687,10 +687,10 @@ module Google
               #
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
               #
-              #   # TODO: Initialize +instance+:
+              #   # TODO: Initialize `instance`:
               #   instance = {}
               #
-              #   # TODO: Initialize +field_mask+:
+              #   # TODO: Initialize `field_mask`:
               #   field_mask = {}
               #
               #   # Register a callback during the method call.
@@ -754,7 +754,7 @@ module Google
               #
               # @param name [String]
               #   Required. The name of the instance to be deleted. Values are of the form
-              #   +projects/<project>/instances/<instance>+
+              #   `projects/<project>/instances/<instance>`
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -784,15 +784,15 @@ module Google
               # Sets the access control policy on an instance resource. Replaces any
               # existing policy.
               #
-              # Authorization requires +spanner.instances.setIamPolicy+ on
+              # Authorization requires `spanner.instances.setIamPolicy` on
               # {Google::Iam::V1::SetIamPolicyRequest#resource resource}.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being specified.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param policy [Google::Iam::V1::Policy | Hash]
-              #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+              #   REQUIRED: The complete policy to be applied to the `resource`. The size of
               #   the policy is limited to a few 10s of KB. An empty policy is a
               #   valid policy but certain Cloud Platform services (such as Projects)
               #   might reject them.
@@ -812,7 +812,7 @@ module Google
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
               #   formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
               #
-              #   # TODO: Initialize +policy+:
+              #   # TODO: Initialize `policy`:
               #   policy = {}
               #   response = instance_admin_client.set_iam_policy(formatted_resource, policy)
 
@@ -832,13 +832,13 @@ module Google
               # Gets the access control policy for an instance resource. Returns an empty
               # policy if an instance exists but does not have a policy set.
               #
-              # Authorization requires +spanner.instances.getIamPolicy+ on
+              # Authorization requires `spanner.instances.getIamPolicy` on
               # {Google::Iam::V1::GetIamPolicyRequest#resource resource}.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy is being requested.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param options [Google::Gax::CallOptions]
               #   Overrides the default settings for this call, e.g, timeout,
               #   retries, etc.
@@ -868,16 +868,16 @@ module Google
               # Returns permissions that the caller has on the specified instance resource.
               #
               # Attempting this RPC on a non-existent Cloud Spanner instance resource will
-              # result in a NOT_FOUND error if the user has +spanner.instances.list+
+              # result in a NOT_FOUND error if the user has `spanner.instances.list`
               # permission on the containing Google Cloud Project. Otherwise returns an
               # empty set of permissions.
               #
               # @param resource [String]
               #   REQUIRED: The resource for which the policy detail is being requested.
-              #   +resource+ is usually specified as a path. For example, a Project
-              #   resource is specified as +projects/\\{project}+.
+              #   `resource` is usually specified as a path. For example, a Project
+              #   resource is specified as `projects/{project}`.
               # @param permissions [Array<String>]
-              #   The set of permissions to check for the +resource+. Permissions with
+              #   The set of permissions to check for the `resource`. Permissions with
               #   wildcards (such as '*' or 'storage.*') are not allowed. For more
               #   information see
               #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -895,7 +895,7 @@ module Google
               #   instance_admin_client = Google::Cloud::Spanner::Admin::Instance.new(version: :v1)
               #   formatted_resource = Google::Cloud::Spanner::Admin::Instance::V1::InstanceAdminClient.instance_path("[PROJECT]", "[INSTANCE]")
               #
-              #   # TODO: Initialize +permissions+:
+              #   # TODO: Initialize `permissions`:
               #   permissions = []
               #   response = instance_admin_client.test_iam_permissions(formatted_resource, permissions)
 

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/struct.rb
@@ -15,25 +15,25 @@
 
 module Google
   module Protobuf
-    # +Struct+ represents a structured data value, consisting of fields
-    # which map to dynamically typed values. In some languages, +Struct+
+    # `Struct` represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, `Struct`
     # might be supported by a native representation. For example, in
     # scripting languages like JS a struct is represented as an
     # object. The details of that representation are described together
     # with the proto support for the language.
     #
-    # The JSON representation for +Struct+ is JSON object.
+    # The JSON representation for `Struct` is JSON object.
     # @!attribute [rw] fields
     #   @return [Hash{String => Google::Protobuf::Value}]
     #     Unordered map of dynamically typed values.
     class Struct; end
 
-    # +Value+ represents a dynamically typed value which can be either
+    # `Value` represents a dynamically typed value which can be either
     # null, a number, a string, a boolean, a recursive struct value, or a
     # list of values. A producer of value is expected to set one of that
     # variants, absence of any variant indicates an error.
     #
-    # The JSON representation for +Value+ is JSON value.
+    # The JSON representation for `Value` is JSON value.
     # @!attribute [rw] null_value
     #   @return [Google::Protobuf::NullValue]
     #     Represents a null value.
@@ -51,21 +51,21 @@ module Google
     #     Represents a structured value.
     # @!attribute [rw] list_value
     #   @return [Google::Protobuf::ListValue]
-    #     Represents a repeated +Value+.
+    #     Represents a repeated `Value`.
     class Value; end
 
-    # +ListValue+ is a wrapper around a repeated field of values.
+    # `ListValue` is a wrapper around a repeated field of values.
     #
-    # The JSON representation for +ListValue+ is JSON array.
+    # The JSON representation for `ListValue` is JSON array.
     # @!attribute [rw] values
     #   @return [Array<Google::Protobuf::Value>]
     #     Repeated field of dynamically typed values.
     class ListValue; end
 
-    # +NullValue+ is a singleton enumeration to represent the null value for the
-    # +Value+ type union.
+    # `NullValue` is a singleton enumeration to represent the null value for the
+    # `Value` type union.
     #
-    #  The JSON representation for +NullValue+ is JSON +null+.
+    #  The JSON representation for `NullValue` is JSON `null`.
     module NullValue
       # Null value.
       NULL_VALUE = 0

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/keys.rb
@@ -37,14 +37,14 @@ module Google
       #     ["Bob", "2014-09-23"]
       #     ["Alfred", "2015-06-12"]
       #
-      # Since the +UserEvents+ table's +PRIMARY KEY+ clause names two
-      # columns, each +UserEvents+ key has two elements; the first is the
-      # +UserName+, and the second is the +EventDate+.
+      # Since the `UserEvents` table's `PRIMARY KEY` clause names two
+      # columns, each `UserEvents` key has two elements; the first is the
+      # `UserName`, and the second is the `EventDate`.
       #
       # Key ranges with multiple components are interpreted
       # lexicographically by component using the table or index key's declared
       # sort order. For example, the following range returns all events for
-      # user +"Bob"+ that occurred in the year 2015:
+      # user `"Bob"` that occurred in the year 2015:
       #
       #     "start_closed": ["Bob", "2015-01-01"]
       #     "end_closed": ["Bob", "2015-12-31"]
@@ -55,13 +55,13 @@ module Google
       # provided components are included; if the key is open, then rows
       # that exactly match are not included.
       #
-      # For example, the following range includes all events for +"Bob"+ that
+      # For example, the following range includes all events for `"Bob"` that
       # occurred during and after the year 2000:
       #
       #     "start_closed": ["Bob", "2000-01-01"]
       #     "end_closed": ["Bob"]
       #
-      # The next example retrieves all events for +"Bob"+:
+      # The next example retrieves all events for `"Bob"`:
       #
       #     "start_closed": ["Bob"]
       #     "end_closed": ["Bob"]
@@ -76,13 +76,13 @@ module Google
       #     "start_closed": []
       #     "end_closed": []
       #
-      # This range returns all users whose +UserName+ begins with any
+      # This range returns all users whose `UserName` begins with any
       # character from A to C:
       #
       #     "start_closed": ["A"]
       #     "end_open": ["D"]
       #
-      # This range returns all users whose +UserName+ begins with B:
+      # This range returns all users whose `UserName` begins with B:
       #
       #     "start_closed": ["B"]
       #     "end_open": ["C"]
@@ -102,26 +102,26 @@ module Google
       #     "end_closed": ["1"]
       #
       # Note that 100 is passed as the start, and 1 is passed as the end,
-      # because +Key+ is a descending column in the schema.
+      # because `Key` is a descending column in the schema.
       # @!attribute [rw] start_closed
       #   @return [Google::Protobuf::ListValue]
       #     If the start is closed, then the range includes all rows whose
-      #     first +len(start_closed)+ key columns exactly match +start_closed+.
+      #     first `len(start_closed)` key columns exactly match `start_closed`.
       # @!attribute [rw] start_open
       #   @return [Google::Protobuf::ListValue]
       #     If the start is open, then the range excludes rows whose first
-      #     +len(start_open)+ key columns exactly match +start_open+.
+      #     `len(start_open)` key columns exactly match `start_open`.
       # @!attribute [rw] end_closed
       #   @return [Google::Protobuf::ListValue]
       #     If the end is closed, then the range includes all rows whose
-      #     first +len(end_closed)+ key columns exactly match +end_closed+.
+      #     first `len(end_closed)` key columns exactly match `end_closed`.
       # @!attribute [rw] end_open
       #   @return [Google::Protobuf::ListValue]
       #     If the end is open, then the range excludes rows whose first
-      #     +len(end_open)+ key columns exactly match +end_open+.
+      #     `len(end_open)` key columns exactly match `end_open`.
       class KeyRange; end
 
-      # +KeySet+ defines a collection of Cloud Spanner keys and/or key ranges. All
+      # `KeySet` defines a collection of Cloud Spanner keys and/or key ranges. All
       # the keys are expected to be in the same table or index. The keys need
       # not be sorted in any particular way.
       #
@@ -130,9 +130,9 @@ module Google
       # behaves as if the key were only specified once.
       # @!attribute [rw] keys
       #   @return [Array<Google::Protobuf::ListValue>]
-      #     A list of specific keys. Entries in +keys+ should have exactly as
+      #     A list of specific keys. Entries in `keys` should have exactly as
       #     many elements as there are columns in the primary or index key
-      #     with which this +KeySet+ is used.  Individual key values are
+      #     with which this `KeySet` is used.  Individual key values are
       #     encoded as described {Google::Spanner::V1::TypeCode here}.
       # @!attribute [rw] ranges
       #   @return [Array<Google::Spanner::V1::KeyRange>]
@@ -140,9 +140,9 @@ module Google
       #     key range specifications.
       # @!attribute [rw] all
       #   @return [true, false]
-      #     For convenience +all+ can be set to +true+ to indicate that this
-      #     +KeySet+ matches all keys in the table or index. Note that any keys
-      #     specified in +keys+ or +ranges+ are only yielded once.
+      #     For convenience `all` can be set to `true` to indicate that this
+      #     `KeySet` matches all keys in the table or index. Note that any keys
+      #     specified in `keys` or `ranges` are only yielded once.
       class KeySet; end
     end
   end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/mutation.rb
@@ -22,11 +22,11 @@ module Google
       # @!attribute [rw] insert
       #   @return [Google::Spanner::V1::Mutation::Write]
       #     Insert new rows in a table. If any of the rows already exist,
-      #     the write or transaction fails with error +ALREADY_EXISTS+.
+      #     the write or transaction fails with error `ALREADY_EXISTS`.
       # @!attribute [rw] update
       #   @return [Google::Spanner::V1::Mutation::Write]
       #     Update existing rows in a table. If any of the rows does not
-      #     already exist, the transaction fails with error +NOT_FOUND+.
+      #     already exist, the transaction fails with error `NOT_FOUND`.
       # @!attribute [rw] insert_or_update
       #   @return [Google::Spanner::V1::Mutation::Write]
       #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row already exists, then
@@ -37,7 +37,7 @@ module Google
       #     Like {Google::Spanner::V1::Mutation#insert insert}, except that if the row already exists, it is
       #     deleted, and the column values provided are inserted
       #     instead. Unlike {Google::Spanner::V1::Mutation#insert_or_update insert_or_update}, this means any values not
-      #     explicitly written become +NULL+.
+      #     explicitly written become `NULL`.
       # @!attribute [rw] delete
       #   @return [Google::Spanner::V1::Mutation::Delete]
       #     Delete rows from a table. Succeeds whether or not the named
@@ -57,12 +57,12 @@ module Google
         #     row(s) to be modified.
         # @!attribute [rw] values
         #   @return [Array<Google::Protobuf::ListValue>]
-        #     The values to be written. +values+ can contain more than one
+        #     The values to be written. `values` can contain more than one
         #     list of values. If it does, then multiple rows are written, one
-        #     for each entry in +values+. Each list in +values+ must have
+        #     for each entry in `values`. Each list in `values` must have
         #     exactly as many entries as there are entries in {Google::Spanner::V1::Mutation::Write#columns columns}
         #     above. Sending multiple lists is equivalent to sending multiple
-        #     +Mutation+s, each containing one +values+ entry and repeating
+        #     `Mutation`s, each containing one `values` entry and repeating
         #     {Google::Spanner::V1::Mutation::Write#table table} and {Google::Spanner::V1::Mutation::Write#columns columns}. Individual values in each list are
         #     encoded as described {Google::Spanner::V1::TypeCode here}.
         class Write; end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/query_plan.rb
@@ -19,7 +19,7 @@ module Google
       # Node information for nodes appearing in a {Google::Spanner::V1::QueryPlan#plan_nodes QueryPlan#plan_nodes}.
       # @!attribute [rw] index
       #   @return [Integer]
-      #     The +PlanNode+'s index in {Google::Spanner::V1::QueryPlan#plan_nodes node list}.
+      #     The `PlanNode`'s index in {Google::Spanner::V1::QueryPlan#plan_nodes node list}.
       # @!attribute [rw] kind
       #   @return [Google::Spanner::V1::PlanNode::Kind]
       #     Used to determine the type of node. May be needed for visualizing
@@ -32,7 +32,7 @@ module Google
       #     The display name for the node.
       # @!attribute [rw] child_links
       #   @return [Array<Google::Spanner::V1::PlanNode::ChildLink>]
-      #     List of child node +index+es and their relationship to this parent.
+      #     List of child node `index`es and their relationship to this parent.
       # @!attribute [rw] short_representation
       #   @return [Google::Spanner::V1::PlanNode::ShortRepresentation]
       #     Condensed representation for {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} nodes.
@@ -69,24 +69,24 @@ module Google
         #     Only present if the child node is {Google::Spanner::V1::PlanNode::Kind::SCALAR SCALAR} and corresponds
         #     to an output variable of the parent node. The field carries the name of
         #     the output variable.
-        #     For example, a +TableScan+ operator that reads rows from a table will
-        #     have child links to the +SCALAR+ nodes representing the output variables
+        #     For example, a `TableScan` operator that reads rows from a table will
+        #     have child links to the `SCALAR` nodes representing the output variables
         #     created for each column that is read by the operator. The corresponding
-        #     +variable+ fields will be set to the variable names assigned to the
+        #     `variable` fields will be set to the variable names assigned to the
         #     columns.
         class ChildLink; end
 
         # Condensed representation of a node and its subtree. Only present for
-        # +SCALAR+ {Google::Spanner::V1::PlanNode PlanNode(s)}.
+        # `SCALAR` {Google::Spanner::V1::PlanNode PlanNode(s)}.
         # @!attribute [rw] description
         #   @return [String]
         #     A string representation of the expression subtree rooted at this node.
         # @!attribute [rw] subqueries
         #   @return [Hash{String => Integer}]
         #     A mapping of (subquery variable name) -> (subquery node id) for cases
-        #     where the +description+ string of this node references a +SCALAR+
+        #     where the `description` string of this node references a `SCALAR`
         #     subquery contained in the expression subtree rooted at this node. The
-        #     referenced +SCALAR+ subquery may not necessarily be a direct child of
+        #     referenced `SCALAR` subquery may not necessarily be a direct child of
         #     this node.
         class ShortRepresentation; end
 
@@ -98,7 +98,7 @@ module Google
 
           # Denotes a Relational operator node in the expression tree. Relational
           # operators represent iterative processing of rows during query execution.
-          # For example, a +TableScan+ operation that reads rows from a table.
+          # For example, a `TableScan` operation that reads rows from a table.
           RELATIONAL = 1
 
           # Denotes a Scalar node in the expression tree. Scalar nodes represent
@@ -113,8 +113,8 @@ module Google
       # @!attribute [rw] plan_nodes
       #   @return [Array<Google::Spanner::V1::PlanNode>]
       #     The nodes in the query plan. Plan nodes are returned in pre-order starting
-      #     with the plan root. Each {Google::Spanner::V1::PlanNode PlanNode}'s +id+ corresponds to its index in
-      #     +plan_nodes+.
+      #     with the plan root. Each {Google::Spanner::V1::PlanNode PlanNode}'s `id` corresponds to its index in
+      #     `plan_nodes`.
       class QueryPlan; end
     end
   end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/result_set.rb
@@ -23,7 +23,7 @@ module Google
       #     Metadata about the result set, such as row type information.
       # @!attribute [rw] rows
       #   @return [Array<Google::Protobuf::ListValue>]
-      #     Each element in +rows+ is a row whose format is defined by
+      #     Each element in `rows` is a row whose format is defined by
       #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. The ith element
       #     in each row matches the ith field in
       #     {Google::Spanner::V1::ResultSetMetadata#row_type metadata::row_type}. Elements are
@@ -46,7 +46,7 @@ module Google
       # @!attribute [rw] values
       #   @return [Array<Google::Protobuf::Value>]
       #     A streamed result set consists of a stream of values, which might
-      #     be split into many +PartialResultSet+ messages to accommodate
+      #     be split into many `PartialResultSet` messages to accommodate
       #     large rows and/or large values. Every N complete values defines a
       #     row, where N is equal to the number of entries in
       #     {Google::Spanner::V1::StructType#fields metadata::row_type::fields}.
@@ -56,16 +56,16 @@ module Google
       #
       #     It is possible that the last value in values is "chunked",
       #     meaning that the rest of the value is sent in subsequent
-      #     +PartialResultSet+(s). This is denoted by the {Google::Spanner::V1::PartialResultSet#chunked_value chunked_value}
+      #     `PartialResultSet`(s). This is denoted by the {Google::Spanner::V1::PartialResultSet#chunked_value chunked_value}
       #     field. Two or more chunked values can be merged to form a
       #     complete value as follows:
       #
-      #     * +bool/number/null+: cannot be chunked
-      #       * +string+: concatenate the strings
-      #       * +list+: concatenate the lists. If the last element in a list is a
-      #         +string+, +list+, or +object+, merge it with the first element in
+      #     * `bool/number/null`: cannot be chunked
+      #       * `string`: concatenate the strings
+      #       * `list`: concatenate the lists. If the last element in a list is a
+      #         `string`, `list`, or `object`, merge it with the first element in
       #         the next list by applying these rules recursively.
-      #       * +object+: concatenate the (field name, field value) pairs. If a
+      #       * `object`: concatenate the (field name, field value) pairs. If a
       #         field name is duplicated, then apply these rules recursively
       #         to merge the field values.
       #
@@ -97,7 +97,7 @@ module Google
       #
       #     For a more complete example, suppose a streaming SQL query is
       #     yielding a result set whose rows contain a single string
-      #     field. The following +PartialResultSet+s might be yielded:
+      #     field. The following `PartialResultSet`s might be yielded:
       #
       #         {
       #           "metadata": { ... }
@@ -115,20 +115,20 @@ module Google
       #           "resume_token": "Zx1B..."
       #         }
       #
-      #     This sequence of +PartialResultSet+s encodes two rows, one
-      #     containing the field value +"Hello"+, and a second containing the
-      #     field value +"World" = "W" + "orl" + "d"+.
+      #     This sequence of `PartialResultSet`s encodes two rows, one
+      #     containing the field value `"Hello"`, and a second containing the
+      #     field value `"World" = "W" + "orl" + "d"`.
       # @!attribute [rw] chunked_value
       #   @return [true, false]
       #     If true, then the final value in {Google::Spanner::V1::PartialResultSet#values values} is chunked, and must
-      #     be combined with more values from subsequent +PartialResultSet+s
+      #     be combined with more values from subsequent `PartialResultSet`s
       #     to obtain a complete field value.
       # @!attribute [rw] resume_token
       #   @return [String]
       #     Streaming calls might be interrupted for a variety of reasons, such
       #     as TCP connection loss. If this occurs, the stream of results can
       #     be resumed by re-sending the original request and including
-      #     +resume_token+. Note that executing any other transaction in the
+      #     `resume_token`. Note that executing any other transaction in the
       #     same session invalidates the token.
       # @!attribute [rw] stats
       #   @return [Google::Spanner::V1::ResultSetStats]
@@ -142,8 +142,8 @@ module Google
       # @!attribute [rw] row_type
       #   @return [Google::Spanner::V1::StructType]
       #     Indicates the field names and types for the rows in the result
-      #     set.  For example, a SQL query like +"SELECT UserId, UserName FROM
-      #     Users"+ could return a +row_type+ value like:
+      #     set.  For example, a SQL query like `"SELECT UserId, UserName FROM
+      #     Users"` could return a `row_type` value like:
       #
       #         "fields": [
       #           { "name": "UserId", "type": { "code": "INT64" } },

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/spanner.rb
@@ -35,9 +35,9 @@ module Google
       #     The labels for the session.
       #
       #     * Label keys must be between 1 and 63 characters long and must conform to
-      #       the following regular expression: +[a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?+.
+      #       the following regular expression: `[a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?`.
       #     * Label values must be between 0 and 63 characters long and must conform
-      #       to the regular expression +([a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?)?+.
+      #       to the regular expression `([a-z](https://cloud.google.com[-a-z0-9]*[a-z0-9])?)?`.
       #     * No more than 64 labels can be associated with a given session.
       #
       #     See https://goo.gl/xmQnxf for more information on and examples of labels.
@@ -66,7 +66,7 @@ module Google
       #     to the server's maximum allowed page size.
       # @!attribute [rw] page_token
       #   @return [String]
-      #     If non-empty, +page_token+ should contain a
+      #     If non-empty, `page_token` should contain a
       #     {Google::Spanner::V1::ListSessionsResponse#next_page_token next_page_token} from a previous
       #     {Google::Spanner::V1::ListSessionsResponse ListSessionsResponse}.
       # @!attribute [rw] filter
@@ -74,12 +74,12 @@ module Google
       #     An expression for filtering the results of the request. Filter rules are
       #     case insensitive. The fields eligible for filtering are:
       #
-      #     * +labels.key+ where key is the name of a label
+      #     * `labels.key` where key is the name of a label
       #
       #     Some examples of using filters are:
       #
-      #     * +labels.env:*+ --> The session has the label "env".
-      #       * +labels.env:dev+ --> The session has the label "env" and the value of
+      #     * `labels.env:*` --> The session has the label "env".
+      #       * `labels.env:dev` --> The session has the label "env" and the value of
       #         the label contains the string "dev".
       class ListSessionsRequest; end
 
@@ -89,7 +89,7 @@ module Google
       #     The list of requested sessions.
       # @!attribute [rw] next_page_token
       #   @return [String]
-      #     +next_page_token+ can be sent in a subsequent
+      #     `next_page_token` can be sent in a subsequent
       #     {Google::Spanner::V1::Spanner::ListSessions ListSessions} call to fetch more of the matching
       #     sessions.
       class ListSessionsResponse; end
@@ -115,33 +115,33 @@ module Google
       # @!attribute [rw] params
       #   @return [Google::Protobuf::Struct]
       #     The SQL query string can contain parameter placeholders. A parameter
-      #     placeholder consists of +'@'+ followed by the parameter
+      #     placeholder consists of `'@'` followed by the parameter
       #     name. Parameter names consist of any combination of letters,
       #     numbers, and underscores.
       #
       #     Parameters can appear anywhere that a literal value is expected.  The same
       #     parameter name can be used more than once, for example:
-      #       +"WHERE id > @msg_id AND id < @msg_id + 100"+
+      #       `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
       #     It is an error to execute an SQL query with unbound parameters.
       #
-      #     Parameter values are specified using +params+, which is a JSON
+      #     Parameter values are specified using `params`, which is a JSON
       #     object whose keys are parameter names, and whose values are the
       #     corresponding parameter values.
       # @!attribute [rw] param_types
       #   @return [Hash{String => Google::Spanner::V1::Type}]
       #     It is not always possible for Cloud Spanner to infer the right SQL type
-      #     from a JSON value.  For example, values of type +BYTES+ and values
-      #     of type +STRING+ both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
+      #     from a JSON value.  For example, values of type `BYTES` and values
+      #     of type `STRING` both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
       #
-      #     In these cases, +param_types+ can be used to specify the exact
+      #     In these cases, `param_types` can be used to specify the exact
       #     SQL type for some or all of the SQL query parameters. See the
       #     definition of {Google::Spanner::V1::Type Type} for more information
       #     about SQL types.
       # @!attribute [rw] resume_token
       #   @return [String]
       #     If this request is resuming a previously interrupted SQL query
-      #     execution, +resume_token+ should be copied from the last
+      #     execution, `resume_token` should be copied from the last
       #     {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
       #     enables the new SQL query execution to resume where the last one left
       #     off. The rest of the request parameters must exactly match the
@@ -215,26 +215,26 @@ module Google
       # @!attribute [rw] params
       #   @return [Google::Protobuf::Struct]
       #     The SQL query string can contain parameter placeholders. A parameter
-      #     placeholder consists of +'@'+ followed by the parameter
+      #     placeholder consists of `'@'` followed by the parameter
       #     name. Parameter names consist of any combination of letters,
       #     numbers, and underscores.
       #
       #     Parameters can appear anywhere that a literal value is expected.  The same
       #     parameter name can be used more than once, for example:
-      #       +"WHERE id > @msg_id AND id < @msg_id + 100"+
+      #       `"WHERE id > @msg_id AND id < @msg_id + 100"`
       #
       #     It is an error to execute an SQL query with unbound parameters.
       #
-      #     Parameter values are specified using +params+, which is a JSON
+      #     Parameter values are specified using `params`, which is a JSON
       #     object whose keys are parameter names, and whose values are the
       #     corresponding parameter values.
       # @!attribute [rw] param_types
       #   @return [Hash{String => Google::Spanner::V1::Type}]
       #     It is not always possible for Cloud Spanner to infer the right SQL type
-      #     from a JSON value.  For example, values of type +BYTES+ and values
-      #     of type +STRING+ both appear in {Google::Spanner::V1::PartitionQueryRequest#params params} as JSON strings.
+      #     from a JSON value.  For example, values of type `BYTES` and values
+      #     of type `STRING` both appear in {Google::Spanner::V1::PartitionQueryRequest#params params} as JSON strings.
       #
-      #     In these cases, +param_types+ can be used to specify the exact
+      #     In these cases, `param_types` can be used to specify the exact
       #     SQL type for some or all of the SQL query parameters. See the
       #     definition of {Google::Spanner::V1::Type Type} for more information
       #     about SQL types.
@@ -265,12 +265,12 @@ module Google
       #     this request.
       # @!attribute [rw] key_set
       #   @return [Google::Spanner::V1::KeySet]
-      #     Required. +key_set+ identifies the rows to be yielded. +key_set+ names the
+      #     Required. `key_set` identifies the rows to be yielded. `key_set` names the
       #     primary keys of the rows in {Google::Spanner::V1::PartitionReadRequest#table table} to be yielded, unless {Google::Spanner::V1::PartitionReadRequest#index index}
       #     is present. If {Google::Spanner::V1::PartitionReadRequest#index index} is present, then {Google::Spanner::V1::PartitionReadRequest#key_set key_set} instead names
       #     index keys in {Google::Spanner::V1::PartitionReadRequest#index index}.
       #
-      #     It is not an error for the +key_set+ to name rows that do not
+      #     It is not an error for the `key_set` to name rows that do not
       #     exist in the database. Read yields nothing for nonexistent rows.
       # @!attribute [rw] partition_options
       #   @return [Google::Spanner::V1::PartitionOptions]
@@ -319,7 +319,7 @@ module Google
       #     this request.
       # @!attribute [rw] key_set
       #   @return [Google::Spanner::V1::KeySet]
-      #     Required. +key_set+ identifies the rows to be yielded. +key_set+ names the
+      #     Required. `key_set` identifies the rows to be yielded. `key_set` names the
       #     primary keys of the rows in {Google::Spanner::V1::ReadRequest#table table} to be yielded, unless {Google::Spanner::V1::ReadRequest#index index}
       #     is present. If {Google::Spanner::V1::ReadRequest#index index} is present, then {Google::Spanner::V1::ReadRequest#key_set key_set} instead names
       #     index keys in {Google::Spanner::V1::ReadRequest#index index}.
@@ -329,17 +329,17 @@ module Google
       #     (if {Google::Spanner::V1::ReadRequest#index index} is non-empty).  If the {Google::Spanner::V1::ReadRequest#partition_token partition_token} field is not
       #     empty, rows will be yielded in an unspecified order.
       #
-      #     It is not an error for the +key_set+ to name rows that do not
+      #     It is not an error for the `key_set` to name rows that do not
       #     exist in the database. Read yields nothing for nonexistent rows.
       # @!attribute [rw] limit
       #   @return [Integer]
-      #     If greater than zero, only the first +limit+ rows are yielded. If +limit+
+      #     If greater than zero, only the first `limit` rows are yielded. If `limit`
       #     is zero, the default is no limit. A limit cannot be specified if
-      #     +partition_token+ is set.
+      #     `partition_token` is set.
       # @!attribute [rw] resume_token
       #   @return [String]
       #     If this request is resuming a previously interrupted read,
-      #     +resume_token+ should be copied from the last
+      #     `resume_token` should be copied from the last
       #     {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
       #     enables the new read to resume where the last read left off. The
       #     rest of the request parameters must exactly match the request
@@ -373,7 +373,7 @@ module Google
       #     Execute mutations in a temporary transaction. Note that unlike
       #     commit of a previously-started transaction, commit with a
       #     temporary transaction is non-idempotent. That is, if the
-      #     +CommitRequest+ is sent to Cloud Spanner more than once (for
+      #     `CommitRequest` is sent to Cloud Spanner more than once (for
       #     instance, due to retries in the application, or in the
       #     transport library), it is possible that the mutations are
       #     executed more than once. If this is undesirable, use

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/transaction.rb
@@ -80,7 +80,7 @@ module Google
       # Cloud Spanner can commit the transaction if all read locks it acquired
       # are still valid at commit time, and it is able to acquire write
       # locks for all writes. Cloud Spanner can abort the transaction for any
-      # reason. If a commit attempt returns +ABORTED+, Cloud Spanner guarantees
+      # reason. If a commit attempt returns `ABORTED`, Cloud Spanner guarantees
       # that the transaction has not modified any user data in Cloud Spanner.
       #
       # Unless the transaction commits, Cloud Spanner makes no guarantees about
@@ -110,10 +110,10 @@ module Google
       # SQL queries and has not started a read or SQL query within the last 10
       # seconds. Idle transactions can be aborted by Cloud Spanner so that they
       # don't hold on to locks indefinitely. In that case, the commit will
-      # fail with error +ABORTED+.
+      # fail with error `ABORTED`.
       #
       # If this behavior is undesirable, periodically executing a simple
-      # SQL query in the transaction (e.g., +SELECT 1+) prevents the
+      # SQL query in the transaction (e.g., `SELECT 1`) prevents the
       # transaction from becoming idle.
       #
       # == Snapshot Read-Only Transactions
@@ -231,21 +231,21 @@ module Google
       # at read timestamps more than one hour in the past. This
       # restriction also applies to in-progress reads and/or SQL queries whose
       # timestamp become too old while executing. Reads and SQL queries with
-      # too-old read timestamps fail with the error +FAILED_PRECONDITION+.
+      # too-old read timestamps fail with the error `FAILED_PRECONDITION`.
       # @!attribute [rw] read_write
       #   @return [Google::Spanner::V1::TransactionOptions::ReadWrite]
       #     Transaction may write.
       #
       #     Authorization to begin a read-write transaction requires
-      #     +spanner.databases.beginOrRollbackReadWriteTransaction+ permission
-      #     on the +session+ resource.
+      #     `spanner.databases.beginOrRollbackReadWriteTransaction` permission
+      #     on the `session` resource.
       # @!attribute [rw] read_only
       #   @return [Google::Spanner::V1::TransactionOptions::ReadOnly]
       #     Transaction will not write.
       #
       #     Authorization to begin a read-only transaction requires
-      #     +spanner.databases.beginReadOnlyTransaction+ permission
-      #     on the +session+ resource.
+      #     `spanner.databases.beginReadOnlyTransaction` permission
+      #     on the `session` resource.
       class TransactionOptions
         # Message type to initiate a read-write transaction. Currently this
         # transaction type has no options.
@@ -258,7 +258,7 @@ module Google
         #     are visible.
         # @!attribute [rw] min_read_timestamp
         #   @return [Google::Protobuf::Timestamp]
-        #     Executes all reads at a timestamp >= +min_read_timestamp+.
+        #     Executes all reads at a timestamp >= `min_read_timestamp`.
         #
         #     This is useful for requesting fresher data than some previous
         #     read, or data that is fresh enough to observe the effects of some
@@ -267,10 +267,10 @@ module Google
         #     Note that this option can only be used in single-use transactions.
         #
         #     A timestamp in RFC3339 UTC \"Zulu\" format, accurate to nanoseconds.
-        #     Example: +"2014-10-02T15:01:23.045123456Z"+.
+        #     Example: `"2014-10-02T15:01:23.045123456Z"`.
         # @!attribute [rw] max_staleness
         #   @return [Google::Protobuf::Duration]
-        #     Read data at a timestamp >= +NOW - max_staleness+
+        #     Read data at a timestamp >= `NOW - max_staleness`
         #     seconds. Guarantees that all writes that have committed more
         #     than the specified number of seconds ago are visible. Because
         #     Cloud Spanner chooses the exact timestamp, this mode works even if
@@ -296,10 +296,10 @@ module Google
         #     data.
         #
         #     A timestamp in RFC3339 UTC \"Zulu\" format, accurate to nanoseconds.
-        #     Example: +"2014-10-02T15:01:23.045123456Z"+.
+        #     Example: `"2014-10-02T15:01:23.045123456Z"`.
         # @!attribute [rw] exact_staleness
         #   @return [Google::Protobuf::Duration]
-        #     Executes all reads at a timestamp that is +exact_staleness+
+        #     Executes all reads at a timestamp that is `exact_staleness`
         #     old. The timestamp is chosen soon after the read is started.
         #
         #     Guarantees that all writes that have committed more than the
@@ -309,7 +309,7 @@ module Google
         #     timestamps.
         #
         #     Useful for reading at nearby replicas without the distributed
-        #     timestamp negotiation overhead of +max_staleness+.
+        #     timestamp negotiation overhead of `max_staleness`.
         # @!attribute [rw] return_read_timestamp
         #   @return [true, false]
         #     If true, the Cloud Spanner-selected read timestamp is included in
@@ -320,7 +320,7 @@ module Google
       # A transaction.
       # @!attribute [rw] id
       #   @return [String]
-      #     +id+ may be used to identify the transaction in subsequent
+      #     `id` may be used to identify the transaction in subsequent
       #     {Google::Spanner::V1::Spanner::Read Read},
       #     {Google::Spanner::V1::Spanner::ExecuteSql ExecuteSql},
       #     {Google::Spanner::V1::Spanner::Commit Commit}, or
@@ -335,7 +335,7 @@ module Google
       #     {Google::Spanner::V1::TransactionOptions::ReadOnly#return_read_timestamp TransactionOptions::ReadOnly#return_read_timestamp}.
       #
       #     A timestamp in RFC3339 UTC \"Zulu\" format, accurate to nanoseconds.
-      #     Example: +"2014-10-02T15:01:23.045123456Z"+.
+      #     Example: `"2014-10-02T15:01:23.045123456Z"`.
       class Transaction; end
 
       # This message is used to select the transaction in which a

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/doc/google/spanner/v1/type.rb
@@ -16,22 +16,22 @@
 module Google
   module Spanner
     module V1
-      # +Type+ indicates the type of a Cloud Spanner value, as might be stored in a
+      # `Type` indicates the type of a Cloud Spanner value, as might be stored in a
       # table cell or returned from an SQL query.
       # @!attribute [rw] code
       #   @return [Google::Spanner::V1::TypeCode]
       #     Required. The {Google::Spanner::V1::TypeCode TypeCode} for this type.
       # @!attribute [rw] array_element_type
       #   @return [Google::Spanner::V1::Type]
-      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::ARRAY ARRAY}, then +array_element_type+
+      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::ARRAY ARRAY}, then `array_element_type`
       #     is the type of the array elements.
       # @!attribute [rw] struct_type
       #   @return [Google::Spanner::V1::StructType]
-      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::STRUCT STRUCT}, then +struct_type+
+      #     If {Google::Spanner::V1::Type#code code} == {Google::Spanner::V1::TypeCode::STRUCT STRUCT}, then `struct_type`
       #     provides type information for the struct's fields.
       class Type; end
 
-      # +StructType+ defines the fields of a {Google::Spanner::V1::TypeCode::STRUCT STRUCT} type.
+      # `StructType` defines the fields of a {Google::Spanner::V1::TypeCode::STRUCT STRUCT} type.
       # @!attribute [rw] fields
       #   @return [Array<Google::Spanner::V1::StructType::Field>]
       #     The list of fields that make up this struct. Order is
@@ -39,17 +39,17 @@ module Google
       #     lists, where the order of field values matches the order of
       #     fields in the {Google::Spanner::V1::StructType StructType}. In turn, the order of fields
       #     matches the order of columns in a read request, or the order of
-      #     fields in the +SELECT+ clause of a query.
+      #     fields in the `SELECT` clause of a query.
       class StructType
         # Message representing a single field of a struct.
         # @!attribute [rw] name
         #   @return [String]
         #     The name of the field. For reads, this is the column name. For
-        #     SQL queries, it is the column alias (e.g., +"Word"+ in the
-        #     query +"SELECT 'hello' AS Word"+), or the column name (e.g.,
-        #     +"ColName"+ in the query +"SELECT ColName FROM Table"+). Some
+        #     SQL queries, it is the column alias (e.g., `"Word"` in the
+        #     query `"SELECT 'hello' AS Word"`), or the column name (e.g.,
+        #     `"ColName"` in the query `"SELECT ColName FROM Table"`). Some
         #     columns might have an empty name (e.g., !"SELECT
-        #     UPPER(ColName)"+). Note that a query result can contain
+        #     UPPER(ColName)"`). Note that a query result can contain
         #     multiple fields with the same name.
         # @!attribute [rw] type
         #   @return [Google::Spanner::V1::Type]
@@ -57,52 +57,52 @@ module Google
         class Field; end
       end
 
-      # +TypeCode+ is used as part of {Google::Spanner::V1::Type Type} to
+      # `TypeCode` is used as part of {Google::Spanner::V1::Type Type} to
       # indicate the type of a Cloud Spanner value.
       #
       # Each legal value of a type can be encoded to or decoded from a JSON
       # value, using the encodings described below. All Cloud Spanner values can
-      # be +null+, regardless of type; +null+s are always encoded as a JSON
-      # +null+.
+      # be `null`, regardless of type; `null`s are always encoded as a JSON
+      # `null`.
       module TypeCode
         # Not specified.
         TYPE_CODE_UNSPECIFIED = 0
 
-        # Encoded as JSON +true+ or +false+.
+        # Encoded as JSON `true` or `false`.
         BOOL = 1
 
-        # Encoded as +string+, in decimal format.
+        # Encoded as `string`, in decimal format.
         INT64 = 2
 
-        # Encoded as +number+, or the strings +"NaN"+, +"Infinity"+, or
-        # +"-Infinity"+.
+        # Encoded as `number`, or the strings `"NaN"`, `"Infinity"`, or
+        # `"-Infinity"`.
         FLOAT64 = 3
 
-        # Encoded as +string+ in RFC 3339 timestamp format. The time zone
-        # must be present, and must be +"Z"+.
+        # Encoded as `string` in RFC 3339 timestamp format. The time zone
+        # must be present, and must be `"Z"`.
         #
         # If the schema has the column option
-        # +allow_commit_timestamp=true+, the placeholder string
-        # +"spanner.commit_timestamp()"+ can be used to instruct the system
+        # `allow_commit_timestamp=true`, the placeholder string
+        # `"spanner.commit_timestamp()"` can be used to instruct the system
         # to insert the commit timestamp associated with the transaction
         # commit.
         TIMESTAMP = 4
 
-        # Encoded as +string+ in RFC 3339 date format.
+        # Encoded as `string` in RFC 3339 date format.
         DATE = 5
 
-        # Encoded as +string+.
+        # Encoded as `string`.
         STRING = 6
 
-        # Encoded as a base64-encoded +string+, as described in RFC 4648,
+        # Encoded as a base64-encoded `string`, as described in RFC 4648,
         # section 4.
         BYTES = 7
 
-        # Encoded as +list+, where the list elements are represented
+        # Encoded as `list`, where the list elements are represented
         # according to {Google::Spanner::V1::Type#array_element_type array_element_type}.
         ARRAY = 8
 
-        # Encoded as +list+, where list element +i+ is represented according
+        # Encoded as `list`, where list element `i` is represented according
         # to [struct_type.fields[i]][google.spanner.v1.StructType.fields].
         STRUCT = 9
       end

--- a/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
+++ b/google-cloud-spanner/lib/google/cloud/spanner/v1/spanner_client.rb
@@ -298,10 +298,10 @@ module Google
           # time; thus, it is a good idea to delete idle and/or unneeded sessions.
           # Aside from explicit deletes, Cloud Spanner can delete sessions for which no
           # operations are sent for more than an hour. If a session is deleted,
-          # requests to it return +NOT_FOUND+.
+          # requests to it return `NOT_FOUND`.
           #
           # Idle sessions can be kept alive by sending a trivial SQL query
-          # periodically, e.g., +"SELECT 1"+.
+          # periodically, e.g., `"SELECT 1"`.
           #
           # @param database [String]
           #   Required. The database in which the new session is created.
@@ -337,7 +337,7 @@ module Google
             @create_session.call(req, options, &block)
           end
 
-          # Gets a session. Returns +NOT_FOUND+ if the session does not exist.
+          # Gets a session. Returns `NOT_FOUND` if the session does not exist.
           # This is mainly useful for determining whether a session is still
           # alive.
           #
@@ -383,12 +383,12 @@ module Google
           #   An expression for filtering the results of the request. Filter rules are
           #   case insensitive. The fields eligible for filtering are:
           #
-          #   * +labels.key+ where key is the name of a label
+          #   * `labels.key` where key is the name of a label
           #
           #   Some examples of using filters are:
           #
-          #   * +labels.env:*+ --> The session has the label "env".
-          #     * +labels.env:dev+ --> The session has the label "env" and the value of
+          #   * `labels.env:*` --> The session has the label "env".
+          #     * `labels.env:dev` --> The session has the label "env" and the value of
           #       the label contains the string "dev".
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -469,9 +469,9 @@ module Google
           # Executes an SQL query, returning all rows in a single reply. This
           # method cannot be used to return a result set larger than 10 MiB;
           # if the query yields more data than that, the query fails with
-          # a +FAILED_PRECONDITION+ error.
+          # a `FAILED_PRECONDITION` error.
           #
-          # Queries inside read-write transactions might return +ABORTED+. If
+          # Queries inside read-write transactions might return `ABORTED`. If
           # this occurs, the application should restart the transaction from
           # the beginning. See {Google::Spanner::V1::Transaction Transaction} for more details.
           #
@@ -489,27 +489,27 @@ module Google
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
           #   The SQL query string can contain parameter placeholders. A parameter
-          #   placeholder consists of +'@'+ followed by the parameter
+          #   placeholder consists of `'@'` followed by the parameter
           #   name. Parameter names consist of any combination of letters,
           #   numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     +"WHERE id > @msg_id AND id < @msg_id + 100"+
+          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
           #   It is an error to execute an SQL query with unbound parameters.
           #
-          #   Parameter values are specified using +params+, which is a JSON
+          #   Parameter values are specified using `params`, which is a JSON
           #   object whose keys are parameter names, and whose values are the
           #   corresponding parameter values.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
           #   It is not always possible for Cloud Spanner to infer the right SQL type
-          #   from a JSON value.  For example, values of type +BYTES+ and values
-          #   of type +STRING+ both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
+          #   from a JSON value.  For example, values of type `BYTES` and values
+          #   of type `STRING` both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
           #
-          #   In these cases, +param_types+ can be used to specify the exact
+          #   In these cases, `param_types` can be used to specify the exact
           #   SQL type for some or all of the SQL query parameters. See the
           #   definition of {Google::Spanner::V1::Type Type} for more information
           #   about SQL types.
@@ -517,7 +517,7 @@ module Google
           #   can also be provided.
           # @param resume_token [String]
           #   If this request is resuming a previously interrupted SQL query
-          #   execution, +resume_token+ should be copied from the last
+          #   execution, `resume_token` should be copied from the last
           #   {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
           #   enables the new SQL query execution to resume where the last one left
           #   off. The rest of the request parameters must exactly match the
@@ -545,7 +545,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +sql+:
+          #   # TODO: Initialize `sql`:
           #   sql = ''
           #   response = spanner_client.execute_sql(formatted_session, sql)
 
@@ -591,27 +591,27 @@ module Google
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
           #   The SQL query string can contain parameter placeholders. A parameter
-          #   placeholder consists of +'@'+ followed by the parameter
+          #   placeholder consists of `'@'` followed by the parameter
           #   name. Parameter names consist of any combination of letters,
           #   numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     +"WHERE id > @msg_id AND id < @msg_id + 100"+
+          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
           #   It is an error to execute an SQL query with unbound parameters.
           #
-          #   Parameter values are specified using +params+, which is a JSON
+          #   Parameter values are specified using `params`, which is a JSON
           #   object whose keys are parameter names, and whose values are the
           #   corresponding parameter values.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
           #   It is not always possible for Cloud Spanner to infer the right SQL type
-          #   from a JSON value.  For example, values of type +BYTES+ and values
-          #   of type +STRING+ both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
+          #   from a JSON value.  For example, values of type `BYTES` and values
+          #   of type `STRING` both appear in {Google::Spanner::V1::ExecuteSqlRequest#params params} as JSON strings.
           #
-          #   In these cases, +param_types+ can be used to specify the exact
+          #   In these cases, `param_types` can be used to specify the exact
           #   SQL type for some or all of the SQL query parameters. See the
           #   definition of {Google::Spanner::V1::Type Type} for more information
           #   about SQL types.
@@ -619,7 +619,7 @@ module Google
           #   can also be provided.
           # @param resume_token [String]
           #   If this request is resuming a previously interrupted SQL query
-          #   execution, +resume_token+ should be copied from the last
+          #   execution, `resume_token` should be copied from the last
           #   {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
           #   enables the new SQL query execution to resume where the last one left
           #   off. The rest of the request parameters must exactly match the
@@ -646,7 +646,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +sql+:
+          #   # TODO: Initialize `sql`:
           #   sql = ''
           #   spanner_client.execute_streaming_sql(formatted_session, sql).each do |element|
           #     # Process element.
@@ -680,10 +680,10 @@ module Google
           # simple key/value style alternative to
           # {Google::Spanner::V1::Spanner::ExecuteSql ExecuteSql}.  This method cannot be used to
           # return a result set larger than 10 MiB; if the read matches more
-          # data than that, the read fails with a +FAILED_PRECONDITION+
+          # data than that, the read fails with a `FAILED_PRECONDITION`
           # error.
           #
-          # Reads inside read-write transactions might return +ABORTED+. If
+          # Reads inside read-write transactions might return `ABORTED`. If
           # this occurs, the application should restart the transaction from
           # the beginning. See {Google::Spanner::V1::Transaction Transaction} for more details.
           #
@@ -698,7 +698,7 @@ module Google
           #   The columns of {Google::Spanner::V1::ReadRequest#table table} to be returned for each row matching
           #   this request.
           # @param key_set [Google::Spanner::V1::KeySet | Hash]
-          #   Required. +key_set+ identifies the rows to be yielded. +key_set+ names the
+          #   Required. `key_set` identifies the rows to be yielded. `key_set` names the
           #   primary keys of the rows in {Google::Spanner::V1::ReadRequest#table table} to be yielded, unless {Google::Spanner::V1::ReadRequest#index index}
           #   is present. If {Google::Spanner::V1::ReadRequest#index index} is present, then {Google::Spanner::V1::ReadRequest#key_set key_set} instead names
           #   index keys in {Google::Spanner::V1::ReadRequest#index index}.
@@ -708,7 +708,7 @@ module Google
           #   (if {Google::Spanner::V1::ReadRequest#index index} is non-empty).  If the {Google::Spanner::V1::ReadRequest#partition_token partition_token} field is not
           #   empty, rows will be yielded in an unspecified order.
           #
-          #   It is not an error for the +key_set+ to name rows that do not
+          #   It is not an error for the `key_set` to name rows that do not
           #   exist in the database. Read yields nothing for nonexistent rows.
           #   A hash of the same form as `Google::Spanner::V1::KeySet`
           #   can also be provided.
@@ -722,12 +722,12 @@ module Google
           #   used instead of the table primary key when interpreting {Google::Spanner::V1::ReadRequest#key_set key_set}
           #   and sorting result rows. See {Google::Spanner::V1::ReadRequest#key_set key_set} for further information.
           # @param limit [Integer]
-          #   If greater than zero, only the first +limit+ rows are yielded. If +limit+
+          #   If greater than zero, only the first `limit` rows are yielded. If `limit`
           #   is zero, the default is no limit. A limit cannot be specified if
-          #   +partition_token+ is set.
+          #   `partition_token` is set.
           # @param resume_token [String]
           #   If this request is resuming a previously interrupted read,
-          #   +resume_token+ should be copied from the last
+          #   `resume_token` should be copied from the last
           #   {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
           #   enables the new read to resume where the last read left off. The
           #   rest of the request parameters must exactly match the request
@@ -751,13 +751,13 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +table+:
+          #   # TODO: Initialize `table`:
           #   table = ''
           #
-          #   # TODO: Initialize +columns+:
+          #   # TODO: Initialize `columns`:
           #   columns = []
           #
-          #   # TODO: Initialize +key_set+:
+          #   # TODO: Initialize `key_set`:
           #   key_set = {}
           #   response = spanner_client.read(formatted_session, table, columns, key_set)
 
@@ -802,7 +802,7 @@ module Google
           #   The columns of {Google::Spanner::V1::ReadRequest#table table} to be returned for each row matching
           #   this request.
           # @param key_set [Google::Spanner::V1::KeySet | Hash]
-          #   Required. +key_set+ identifies the rows to be yielded. +key_set+ names the
+          #   Required. `key_set` identifies the rows to be yielded. `key_set` names the
           #   primary keys of the rows in {Google::Spanner::V1::ReadRequest#table table} to be yielded, unless {Google::Spanner::V1::ReadRequest#index index}
           #   is present. If {Google::Spanner::V1::ReadRequest#index index} is present, then {Google::Spanner::V1::ReadRequest#key_set key_set} instead names
           #   index keys in {Google::Spanner::V1::ReadRequest#index index}.
@@ -812,7 +812,7 @@ module Google
           #   (if {Google::Spanner::V1::ReadRequest#index index} is non-empty).  If the {Google::Spanner::V1::ReadRequest#partition_token partition_token} field is not
           #   empty, rows will be yielded in an unspecified order.
           #
-          #   It is not an error for the +key_set+ to name rows that do not
+          #   It is not an error for the `key_set` to name rows that do not
           #   exist in the database. Read yields nothing for nonexistent rows.
           #   A hash of the same form as `Google::Spanner::V1::KeySet`
           #   can also be provided.
@@ -826,12 +826,12 @@ module Google
           #   used instead of the table primary key when interpreting {Google::Spanner::V1::ReadRequest#key_set key_set}
           #   and sorting result rows. See {Google::Spanner::V1::ReadRequest#key_set key_set} for further information.
           # @param limit [Integer]
-          #   If greater than zero, only the first +limit+ rows are yielded. If +limit+
+          #   If greater than zero, only the first `limit` rows are yielded. If `limit`
           #   is zero, the default is no limit. A limit cannot be specified if
-          #   +partition_token+ is set.
+          #   `partition_token` is set.
           # @param resume_token [String]
           #   If this request is resuming a previously interrupted read,
-          #   +resume_token+ should be copied from the last
+          #   `resume_token` should be copied from the last
           #   {Google::Spanner::V1::PartialResultSet PartialResultSet} yielded before the interruption. Doing this
           #   enables the new read to resume where the last read left off. The
           #   rest of the request parameters must exactly match the request
@@ -854,13 +854,13 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +table+:
+          #   # TODO: Initialize `table`:
           #   table = ''
           #
-          #   # TODO: Initialize +columns+:
+          #   # TODO: Initialize `columns`:
           #   columns = []
           #
-          #   # TODO: Initialize +key_set+:
+          #   # TODO: Initialize `key_set`:
           #   key_set = {}
           #   spanner_client.streaming_read(formatted_session, table, columns, key_set).each do |element|
           #     # Process element.
@@ -917,7 +917,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +options_+:
+          #   # TODO: Initialize `options_`:
           #   options_ = {}
           #   response = spanner_client.begin_transaction(formatted_session, options_)
 
@@ -937,10 +937,10 @@ module Google
           # Commits a transaction. The request includes the mutations to be
           # applied to rows in the database.
           #
-          # +Commit+ might return an +ABORTED+ error. This can occur at any time;
+          # `Commit` might return an `ABORTED` error. This can occur at any time;
           # commonly, the cause is conflicts with concurrent
           # transactions. However, it can also happen for a variety of other
-          # reasons. If +Commit+ returns +ABORTED+, the caller should re-attempt
+          # reasons. If `Commit` returns `ABORTED`, the caller should re-attempt
           # the transaction from the beginning, re-using the same session.
           #
           # @param session [String]
@@ -957,7 +957,7 @@ module Google
           #   Execute mutations in a temporary transaction. Note that unlike
           #   commit of a previously-started transaction, commit with a
           #   temporary transaction is non-idempotent. That is, if the
-          #   +CommitRequest+ is sent to Cloud Spanner more than once (for
+          #   `CommitRequest` is sent to Cloud Spanner more than once (for
           #   instance, due to retries in the application, or in the
           #   transport library), it is possible that the mutations are
           #   executed more than once. If this is undesirable, use
@@ -979,7 +979,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +mutations+:
+          #   # TODO: Initialize `mutations`:
           #   mutations = []
           #   response = spanner_client.commit(formatted_session, mutations)
 
@@ -1005,9 +1005,9 @@ module Google
           # {Google::Spanner::V1::Spanner::Read Read} or {Google::Spanner::V1::Spanner::ExecuteSql ExecuteSql} requests and
           # ultimately decides not to commit.
           #
-          # +Rollback+ returns +OK+ if it successfully aborts the transaction, the
+          # `Rollback` returns `OK` if it successfully aborts the transaction, the
           # transaction was already aborted, or the transaction is not
-          # found. +Rollback+ never returns +ABORTED+.
+          # found. `Rollback` never returns `ABORTED`.
           #
           # @param session [String]
           #   Required. The session in which the transaction to roll back is running.
@@ -1026,7 +1026,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +transaction_id+:
+          #   # TODO: Initialize `transaction_id`:
           #   transaction_id = ''
           #   spanner_client.rollback(formatted_session, transaction_id)
 
@@ -1069,27 +1069,27 @@ module Google
           #   can also be provided.
           # @param params [Google::Protobuf::Struct | Hash]
           #   The SQL query string can contain parameter placeholders. A parameter
-          #   placeholder consists of +'@'+ followed by the parameter
+          #   placeholder consists of `'@'` followed by the parameter
           #   name. Parameter names consist of any combination of letters,
           #   numbers, and underscores.
           #
           #   Parameters can appear anywhere that a literal value is expected.  The same
           #   parameter name can be used more than once, for example:
-          #     +"WHERE id > @msg_id AND id < @msg_id + 100"+
+          #     `"WHERE id > @msg_id AND id < @msg_id + 100"`
           #
           #   It is an error to execute an SQL query with unbound parameters.
           #
-          #   Parameter values are specified using +params+, which is a JSON
+          #   Parameter values are specified using `params`, which is a JSON
           #   object whose keys are parameter names, and whose values are the
           #   corresponding parameter values.
           #   A hash of the same form as `Google::Protobuf::Struct`
           #   can also be provided.
           # @param param_types [Hash{String => Google::Spanner::V1::Type | Hash}]
           #   It is not always possible for Cloud Spanner to infer the right SQL type
-          #   from a JSON value.  For example, values of type +BYTES+ and values
-          #   of type +STRING+ both appear in {Google::Spanner::V1::PartitionQueryRequest#params params} as JSON strings.
+          #   from a JSON value.  For example, values of type `BYTES` and values
+          #   of type `STRING` both appear in {Google::Spanner::V1::PartitionQueryRequest#params params} as JSON strings.
           #
-          #   In these cases, +param_types+ can be used to specify the exact
+          #   In these cases, `param_types` can be used to specify the exact
           #   SQL type for some or all of the SQL query parameters. See the
           #   definition of {Google::Spanner::V1::Type Type} for more information
           #   about SQL types.
@@ -1113,7 +1113,7 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +sql+:
+          #   # TODO: Initialize `sql`:
           #   sql = ''
           #   response = spanner_client.partition_query(formatted_session, sql)
 
@@ -1152,12 +1152,12 @@ module Google
           # @param table [String]
           #   Required. The name of the table in the database to be read.
           # @param key_set [Google::Spanner::V1::KeySet | Hash]
-          #   Required. +key_set+ identifies the rows to be yielded. +key_set+ names the
+          #   Required. `key_set` identifies the rows to be yielded. `key_set` names the
           #   primary keys of the rows in {Google::Spanner::V1::PartitionReadRequest#table table} to be yielded, unless {Google::Spanner::V1::PartitionReadRequest#index index}
           #   is present. If {Google::Spanner::V1::PartitionReadRequest#index index} is present, then {Google::Spanner::V1::PartitionReadRequest#key_set key_set} instead names
           #   index keys in {Google::Spanner::V1::PartitionReadRequest#index index}.
           #
-          #   It is not an error for the +key_set+ to name rows that do not
+          #   It is not an error for the `key_set` to name rows that do not
           #   exist in the database. Read yields nothing for nonexistent rows.
           #   A hash of the same form as `Google::Spanner::V1::KeySet`
           #   can also be provided.
@@ -1191,10 +1191,10 @@ module Google
           #   spanner_client = Google::Cloud::Spanner::V1::SpannerClient.new
           #   formatted_session = Google::Cloud::Spanner::V1::SpannerClient.session_path("[PROJECT]", "[INSTANCE]", "[DATABASE]", "[SESSION]")
           #
-          #   # TODO: Initialize +table+:
+          #   # TODO: Initialize `table`:
           #   table = ''
           #
-          #   # TODO: Initialize +key_set+:
+          #   # TODO: Initialize `key_set`:
           #   key_set = {}
           #   response = spanner_client.partition_read(formatted_session, table, key_set)
 

--- a/google-cloud-spanner/synth.py
+++ b/google-cloud-spanner/synth.py
@@ -123,10 +123,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^#\\$\\\\])\\{([\\w,]+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/cloud/speech/v1/cloud_speech.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Speech
       module V1
-        # The top-level message sent by the client for the +Recognize+ method.
+        # The top-level message sent by the client for the `Recognize` method.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig]
         #     *Required* Provides information to the recognizer that specifies how to
@@ -27,7 +27,7 @@ module Google
         #     *Required* The audio data to be recognized.
         class RecognizeRequest; end
 
-        # The top-level message sent by the client for the +LongRunningRecognize+
+        # The top-level message sent by the client for the `LongRunningRecognize`
         # method.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig]
@@ -38,24 +38,24 @@ module Google
         #     *Required* The audio data to be recognized.
         class LongRunningRecognizeRequest; end
 
-        # The top-level message sent by the client for the +StreamingRecognize+ method.
-        # Multiple +StreamingRecognizeRequest+ messages are sent. The first message
-        # must contain a +streaming_config+ message and must not contain +audio+ data.
-        # All subsequent messages must contain +audio+ data and must not contain a
-        # +streaming_config+ message.
+        # The top-level message sent by the client for the `StreamingRecognize` method.
+        # Multiple `StreamingRecognizeRequest` messages are sent. The first message
+        # must contain a `streaming_config` message and must not contain `audio` data.
+        # All subsequent messages must contain `audio` data and must not contain a
+        # `streaming_config` message.
         # @!attribute [rw] streaming_config
         #   @return [Google::Cloud::Speech::V1::StreamingRecognitionConfig]
         #     Provides information to the recognizer that specifies how to process the
-        #     request. The first +StreamingRecognizeRequest+ message must contain a
-        #     +streaming_config+  message.
+        #     request. The first `StreamingRecognizeRequest` message must contain a
+        #     `streaming_config`  message.
         # @!attribute [rw] audio_content
         #   @return [String]
         #     The audio data to be recognized. Sequential chunks of audio data are sent
-        #     in sequential +StreamingRecognizeRequest+ messages. The first
-        #     +StreamingRecognizeRequest+ message must not contain +audio_content+ data
-        #     and all subsequent +StreamingRecognizeRequest+ messages must contain
-        #     +audio_content+ data. The audio bytes must be encoded as specified in
-        #     +RecognitionConfig+. Note: as with all bytes fields, protobuffers use a
+        #     in sequential `StreamingRecognizeRequest` messages. The first
+        #     `StreamingRecognizeRequest` message must not contain `audio_content` data
+        #     and all subsequent `StreamingRecognizeRequest` messages must contain
+        #     `audio_content` data. The audio bytes must be encoded as specified in
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
         #     pure binary representation (not base64). See
         #     [content limits](https://cloud.google.com/speech-to-text/quotas#content).
         class StreamingRecognizeRequest; end
@@ -68,40 +68,40 @@ module Google
         #     process the request.
         # @!attribute [rw] single_utterance
         #   @return [true, false]
-        #     *Optional* If +false+ or omitted, the recognizer will perform continuous
+        #     *Optional* If `false` or omitted, the recognizer will perform continuous
         #     recognition (continuing to wait for and process audio even if the user
         #     pauses speaking) until the client closes the input stream (gRPC API) or
         #     until the maximum time limit has been reached. May return multiple
-        #     +StreamingRecognitionResult+s with the +is_final+ flag set to +true+.
+        #     `StreamingRecognitionResult`s with the `is_final` flag set to `true`.
         #
-        #     If +true+, the recognizer will detect a single spoken utterance. When it
+        #     If `true`, the recognizer will detect a single spoken utterance. When it
         #     detects that the user has paused or stopped speaking, it will return an
-        #     +END_OF_SINGLE_UTTERANCE+ event and cease recognition. It will return no
-        #     more than one +StreamingRecognitionResult+ with the +is_final+ flag set to
-        #     +true+.
+        #     `END_OF_SINGLE_UTTERANCE` event and cease recognition. It will return no
+        #     more than one `StreamingRecognitionResult` with the `is_final` flag set to
+        #     `true`.
         # @!attribute [rw] interim_results
         #   @return [true, false]
-        #     *Optional* If +true+, interim results (tentative hypotheses) may be
+        #     *Optional* If `true`, interim results (tentative hypotheses) may be
         #     returned as they become available (these interim results are indicated with
-        #     the +is_final=false+ flag).
-        #     If +false+ or omitted, only +is_final=true+ result(s) are returned.
+        #     the `is_final=false` flag).
+        #     If `false` or omitted, only `is_final=true` result(s) are returned.
         class StreamingRecognitionConfig; end
 
         # Provides information to the recognizer that specifies how to process the
         # request.
         # @!attribute [rw] encoding
         #   @return [Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding]
-        #     Encoding of audio data sent in all +RecognitionAudio+ messages.
-        #     This field is optional for +FLAC+ and +WAV+ audio files and required
+        #     Encoding of audio data sent in all `RecognitionAudio` messages.
+        #     This field is optional for `FLAC` and `WAV` audio files and required
         #     for all other audio formats. For details, see {Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] sample_rate_hertz
         #   @return [Integer]
         #     Sample rate in Hertz of the audio data sent in all
-        #     +RecognitionAudio+ messages. Valid values are: 8000-48000.
+        #     `RecognitionAudio` messages. Valid values are: 8000-48000.
         #     16000 is optimal. For best results, set the sampling rate of the audio
         #     source to 16000 Hz. If that's not possible, use the native sample rate of
         #     the audio source (instead of re-sampling).
-        #     This field is optional for +FLAC+ and +WAV+ audio files and required
+        #     This field is optional for `FLAC` and `WAV` audio files and required
         #     for all other audio formats. For details, see {Google::Cloud::Speech::V1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] language_code
         #   @return [String]
@@ -113,16 +113,16 @@ module Google
         # @!attribute [rw] max_alternatives
         #   @return [Integer]
         #     *Optional* Maximum number of recognition hypotheses to be returned.
-        #     Specifically, the maximum number of +SpeechRecognitionAlternative+ messages
-        #     within each +SpeechRecognitionResult+.
-        #     The server may return fewer than +max_alternatives+.
-        #     Valid values are +0+-+30+. A value of +0+ or +1+ will return a maximum of
+        #     Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+        #     within each `SpeechRecognitionResult`.
+        #     The server may return fewer than `max_alternatives`.
+        #     Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
         #     one. If omitted, will return a maximum of one.
         # @!attribute [rw] profanity_filter
         #   @return [true, false]
-        #     *Optional* If set to +true+, the server will attempt to filter out
+        #     *Optional* If set to `true`, the server will attempt to filter out
         #     profanities, replacing all but the initial character in each filtered word
-        #     with asterisks, e.g. "f***". If set to +false+ or omitted, profanities
+        #     with asterisks, e.g. "f***". If set to `false` or omitted, profanities
         #     won't be filtered out.
         # @!attribute [rw] speech_contexts
         #   @return [Array<Google::Cloud::Speech::V1::SpeechContext>]
@@ -131,10 +131,10 @@ module Google
         #     information, see [Phrase Hints](https://cloud.google.com/speech-to-text/docs/basics#phrase-hints).
         # @!attribute [rw] enable_word_time_offsets
         #   @return [true, false]
-        #     *Optional* If +true+, the top result includes a list of words and
+        #     *Optional* If `true`, the top result includes a list of words and
         #     the start and end time offsets (timestamps) for those words. If
-        #     +false+, no word-level time offset information is returned. The default is
-        #     +false+.
+        #     `false`, no word-level time offset information is returned. The default is
+        #     `false`.
         # @!attribute [rw] enable_automatic_punctuation
         #   @return [true, false]
         #     *Optional* If 'true', adds punctuation to recognition result hypotheses.
@@ -181,15 +181,15 @@ module Google
         # @!attribute [rw] use_enhanced
         #   @return [true, false]
         #     *Optional* Set to true to use an enhanced model for speech recognition.
-        #     You must also set the +model+ field to a valid, enhanced model. If
-        #     +use_enhanced+ is set to true and the +model+ field is not set, then
-        #     +use_enhanced+ is ignored. If +use_enhanced+ is true and an enhanced
+        #     You must also set the `model` field to a valid, enhanced model. If
+        #     `use_enhanced` is set to true and the `model` field is not set, then
+        #     `use_enhanced` is ignored. If `use_enhanced` is true and an enhanced
         #     version of the specified model does not exist, then the speech is
         #     recognized using the standard version of the specified model.
         #
         #     Enhanced speech models require that you opt-in to data logging using
         #     instructions in the [documentation](https://cloud.google.com/speech-to-text/enable-data-logging).
-        #     If you set +use_enhanced+ to true and you have not enabled audio logging,
+        #     If you set `use_enhanced` to true and you have not enabled audio logging,
         #     then you will receive an error.
         class RecognitionConfig
           # The encoding of the audio data sent in the request.
@@ -197,18 +197,18 @@ module Google
           # All encodings support only 1 channel (mono) audio.
           #
           # For best results, the audio source should be captured and transmitted using
-          # a lossless encoding (+FLAC+ or +LINEAR16+). The accuracy of the speech
+          # a lossless encoding (`FLAC` or `LINEAR16`). The accuracy of the speech
           # recognition can be reduced if lossy codecs are used to capture or transmit
           # audio, particularly if background noise is present. Lossy codecs include
-          # +MULAW+, +AMR+, +AMR_WB+, +OGG_OPUS+, and +SPEEX_WITH_HEADER_BYTE+.
+          # `MULAW`, `AMR`, `AMR_WB`, `OGG_OPUS`, and `SPEEX_WITH_HEADER_BYTE`.
           #
-          # The +FLAC+ and +WAV+ audio file formats include a header that describes the
-          # included audio content. You can request recognition for +WAV+ files that
-          # contain either +LINEAR16+ or +MULAW+ encoded audio.
-          # If you send +FLAC+ or +WAV+ audio file format in
-          # your request, you do not need to specify an +AudioEncoding+; the audio
+          # The `FLAC` and `WAV` audio file formats include a header that describes the
+          # included audio content. You can request recognition for `WAV` files that
+          # contain either `LINEAR16` or `MULAW` encoded audio.
+          # If you send `FLAC` or `WAV` audio file format in
+          # your request, you do not need to specify an `AudioEncoding`; the audio
           # encoding format is determined from the file header. If you specify
-          # an +AudioEncoding+ when you send  send +FLAC+ or +WAV+ audio, the
+          # an `AudioEncoding` when you send  send `FLAC` or `WAV` audio, the
           # encoding configuration must match the encoding described in the audio
           # header; otherwise the request returns an
           # {Google::Rpc::Code::INVALID_ARGUMENT} error code.
@@ -219,33 +219,33 @@ module Google
             # Uncompressed 16-bit signed little-endian samples (Linear PCM).
             LINEAR16 = 1
 
-            # +FLAC+ (Free Lossless Audio
+            # `FLAC` (Free Lossless Audio
             # Codec) is the recommended encoding because it is
             # lossless--therefore recognition is not compromised--and
-            # requires only about half the bandwidth of +LINEAR16+. +FLAC+ stream
+            # requires only about half the bandwidth of `LINEAR16`. `FLAC` stream
             # encoding supports 16-bit and 24-bit samples, however, not all fields in
-            # +STREAMINFO+ are supported.
+            # `STREAMINFO` are supported.
             FLAC = 2
 
             # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
             MULAW = 3
 
-            # Adaptive Multi-Rate Narrowband codec. +sample_rate_hertz+ must be 8000.
+            # Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
             AMR = 4
 
-            # Adaptive Multi-Rate Wideband codec. +sample_rate_hertz+ must be 16000.
+            # Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
             AMR_WB = 5
 
             # Opus encoded audio frames in Ogg container
             # ([OggOpus](https://wiki.xiph.org/OggOpus)).
-            # +sample_rate_hertz+ must be one of 8000, 12000, 16000, 24000, or 48000.
+            # `sample_rate_hertz` must be one of 8000, 12000, 16000, 24000, or 48000.
             OGG_OPUS = 6
 
             # Although the use of lossy encodings is not recommended, if a very low
-            # bitrate encoding is required, +OGG_OPUS+ is highly preferred over
+            # bitrate encoding is required, `OGG_OPUS` is highly preferred over
             # Speex encoding. The [Speex](https://speex.org/)  encoding supported by
             # Cloud Speech API has a header byte in each block, as in MIME type
-            # +audio/x-speex-with-header-byte+.
+            # `audio/x-speex-with-header-byte`.
             # It is a variant of the RTP Speex encoding defined in
             # [RFC 5574](https://tools.ietf.org/html/rfc5574).
             # The stream is a sequence of blocks, one block per RTP packet. Each block
@@ -253,7 +253,7 @@ module Google
             # by one or more frames of Speex data, padded to an integral number of
             # bytes (octets) as specified in RFC 5574. In other words, each RTP header
             # is replaced with a single byte containing the block length. Only Speex
-            # wideband is supported. +sample_rate_hertz+ must be 16000.
+            # wideband is supported. `sample_rate_hertz` must be 16000.
             SPEEX_WITH_HEADER_BYTE = 7
           end
         end
@@ -270,28 +270,28 @@ module Google
         #     [usage limits](https://cloud.google.com/speech-to-text/quotas#content).
         class SpeechContext; end
 
-        # Contains audio data in the encoding specified in the +RecognitionConfig+.
-        # Either +content+ or +uri+ must be supplied. Supplying both or neither
+        # Contains audio data in the encoding specified in the `RecognitionConfig`.
+        # Either `content` or `uri` must be supplied. Supplying both or neither
         # returns {Google::Rpc::Code::INVALID_ARGUMENT}. See
         # [content limits](https://cloud.google.com/speech-to-text/quotas#content).
         # @!attribute [rw] content
         #   @return [String]
         #     The audio data bytes encoded as specified in
-        #     +RecognitionConfig+. Note: as with all bytes fields, protobuffers use a
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
         #     pure binary representation, whereas JSON representations use base64.
         # @!attribute [rw] uri
         #   @return [String]
         #     URI that points to a file that contains audio data bytes as specified in
-        #     +RecognitionConfig+. The file must not be compressed (for example, gzip).
+        #     `RecognitionConfig`. The file must not be compressed (for example, gzip).
         #     Currently, only Google Cloud Storage URIs are
         #     supported, which must be specified in the following format:
-        #     +gs://bucket_name/object_name+ (other URI formats return
+        #     `gs://bucket_name/object_name` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
         class RecognitionAudio; end
 
-        # The only message returned to the client by the +Recognize+ method. It
-        # contains the result as zero or more sequential +SpeechRecognitionResult+
+        # The only message returned to the client by the `Recognize` method. It
+        # contains the result as zero or more sequential `SpeechRecognitionResult`
         # messages.
         # @!attribute [rw] results
         #   @return [Array<Google::Cloud::Speech::V1::SpeechRecognitionResult>]
@@ -299,10 +299,10 @@ module Google
         #     sequential portions of audio.
         class RecognizeResponse; end
 
-        # The only message returned to the client by the +LongRunningRecognize+ method.
-        # It contains the result as zero or more sequential +SpeechRecognitionResult+
-        # messages. It is included in the +result.response+ field of the +Operation+
-        # returned by the +GetOperation+ call of the +google::longrunning::Operations+
+        # The only message returned to the client by the `LongRunningRecognize` method.
+        # It contains the result as zero or more sequential `SpeechRecognitionResult`
+        # messages. It is included in the `result.response` field of the `Operation`
+        # returned by the `GetOperation` call of the `google::longrunning::Operations`
         # service.
         # @!attribute [rw] results
         #   @return [Array<Google::Cloud::Speech::V1::SpeechRecognitionResult>]
@@ -310,9 +310,9 @@ module Google
         #     sequential portions of audio.
         class LongRunningRecognizeResponse; end
 
-        # Describes the progress of a long-running +LongRunningRecognize+ call. It is
-        # included in the +metadata+ field of the +Operation+ returned by the
-        # +GetOperation+ call of the +google::longrunning::Operations+ service.
+        # Describes the progress of a long-running `LongRunningRecognize` call. It is
+        # included in the `metadata` field of the `Operation` returned by the
+        # `GetOperation` call of the `google::longrunning::Operations` service.
         # @!attribute [rw] progress_percent
         #   @return [Integer]
         #     Approximate percentage of audio processed thus far. Guaranteed to be 100
@@ -325,13 +325,13 @@ module Google
         #     Time of the most recent processing update.
         class LongRunningRecognizeMetadata; end
 
-        # +StreamingRecognizeResponse+ is the only message returned to the client by
-        # +StreamingRecognize+. A series of zero or more +StreamingRecognizeResponse+
+        # `StreamingRecognizeResponse` is the only message returned to the client by
+        # `StreamingRecognize`. A series of zero or more `StreamingRecognizeResponse`
         # messages are streamed back to the client. If there is no recognizable
-        # audio, and +single_utterance+ is set to false, then no messages are streamed
+        # audio, and `single_utterance` is set to false, then no messages are streamed
         # back to the client.
         #
-        # Here's an example of a series of ten +StreamingRecognizeResponse+s that might
+        # Here's an example of a series of ten `StreamingRecognizeResponse`s that might
         # be returned while processing audio:
         #
         # 1. results { alternatives { transcript: "tube" } stability: 0.01 }
@@ -359,21 +359,21 @@ module Google
         # Notes:
         #
         # * Only two of the above responses #4 and #7 contain final results; they are
-        #   indicated by +is_final: true+. Concatenating these together generates the
+        #   indicated by `is_final: true`. Concatenating these together generates the
         #   full transcript: "to be or not to be that is the question".
         #
-        # * The others contain interim +results+. #3 and #6 contain two interim
-        #   +results+: the first portion has a high stability and is less likely to
+        # * The others contain interim `results`. #3 and #6 contain two interim
+        #   `results`: the first portion has a high stability and is less likely to
         #   change; the second portion has a low stability and is very likely to
-        #   change. A UI designer might choose to show only high stability +results+.
+        #   change. A UI designer might choose to show only high stability `results`.
         #
-        # * The specific +stability+ and +confidence+ values shown above are only for
+        # * The specific `stability` and `confidence` values shown above are only for
         #   illustrative purposes. Actual values may vary.
         #
         # * In each response, only one of these fields will be set:
-        #   +error+,
-        #   +speech_event_type+, or
-        #   one or more (repeated) +results+.
+        #   `error`,
+        #   `speech_event_type`, or
+        #   one or more (repeated) `results`.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
         #     Output only. If set, returns a {Google::Rpc::Status} message that
@@ -382,8 +382,8 @@ module Google
         #   @return [Array<Google::Cloud::Speech::V1::StreamingRecognitionResult>]
         #     Output only. This repeated list contains zero or more results that
         #     correspond to consecutive portions of the audio currently being processed.
-        #     It contains zero or one +is_final=true+ result (the newly settled portion),
-        #     followed by zero or more +is_final=false+ results (the interim results).
+        #     It contains zero or one `is_final=true` result (the newly settled portion),
+        #     followed by zero or more `is_final=false` results (the interim results).
         # @!attribute [rw] speech_event_type
         #   @return [Google::Cloud::Speech::V1::StreamingRecognizeResponse::SpeechEventType]
         #     Output only. Indicates the type of speech event.
@@ -399,7 +399,7 @@ module Google
             # additional results). The client should stop sending additional audio
             # data, half-close the gRPC connection, and wait for any additional results
             # until the server closes the gRPC connection. This event is only sent if
-            # +single_utterance+ was set to +true+, and is not used otherwise.
+            # `single_utterance` was set to `true`, and is not used otherwise.
             END_OF_SINGLE_UTTERANCE = 1
           end
         end
@@ -409,14 +409,14 @@ module Google
         # @!attribute [rw] alternatives
         #   @return [Array<Google::Cloud::Speech::V1::SpeechRecognitionAlternative>]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #     maximum specified in +max_alternatives+).
+        #     maximum specified in `max_alternatives`).
         #     These alternatives are ordered in terms of accuracy, with the top (first)
         #     alternative being the most probable, as ranked by the recognizer.
         # @!attribute [rw] is_final
         #   @return [true, false]
-        #     Output only. If +false+, this +StreamingRecognitionResult+ represents an
-        #     interim result that may change. If +true+, this is the final time the
-        #     speech service will return this particular +StreamingRecognitionResult+,
+        #     Output only. If `false`, this `StreamingRecognitionResult` represents an
+        #     interim result that may change. If `true`, this is the final time the
+        #     speech service will return this particular `StreamingRecognitionResult`,
         #     the recognizer will not return any further hypotheses for this portion of
         #     the transcript and corresponding audio.
         # @!attribute [rw] stability
@@ -424,15 +424,15 @@ module Google
         #     Output only. An estimate of the likelihood that the recognizer will not
         #     change its guess about this interim result. Values range from 0.0
         #     (completely unstable) to 1.0 (completely stable).
-        #     This field is only provided for interim results (+is_final=false+).
-        #     The default of 0.0 is a sentinel value indicating +stability+ was not set.
+        #     This field is only provided for interim results (`is_final=false`).
+        #     The default of 0.0 is a sentinel value indicating `stability` was not set.
         class StreamingRecognitionResult; end
 
         # A speech recognition result corresponding to a portion of the audio.
         # @!attribute [rw] alternatives
         #   @return [Array<Google::Cloud::Speech::V1::SpeechRecognitionAlternative>]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #     maximum specified in +max_alternatives+).
+        #     maximum specified in `max_alternatives`).
         #     These alternatives are ordered in terms of accuracy, with the top (first)
         #     alternative being the most probable, as ranked by the recognizer.
         class SpeechRecognitionResult; end
@@ -446,10 +446,10 @@ module Google
         #     Output only. The confidence estimate between 0.0 and 1.0. A higher number
         #     indicates an estimated greater likelihood that the recognized words are
         #     correct. This field is set only for the top alternative of a non-streaming
-        #     result or, of a streaming result where +is_final=true+.
+        #     result or, of a streaming result where `is_final=true`.
         #     This field is not guaranteed to be accurate and users should not rely on it
         #     to be always provided.
-        #     The default of 0.0 is a sentinel value indicating +confidence+ was not set.
+        #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] words
         #   @return [Array<Google::Cloud::Speech::V1::WordInfo>]
         #     Output only. A list of word-specific information for each recognized word.
@@ -460,7 +460,7 @@ module Google
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
         #     and corresponding to the start of the spoken word.
-        #     This field is only set if +enable_word_time_offsets=true+ and only
+        #     This field is only set if `enable_word_time_offsets=true` and only
         #     in the top hypothesis.
         #     This is an experimental feature and the accuracy of the time offset can
         #     vary.
@@ -468,7 +468,7 @@ module Google
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
         #     and corresponding to the end of the spoken word.
-        #     This field is only set if +enable_word_time_offsets=true+ and only
+        #     This field is only set if `enable_word_time_offsets=true` and only
         #     in the top hypothesis.
         #     This is an experimental feature and the accuracy of the time offset can
         #     vary.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1/speech_client.rb
@@ -246,8 +246,8 @@ module Google
 
           # Performs asynchronous speech recognition: receive results via the
           # google.longrunning.Operations interface. Returns either an
-          # +Operation.error+ or an +Operation.response+ which contains
-          # a +LongRunningRecognizeResponse+ message.
+          # `Operation.error` or an `Operation.response` which contains
+          # a `LongRunningRecognizeResponse` message.
           #
           # @param config [Google::Cloud::Speech::V1::RecognitionConfig | Hash]
           #   *Required* Provides information to the recognizer that specifies how to

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/cloud/speech/v1p1beta1/cloud_speech.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Speech
       module V1p1beta1
-        # The top-level message sent by the client for the +Recognize+ method.
+        # The top-level message sent by the client for the `Recognize` method.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1p1beta1::RecognitionConfig]
         #     *Required* Provides information to the recognizer that specifies how to
@@ -27,7 +27,7 @@ module Google
         #     *Required* The audio data to be recognized.
         class RecognizeRequest; end
 
-        # The top-level message sent by the client for the +LongRunningRecognize+
+        # The top-level message sent by the client for the `LongRunningRecognize`
         # method.
         # @!attribute [rw] config
         #   @return [Google::Cloud::Speech::V1p1beta1::RecognitionConfig]
@@ -38,24 +38,24 @@ module Google
         #     *Required* The audio data to be recognized.
         class LongRunningRecognizeRequest; end
 
-        # The top-level message sent by the client for the +StreamingRecognize+ method.
-        # Multiple +StreamingRecognizeRequest+ messages are sent. The first message
-        # must contain a +streaming_config+ message and must not contain +audio+ data.
-        # All subsequent messages must contain +audio+ data and must not contain a
-        # +streaming_config+ message.
+        # The top-level message sent by the client for the `StreamingRecognize` method.
+        # Multiple `StreamingRecognizeRequest` messages are sent. The first message
+        # must contain a `streaming_config` message and must not contain `audio` data.
+        # All subsequent messages must contain `audio` data and must not contain a
+        # `streaming_config` message.
         # @!attribute [rw] streaming_config
         #   @return [Google::Cloud::Speech::V1p1beta1::StreamingRecognitionConfig]
         #     Provides information to the recognizer that specifies how to process the
-        #     request. The first +StreamingRecognizeRequest+ message must contain a
-        #     +streaming_config+  message.
+        #     request. The first `StreamingRecognizeRequest` message must contain a
+        #     `streaming_config`  message.
         # @!attribute [rw] audio_content
         #   @return [String]
         #     The audio data to be recognized. Sequential chunks of audio data are sent
-        #     in sequential +StreamingRecognizeRequest+ messages. The first
-        #     +StreamingRecognizeRequest+ message must not contain +audio_content+ data
-        #     and all subsequent +StreamingRecognizeRequest+ messages must contain
-        #     +audio_content+ data. The audio bytes must be encoded as specified in
-        #     +RecognitionConfig+. Note: as with all bytes fields, protobuffers use a
+        #     in sequential `StreamingRecognizeRequest` messages. The first
+        #     `StreamingRecognizeRequest` message must not contain `audio_content` data
+        #     and all subsequent `StreamingRecognizeRequest` messages must contain
+        #     `audio_content` data. The audio bytes must be encoded as specified in
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
         #     pure binary representation (not base64). See
         #     [audio limits](https://cloud.google.com/speech/limits#content).
         class StreamingRecognizeRequest; end
@@ -68,49 +68,49 @@ module Google
         #     process the request.
         # @!attribute [rw] single_utterance
         #   @return [true, false]
-        #     *Optional* If +false+ or omitted, the recognizer will perform continuous
+        #     *Optional* If `false` or omitted, the recognizer will perform continuous
         #     recognition (continuing to wait for and process audio even if the user
         #     pauses speaking) until the client closes the input stream (gRPC API) or
         #     until the maximum time limit has been reached. May return multiple
-        #     +StreamingRecognitionResult+s with the +is_final+ flag set to +true+.
+        #     `StreamingRecognitionResult`s with the `is_final` flag set to `true`.
         #
-        #     If +true+, the recognizer will detect a single spoken utterance. When it
+        #     If `true`, the recognizer will detect a single spoken utterance. When it
         #     detects that the user has paused or stopped speaking, it will return an
-        #     +END_OF_SINGLE_UTTERANCE+ event and cease recognition. It will return no
-        #     more than one +StreamingRecognitionResult+ with the +is_final+ flag set to
-        #     +true+.
+        #     `END_OF_SINGLE_UTTERANCE` event and cease recognition. It will return no
+        #     more than one `StreamingRecognitionResult` with the `is_final` flag set to
+        #     `true`.
         # @!attribute [rw] interim_results
         #   @return [true, false]
-        #     *Optional* If +true+, interim results (tentative hypotheses) may be
+        #     *Optional* If `true`, interim results (tentative hypotheses) may be
         #     returned as they become available (these interim results are indicated with
-        #     the +is_final=false+ flag).
-        #     If +false+ or omitted, only +is_final=true+ result(s) are returned.
+        #     the `is_final=false` flag).
+        #     If `false` or omitted, only `is_final=true` result(s) are returned.
         class StreamingRecognitionConfig; end
 
         # Provides information to the recognizer that specifies how to process the
         # request.
         # @!attribute [rw] encoding
         #   @return [Google::Cloud::Speech::V1p1beta1::RecognitionConfig::AudioEncoding]
-        #     Encoding of audio data sent in all +RecognitionAudio+ messages.
-        #     This field is optional for +FLAC+ and +WAV+ audio files and required
+        #     Encoding of audio data sent in all `RecognitionAudio` messages.
+        #     This field is optional for `FLAC` and `WAV` audio files and required
         #     for all other audio formats. For details, see {Google::Cloud::Speech::V1p1beta1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] sample_rate_hertz
         #   @return [Integer]
         #     Sample rate in Hertz of the audio data sent in all
-        #     +RecognitionAudio+ messages. Valid values are: 8000-48000.
+        #     `RecognitionAudio` messages. Valid values are: 8000-48000.
         #     16000 is optimal. For best results, set the sampling rate of the audio
         #     source to 16000 Hz. If that's not possible, use the native sample rate of
         #     the audio source (instead of re-sampling).
-        #     This field is optional for +FLAC+ and +WAV+ audio files and required
+        #     This field is optional for `FLAC` and `WAV` audio files and required
         #     for all other audio formats. For details, see {Google::Cloud::Speech::V1p1beta1::RecognitionConfig::AudioEncoding AudioEncoding}.
         # @!attribute [rw] audio_channel_count
         #   @return [Integer]
         #     *Optional* The number of channels in the input audio data.
         #     ONLY set this for MULTI-CHANNEL recognition.
-        #     Valid values for LINEAR16 and FLAC are +1+-+8+.
+        #     Valid values for LINEAR16 and FLAC are `1`-`8`.
         #     Valid values for OGG_OPUS are '1'-'254'.
-        #     Valid value for MULAW, AMR, AMR_WB and SPEEX_WITH_HEADER_BYTE is only +1+.
-        #     If +0+ or omitted, defaults to one channel (mono).
+        #     Valid value for MULAW, AMR, AMR_WB and SPEEX_WITH_HEADER_BYTE is only `1`.
+        #     If `0` or omitted, defaults to one channel (mono).
         #     NOTE: We only recognize the first channel by default.
         #     To perform independent recognition on each channel set
         #     enable_separate_recognition_per_channel to 'true'.
@@ -146,31 +146,31 @@ module Google
         # @!attribute [rw] max_alternatives
         #   @return [Integer]
         #     *Optional* Maximum number of recognition hypotheses to be returned.
-        #     Specifically, the maximum number of +SpeechRecognitionAlternative+ messages
-        #     within each +SpeechRecognitionResult+.
-        #     The server may return fewer than +max_alternatives+.
-        #     Valid values are +0+-+30+. A value of +0+ or +1+ will return a maximum of
+        #     Specifically, the maximum number of `SpeechRecognitionAlternative` messages
+        #     within each `SpeechRecognitionResult`.
+        #     The server may return fewer than `max_alternatives`.
+        #     Valid values are `0`-`30`. A value of `0` or `1` will return a maximum of
         #     one. If omitted, will return a maximum of one.
         # @!attribute [rw] profanity_filter
         #   @return [true, false]
-        #     *Optional* If set to +true+, the server will attempt to filter out
+        #     *Optional* If set to `true`, the server will attempt to filter out
         #     profanities, replacing all but the initial character in each filtered word
-        #     with asterisks, e.g. "f***". If set to +false+ or omitted, profanities
+        #     with asterisks, e.g. "f***". If set to `false` or omitted, profanities
         #     won't be filtered out.
         # @!attribute [rw] speech_contexts
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::SpeechContext>]
         #     *Optional* A means to provide context to assist the speech recognition.
         # @!attribute [rw] enable_word_time_offsets
         #   @return [true, false]
-        #     *Optional* If +true+, the top result includes a list of words and
+        #     *Optional* If `true`, the top result includes a list of words and
         #     the start and end time offsets (timestamps) for those words. If
-        #     +false+, no word-level time offset information is returned. The default is
-        #     +false+.
+        #     `false`, no word-level time offset information is returned. The default is
+        #     `false`.
         # @!attribute [rw] enable_word_confidence
         #   @return [true, false]
-        #     *Optional* If +true+, the top result includes a list of words and the
-        #     confidence for those words. If +false+, no word-level confidence
-        #     information is returned. The default is +false+.
+        #     *Optional* If `true`, the top result includes a list of words and the
+        #     confidence for those words. If `false`, no word-level confidence
+        #     information is returned. The default is `false`.
         # @!attribute [rw] enable_automatic_punctuation
         #   @return [true, false]
         #     *Optional* If 'true', adds punctuation to recognition result hypotheses.
@@ -235,15 +235,15 @@ module Google
         # @!attribute [rw] use_enhanced
         #   @return [true, false]
         #     *Optional* Set to true to use an enhanced model for speech recognition.
-        #     You must also set the +model+ field to a valid, enhanced model. If
-        #     +use_enhanced+ is set to true and the +model+ field is not set, then
-        #     +use_enhanced+ is ignored. If +use_enhanced+ is true and an enhanced
+        #     You must also set the `model` field to a valid, enhanced model. If
+        #     `use_enhanced` is set to true and the `model` field is not set, then
+        #     `use_enhanced` is ignored. If `use_enhanced` is true and an enhanced
         #     version of the specified model does not exist, then the speech is
         #     recognized using the standard version of the specified model.
         #
         #     Enhanced speech models require that you opt-in to the audio logging using
         #     instructions in the [alpha documentation](https://cloud.google.com/speech/data-sharing). If you set
-        #     +use_enhanced+ to true and you have not enabled audio logging, then you
+        #     `use_enhanced` to true and you have not enabled audio logging, then you
         #     will receive an error.
         class RecognitionConfig
           # The encoding of the audio data sent in the request.
@@ -251,18 +251,18 @@ module Google
           # All encodings support only 1 channel (mono) audio.
           #
           # For best results, the audio source should be captured and transmitted using
-          # a lossless encoding (+FLAC+ or +LINEAR16+). The accuracy of the speech
+          # a lossless encoding (`FLAC` or `LINEAR16`). The accuracy of the speech
           # recognition can be reduced if lossy codecs are used to capture or transmit
           # audio, particularly if background noise is present. Lossy codecs include
-          # +MULAW+, +AMR+, +AMR_WB+, +OGG_OPUS+, and +SPEEX_WITH_HEADER_BYTE+.
+          # `MULAW`, `AMR`, `AMR_WB`, `OGG_OPUS`, and `SPEEX_WITH_HEADER_BYTE`.
           #
-          # The +FLAC+ and +WAV+ audio file formats include a header that describes the
-          # included audio content. You can request recognition for +WAV+ files that
-          # contain either +LINEAR16+ or +MULAW+ encoded audio.
-          # If you send +FLAC+ or +WAV+ audio file format in
-          # your request, you do not need to specify an +AudioEncoding+; the audio
+          # The `FLAC` and `WAV` audio file formats include a header that describes the
+          # included audio content. You can request recognition for `WAV` files that
+          # contain either `LINEAR16` or `MULAW` encoded audio.
+          # If you send `FLAC` or `WAV` audio file format in
+          # your request, you do not need to specify an `AudioEncoding`; the audio
           # encoding format is determined from the file header. If you specify
-          # an +AudioEncoding+ when you send  send +FLAC+ or +WAV+ audio, the
+          # an `AudioEncoding` when you send  send `FLAC` or `WAV` audio, the
           # encoding configuration must match the encoding described in the audio
           # header; otherwise the request returns an
           # {Google::Rpc::Code::INVALID_ARGUMENT} error code.
@@ -273,33 +273,33 @@ module Google
             # Uncompressed 16-bit signed little-endian samples (Linear PCM).
             LINEAR16 = 1
 
-            # +FLAC+ (Free Lossless Audio
+            # `FLAC` (Free Lossless Audio
             # Codec) is the recommended encoding because it is
             # lossless--therefore recognition is not compromised--and
-            # requires only about half the bandwidth of +LINEAR16+. +FLAC+ stream
+            # requires only about half the bandwidth of `LINEAR16`. `FLAC` stream
             # encoding supports 16-bit and 24-bit samples, however, not all fields in
-            # +STREAMINFO+ are supported.
+            # `STREAMINFO` are supported.
             FLAC = 2
 
             # 8-bit samples that compand 14-bit audio samples using G.711 PCMU/mu-law.
             MULAW = 3
 
-            # Adaptive Multi-Rate Narrowband codec. +sample_rate_hertz+ must be 8000.
+            # Adaptive Multi-Rate Narrowband codec. `sample_rate_hertz` must be 8000.
             AMR = 4
 
-            # Adaptive Multi-Rate Wideband codec. +sample_rate_hertz+ must be 16000.
+            # Adaptive Multi-Rate Wideband codec. `sample_rate_hertz` must be 16000.
             AMR_WB = 5
 
             # Opus encoded audio frames in Ogg container
             # ([OggOpus](https://wiki.xiph.org/OggOpus)).
-            # +sample_rate_hertz+ must be one of 8000, 12000, 16000, 24000, or 48000.
+            # `sample_rate_hertz` must be one of 8000, 12000, 16000, 24000, or 48000.
             OGG_OPUS = 6
 
             # Although the use of lossy encodings is not recommended, if a very low
-            # bitrate encoding is required, +OGG_OPUS+ is highly preferred over
+            # bitrate encoding is required, `OGG_OPUS` is highly preferred over
             # Speex encoding. The [Speex](https://speex.org/)  encoding supported by
             # Cloud Speech API has a header byte in each block, as in MIME type
-            # +audio/x-speex-with-header-byte+.
+            # `audio/x-speex-with-header-byte`.
             # It is a variant of the RTP Speex encoding defined in
             # [RFC 5574](https://tools.ietf.org/html/rfc5574).
             # The stream is a sequence of blocks, one block per RTP packet. Each block
@@ -307,7 +307,7 @@ module Google
             # by one or more frames of Speex data, padded to an integral number of
             # bytes (octets) as specified in RFC 5574. In other words, each RTP header
             # is replaced with a single byte containing the block length. Only Speex
-            # wideband is supported. +sample_rate_hertz+ must be 16000.
+            # wideband is supported. `sample_rate_hertz` must be 16000.
             SPEEX_WITH_HEADER_BYTE = 7
           end
         end
@@ -338,8 +338,8 @@ module Google
         #     'Cardioid Microphone'.
         # @!attribute [rw] original_mime_type
         #   @return [String]
-        #     Mime type of the original audio file.  For example +audio/m4a+,
-        #     +audio/x-alaw-basic+, +audio/mp3+, +audio/3gpp+.
+        #     Mime type of the original audio file.  For example `audio/m4a`,
+        #     `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
         #     A list of possible audio mime types is maintained at
         #     http://www.iana.org/assignments/media-types/media-types.xhtml#audio
         # @!attribute [rw] obfuscated_id
@@ -455,27 +455,27 @@ module Google
         #     [usage limits](https://cloud.google.com/speech/limits#content).
         class SpeechContext; end
 
-        # Contains audio data in the encoding specified in the +RecognitionConfig+.
-        # Either +content+ or +uri+ must be supplied. Supplying both or neither
+        # Contains audio data in the encoding specified in the `RecognitionConfig`.
+        # Either `content` or `uri` must be supplied. Supplying both or neither
         # returns {Google::Rpc::Code::INVALID_ARGUMENT}. See
         # [audio limits](https://cloud.google.com/speech/limits#content).
         # @!attribute [rw] content
         #   @return [String]
         #     The audio data bytes encoded as specified in
-        #     +RecognitionConfig+. Note: as with all bytes fields, protobuffers use a
+        #     `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
         #     pure binary representation, whereas JSON representations use base64.
         # @!attribute [rw] uri
         #   @return [String]
         #     URI that points to a file that contains audio data bytes as specified in
-        #     +RecognitionConfig+. Currently, only Google Cloud Storage URIs are
+        #     `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
         #     supported, which must be specified in the following format:
-        #     +gs://bucket_name/object_name+ (other URI formats return
+        #     `gs://bucket_name/object_name` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
         class RecognitionAudio; end
 
-        # The only message returned to the client by the +Recognize+ method. It
-        # contains the result as zero or more sequential +SpeechRecognitionResult+
+        # The only message returned to the client by the `Recognize` method. It
+        # contains the result as zero or more sequential `SpeechRecognitionResult`
         # messages.
         # @!attribute [rw] results
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::SpeechRecognitionResult>]
@@ -483,10 +483,10 @@ module Google
         #     sequential portions of audio.
         class RecognizeResponse; end
 
-        # The only message returned to the client by the +LongRunningRecognize+ method.
-        # It contains the result as zero or more sequential +SpeechRecognitionResult+
-        # messages. It is included in the +result.response+ field of the +Operation+
-        # returned by the +GetOperation+ call of the +google::longrunning::Operations+
+        # The only message returned to the client by the `LongRunningRecognize` method.
+        # It contains the result as zero or more sequential `SpeechRecognitionResult`
+        # messages. It is included in the `result.response` field of the `Operation`
+        # returned by the `GetOperation` call of the `google::longrunning::Operations`
         # service.
         # @!attribute [rw] results
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::SpeechRecognitionResult>]
@@ -494,9 +494,9 @@ module Google
         #     sequential portions of audio.
         class LongRunningRecognizeResponse; end
 
-        # Describes the progress of a long-running +LongRunningRecognize+ call. It is
-        # included in the +metadata+ field of the +Operation+ returned by the
-        # +GetOperation+ call of the +google::longrunning::Operations+ service.
+        # Describes the progress of a long-running `LongRunningRecognize` call. It is
+        # included in the `metadata` field of the `Operation` returned by the
+        # `GetOperation` call of the `google::longrunning::Operations` service.
         # @!attribute [rw] progress_percent
         #   @return [Integer]
         #     Approximate percentage of audio processed thus far. Guaranteed to be 100
@@ -509,13 +509,13 @@ module Google
         #     Time of the most recent processing update.
         class LongRunningRecognizeMetadata; end
 
-        # +StreamingRecognizeResponse+ is the only message returned to the client by
-        # +StreamingRecognize+. A series of zero or more +StreamingRecognizeResponse+
+        # `StreamingRecognizeResponse` is the only message returned to the client by
+        # `StreamingRecognize`. A series of zero or more `StreamingRecognizeResponse`
         # messages are streamed back to the client. If there is no recognizable
-        # audio, and +single_utterance+ is set to false, then no messages are streamed
+        # audio, and `single_utterance` is set to false, then no messages are streamed
         # back to the client.
         #
-        # Here's an example of a series of ten +StreamingRecognizeResponse+s that might
+        # Here's an example of a series of ten `StreamingRecognizeResponse`s that might
         # be returned while processing audio:
         #
         # 1. results { alternatives { transcript: "tube" } stability: 0.01 }
@@ -543,21 +543,21 @@ module Google
         # Notes:
         #
         # * Only two of the above responses #4 and #7 contain final results; they are
-        #   indicated by +is_final: true+. Concatenating these together generates the
+        #   indicated by `is_final: true`. Concatenating these together generates the
         #   full transcript: "to be or not to be that is the question".
         #
-        # * The others contain interim +results+. #3 and #6 contain two interim
-        #   +results+: the first portion has a high stability and is less likely to
+        # * The others contain interim `results`. #3 and #6 contain two interim
+        #   `results`: the first portion has a high stability and is less likely to
         #   change; the second portion has a low stability and is very likely to
-        #   change. A UI designer might choose to show only high stability +results+.
+        #   change. A UI designer might choose to show only high stability `results`.
         #
-        # * The specific +stability+ and +confidence+ values shown above are only for
+        # * The specific `stability` and `confidence` values shown above are only for
         #   illustrative purposes. Actual values may vary.
         #
         # * In each response, only one of these fields will be set:
-        #   +error+,
-        #   +speech_event_type+, or
-        #   one or more (repeated) +results+.
+        #   `error`,
+        #   `speech_event_type`, or
+        #   one or more (repeated) `results`.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
         #     Output only. If set, returns a {Google::Rpc::Status} message that
@@ -566,8 +566,8 @@ module Google
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::StreamingRecognitionResult>]
         #     Output only. This repeated list contains zero or more results that
         #     correspond to consecutive portions of the audio currently being processed.
-        #     It contains zero or one +is_final=true+ result (the newly settled portion),
-        #     followed by zero or more +is_final=false+ results (the interim results).
+        #     It contains zero or one `is_final=true` result (the newly settled portion),
+        #     followed by zero or more `is_final=false` results (the interim results).
         # @!attribute [rw] speech_event_type
         #   @return [Google::Cloud::Speech::V1p1beta1::StreamingRecognizeResponse::SpeechEventType]
         #     Output only. Indicates the type of speech event.
@@ -583,7 +583,7 @@ module Google
             # additional results). The client should stop sending additional audio
             # data, half-close the gRPC connection, and wait for any additional results
             # until the server closes the gRPC connection. This event is only sent if
-            # +single_utterance+ was set to +true+, and is not used otherwise.
+            # `single_utterance` was set to `true`, and is not used otherwise.
             END_OF_SINGLE_UTTERANCE = 1
           end
         end
@@ -593,14 +593,14 @@ module Google
         # @!attribute [rw] alternatives
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::SpeechRecognitionAlternative>]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #     maximum specified in +max_alternatives+).
+        #     maximum specified in `max_alternatives`).
         #     These alternatives are ordered in terms of accuracy, with the top (first)
         #     alternative being the most probable, as ranked by the recognizer.
         # @!attribute [rw] is_final
         #   @return [true, false]
-        #     Output only. If +false+, this +StreamingRecognitionResult+ represents an
-        #     interim result that may change. If +true+, this is the final time the
-        #     speech service will return this particular +StreamingRecognitionResult+,
+        #     Output only. If `false`, this `StreamingRecognitionResult` represents an
+        #     interim result that may change. If `true`, this is the final time the
+        #     speech service will return this particular `StreamingRecognitionResult`,
         #     the recognizer will not return any further hypotheses for this portion of
         #     the transcript and corresponding audio.
         # @!attribute [rw] stability
@@ -608,8 +608,8 @@ module Google
         #     Output only. An estimate of the likelihood that the recognizer will not
         #     change its guess about this interim result. Values range from 0.0
         #     (completely unstable) to 1.0 (completely stable).
-        #     This field is only provided for interim results (+is_final=false+).
-        #     The default of 0.0 is a sentinel value indicating +stability+ was not set.
+        #     This field is only provided for interim results (`is_final=false`).
+        #     The default of 0.0 is a sentinel value indicating `stability` was not set.
         # @!attribute [rw] channel_tag
         #   @return [Integer]
         #     For multi-channel audio, this is the channel number corresponding to the
@@ -627,7 +627,7 @@ module Google
         # @!attribute [rw] alternatives
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::SpeechRecognitionAlternative>]
         #     Output only. May contain one or more recognition hypotheses (up to the
-        #     maximum specified in +max_alternatives+).
+        #     maximum specified in `max_alternatives`).
         #     These alternatives are ordered in terms of accuracy, with the top (first)
         #     alternative being the most probable, as ranked by the recognizer.
         # @!attribute [rw] channel_tag
@@ -652,10 +652,10 @@ module Google
         #     Output only. The confidence estimate between 0.0 and 1.0. A higher number
         #     indicates an estimated greater likelihood that the recognized words are
         #     correct. This field is set only for the top alternative of a non-streaming
-        #     result or, of a streaming result where +is_final=true+.
+        #     result or, of a streaming result where `is_final=true`.
         #     This field is not guaranteed to be accurate and users should not rely on it
         #     to be always provided.
-        #     The default of 0.0 is a sentinel value indicating +confidence+ was not set.
+        #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] words
         #   @return [Array<Google::Cloud::Speech::V1p1beta1::WordInfo>]
         #     Output only. A list of word-specific information for each recognized word.
@@ -668,7 +668,7 @@ module Google
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
         #     and corresponding to the start of the spoken word.
-        #     This field is only set if +enable_word_time_offsets=true+ and only
+        #     This field is only set if `enable_word_time_offsets=true` and only
         #     in the top hypothesis.
         #     This is an experimental feature and the accuracy of the time offset can
         #     vary.
@@ -676,7 +676,7 @@ module Google
         #   @return [Google::Protobuf::Duration]
         #     Output only. Time offset relative to the beginning of the audio,
         #     and corresponding to the end of the spoken word.
-        #     This field is only set if +enable_word_time_offsets=true+ and only
+        #     This field is only set if `enable_word_time_offsets=true` and only
         #     in the top hypothesis.
         #     This is an experimental feature and the accuracy of the time offset can
         #     vary.
@@ -688,10 +688,10 @@ module Google
         #     Output only. The confidence estimate between 0.0 and 1.0. A higher number
         #     indicates an estimated greater likelihood that the recognized words are
         #     correct. This field is set only for the top alternative of a non-streaming
-        #     result or, of a streaming result where +is_final=true+.
+        #     result or, of a streaming result where `is_final=true`.
         #     This field is not guaranteed to be accurate and users should not rely on it
         #     to be always provided.
-        #     The default of 0.0 is a sentinel value indicating +confidence+ was not set.
+        #     The default of 0.0 is a sentinel value indicating `confidence` was not set.
         # @!attribute [rw] speaker_tag
         #   @return [Integer]
         #     Output only. A distinct integer value is assigned for every speaker within

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/longrunning/operations.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/protobuf/duration.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
+++ b/google-cloud-speech/lib/google/cloud/speech/v1p1beta1/speech_client.rb
@@ -246,8 +246,8 @@ module Google
 
           # Performs asynchronous speech recognition: receive results via the
           # google.longrunning.Operations interface. Returns either an
-          # +Operation.error+ or an +Operation.response+ which contains
-          # a +LongRunningRecognizeResponse+ message.
+          # `Operation.error` or an `Operation.response` which contains
+          # a `LongRunningRecognizeResponse` message.
           #
           # @param config [Google::Cloud::Speech::V1p1beta1::RecognitionConfig | Hash]
           #   *Required* Provides information to the recognizer that specifies how to

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/cloud_tasks_client.rb
@@ -419,11 +419,11 @@ module Google
           #   Required.
           #
           #   The location name.
-          #   For example: +projects/PROJECT_ID/locations/LOCATION_ID+
+          #   For example: `projects/PROJECT_ID/locations/LOCATION_ID`
           # @param filter [String]
-          #   +filter+ can be used to specify a subset of queues. Any {Google::Cloud::Tasks::V2beta2::Queue Queue}
+          #   `filter` can be used to specify a subset of queues. Any {Google::Cloud::Tasks::V2beta2::Queue Queue}
           #   field can be used as a filter and several operators as supported.
-          #   For example: +<=, <, >=, >, !=, =, :+. The filter syntax is the same as
+          #   For example: `<=, <, >=, >, !=, =, :`. The filter syntax is the same as
           #   described in
           #   [Stackdriver's Advanced Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
           #
@@ -489,7 +489,7 @@ module Google
           #   Required.
           #
           #   The resource name of the queue. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -523,7 +523,7 @@ module Google
           # it was dispatched or not.
           #
           # WARNING: Using this method may have unintended side effects if you are
-          # using an App Engine +queue.yaml+ or +queue.xml+ file to manage your queues.
+          # using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
           # Read
           # [Overview of Queue Management and queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml)
           # before using this method.
@@ -532,7 +532,7 @@ module Google
           #   Required.
           #
           #   The location name in which the queue will be created.
-          #   For example: +projects/PROJECT_ID/locations/LOCATION_ID+
+          #   For example: `projects/PROJECT_ID/locations/LOCATION_ID`
           #
           #   The list of allowed locations can be obtained by calling Cloud
           #   Tasks' implementation of
@@ -559,7 +559,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_parent = Google::Cloud::Tasks::V2beta2::CloudTasksClient.location_path("[PROJECT]", "[LOCATION]")
           #
-          #   # TODO: Initialize +queue+:
+          #   # TODO: Initialize `queue`:
           #   queue = {}
           #   response = cloud_tasks_client.create_queue(formatted_parent, queue)
 
@@ -586,7 +586,7 @@ module Google
           # it was dispatched or not.
           #
           # WARNING: Using this method may have unintended side effects if you are
-          # using an App Engine +queue.yaml+ or +queue.xml+ file to manage your queues.
+          # using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
           # Read
           # [Overview of Queue Management and queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml)
           # before using this method.
@@ -622,7 +622,7 @@ module Google
           #
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #
-          #   # TODO: Initialize +queue+:
+          #   # TODO: Initialize `queue`:
           #   queue = {}
           #   response = cloud_tasks_client.update_queue(queue)
 
@@ -647,7 +647,7 @@ module Google
           # for 7 days.
           #
           # WARNING: Using this method may have unintended side effects if you are
-          # using an App Engine +queue.yaml+ or +queue.xml+ file to manage your queues.
+          # using an App Engine `queue.yaml` or `queue.xml` file to manage your queues.
           # Read
           # [Overview of Queue Management and queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml)
           # before using this method.
@@ -656,7 +656,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -694,7 +694,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -733,7 +733,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -777,7 +777,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -812,12 +812,12 @@ module Google
           # [Google IAM](https://cloud.google.com/iam) permission on the specified
           # resource parent:
           #
-          # * +cloudtasks.queues.getIamPolicy+
+          # * `cloudtasks.queues.getIamPolicy`
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -854,14 +854,14 @@ module Google
           # [Google IAM](https://cloud.google.com/iam) permission on the specified
           # resource parent:
           #
-          # * +cloudtasks.queues.setIamPolicy+
+          # * `cloudtasks.queues.setIamPolicy`
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy is being specified.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param policy [Google::Iam::V1::Policy | Hash]
-          #   REQUIRED: The complete policy to be applied to the +resource+. The size of
+          #   REQUIRED: The complete policy to be applied to the `resource`. The size of
           #   the policy is limited to a few 10s of KB. An empty policy is a
           #   valid policy but certain Cloud Platform services (such as Projects)
           #   might reject them.
@@ -881,7 +881,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_resource = Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path("[PROJECT]", "[LOCATION]", "[QUEUE]")
           #
-          #   # TODO: Initialize +policy+:
+          #   # TODO: Initialize `policy`:
           #   policy = {}
           #   response = cloud_tasks_client.set_iam_policy(formatted_resource, policy)
 
@@ -908,10 +908,10 @@ module Google
           #
           # @param resource [String]
           #   REQUIRED: The resource for which the policy detail is being requested.
-          #   +resource+ is usually specified as a path. For example, a Project
-          #   resource is specified as +projects/\\{project}+.
+          #   `resource` is usually specified as a path. For example, a Project
+          #   resource is specified as `projects/{project}`.
           # @param permissions [Array<String>]
-          #   The set of permissions to check for the +resource+. Permissions with
+          #   The set of permissions to check for the `resource`. Permissions with
           #   wildcards (such as '*' or 'storage.*') are not allowed. For more
           #   information see
           #   [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
@@ -929,7 +929,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_resource = Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path("[PROJECT]", "[LOCATION]", "[QUEUE]")
           #
-          #   # TODO: Initialize +permissions+:
+          #   # TODO: Initialize `permissions`:
           #   permissions = []
           #   response = cloud_tasks_client.test_iam_permissions(formatted_resource, permissions)
 
@@ -960,7 +960,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
           # @param response_view [Google::Cloud::Tasks::V2beta2::Task::View]
           #   The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
           #   returned.
@@ -972,7 +972,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param page_size [Integer]
           #   The maximum number of resources contained in the underlying API
@@ -1032,7 +1032,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param response_view [Google::Cloud::Tasks::V2beta2::Task::View]
           #   The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
           #   returned.
@@ -1044,7 +1044,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1086,7 +1086,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
           #
           #   The queue must already exist.
           # @param task [Google::Cloud::Tasks::V2beta2::Task | Hash]
@@ -1095,7 +1095,7 @@ module Google
           #   The task to add.
           #
           #   Task names have the following format:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+.
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
           #   The user can optionally specify a task {Google::Cloud::Tasks::V2beta2::Task#name name}. If a
           #   name is not specified then the system will generate a random
           #   unique task id, which will be set in the task returned in the
@@ -1138,7 +1138,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1154,7 +1154,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_parent = Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path("[PROJECT]", "[LOCATION]", "[QUEUE]")
           #
-          #   # TODO: Initialize +task+:
+          #   # TODO: Initialize `task`:
           #   task = {}
           #   response = cloud_tasks_client.create_task(formatted_parent, task)
 
@@ -1183,7 +1183,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -1237,7 +1237,7 @@ module Google
           #   Required.
           #
           #   The queue name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
           # @param lease_duration [Google::Protobuf::Duration | Hash]
           #   After the worker has successfully finished the work associated
           #   with the task, the worker must call via
@@ -1247,16 +1247,16 @@ module Google
           #   that another worker can retry it.
           #
           #   The maximum lease duration is 1 week.
-          #   +lease_duration+ will be truncated to the nearest second.
+          #   `lease_duration` will be truncated to the nearest second.
           #   A hash of the same form as `Google::Protobuf::Duration`
           #   can also be provided.
           # @param max_tasks [Integer]
           #   The maximum number of tasks to lease.
           #
           #   The system will make a best effort to return as close to as
-          #   +max_tasks+ as possible.
+          #   `max_tasks` as possible.
           #
-          #   The largest that +max_tasks+ can be is 1000.
+          #   The largest that `max_tasks` can be is 1000.
           # @param response_view [Google::Cloud::Tasks::V2beta2::Task::View]
           #   The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
           #   returned.
@@ -1268,29 +1268,29 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param filter [String]
-          #   +filter+ can be used to specify a subset of tasks to lease.
+          #   `filter` can be used to specify a subset of tasks to lease.
           #
-          #   When +filter+ is set to +tag=<my-tag>+ then the
+          #   When `filter` is set to `tag=<my-tag>` then the
           #   {Google::Cloud::Tasks::V2beta2::LeaseTasksResponse response} will contain only tasks whose
-          #   {Google::Cloud::Tasks::V2beta2::PullMessage#tag tag} is equal to +<my-tag>+. +<my-tag>+ must be
+          #   {Google::Cloud::Tasks::V2beta2::PullMessage#tag tag} is equal to `<my-tag>`. `<my-tag>` must be
           #   less than 500 characters.
           #
-          #   When +filter+ is set to +tag_function=oldest_tag()+, only tasks which have
+          #   When `filter` is set to `tag_function=oldest_tag()`, only tasks which have
           #   the same tag as the task with the oldest
           #   {Google::Cloud::Tasks::V2beta2::Task#schedule_time schedule_time} will be returned.
           #
           #   Grammar Syntax:
           #
-          #   * +filter = "tag=" tag | "tag_function=" function+
+          #   * `filter = "tag=" tag | "tag_function=" function`
           #
-          #   * +tag = string+
+          #   * `tag = string`
           #
-          #   * +function = "oldest_tag()"+
+          #   * `function = "oldest_tag()"`
           #
-          #   The +oldest_tag()+ function returns tasks which have the same tag as the
+          #   The `oldest_tag()` function returns tasks which have the same tag as the
           #   oldest task (ordered by schedule time).
           #
           #   SDK compatibility: Although the SDK allows tags to be either
@@ -1314,7 +1314,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_parent = Google::Cloud::Tasks::V2beta2::CloudTasksClient.queue_path("[PROJECT]", "[LOCATION]", "[QUEUE]")
           #
-          #   # TODO: Initialize +lease_duration+:
+          #   # TODO: Initialize `lease_duration`:
           #   lease_duration = {}
           #   response = cloud_tasks_client.lease_tasks(formatted_parent, lease_duration)
 
@@ -1355,7 +1355,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param schedule_time [Google::Protobuf::Timestamp | Hash]
           #   Required.
           #
@@ -1379,7 +1379,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_name = Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path("[PROJECT]", "[LOCATION]", "[QUEUE]", "[TASK]")
           #
-          #   # TODO: Initialize +schedule_time+:
+          #   # TODO: Initialize `schedule_time`:
           #   schedule_time = {}
           #   cloud_tasks_client.acknowledge_task(formatted_name, schedule_time)
 
@@ -1407,7 +1407,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param schedule_time [Google::Protobuf::Timestamp | Hash]
           #   Required.
           #
@@ -1425,7 +1425,7 @@ module Google
           #
           #
           #   The maximum lease duration is 1 week.
-          #   +lease_duration+ will be truncated to the nearest second.
+          #   `lease_duration` will be truncated to the nearest second.
           #   A hash of the same form as `Google::Protobuf::Duration`
           #   can also be provided.
           # @param response_view [Google::Cloud::Tasks::V2beta2::Task::View]
@@ -1439,7 +1439,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1455,10 +1455,10 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_name = Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path("[PROJECT]", "[LOCATION]", "[QUEUE]", "[TASK]")
           #
-          #   # TODO: Initialize +schedule_time+:
+          #   # TODO: Initialize `schedule_time`:
           #   schedule_time = {}
           #
-          #   # TODO: Initialize +lease_duration+:
+          #   # TODO: Initialize `lease_duration`:
           #   lease_duration = {}
           #   response = cloud_tasks_client.renew_lease(formatted_name, schedule_time, lease_duration)
 
@@ -1490,7 +1490,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param schedule_time [Google::Protobuf::Timestamp | Hash]
           #   Required.
           #
@@ -1512,7 +1512,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
@@ -1528,7 +1528,7 @@ module Google
           #   cloud_tasks_client = Google::Cloud::Tasks.new(version: :v2beta2)
           #   formatted_name = Google::Cloud::Tasks::V2beta2::CloudTasksClient.task_path("[PROJECT]", "[LOCATION]", "[QUEUE]", "[TASK]")
           #
-          #   # TODO: Initialize +schedule_time+:
+          #   # TODO: Initialize `schedule_time`:
           #   schedule_time = {}
           #   response = cloud_tasks_client.cancel_lease(formatted_name, schedule_time)
 
@@ -1579,7 +1579,7 @@ module Google
           #   Required.
           #
           #   The task name. For example:
-          #   +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+          #   `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
           # @param response_view [Google::Cloud::Tasks::V2beta2::Task::View]
           #   The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
           #   returned.
@@ -1591,7 +1591,7 @@ module Google
           #   contains.
           #
           #   Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-          #   +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+          #   `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
           #   permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/cloudtasks.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/cloudtasks.rb
@@ -23,12 +23,12 @@ module Google
         #     Required.
         #
         #     The location name.
-        #     For example: +projects/PROJECT_ID/locations/LOCATION_ID+
+        #     For example: `projects/PROJECT_ID/locations/LOCATION_ID`
         # @!attribute [rw] filter
         #   @return [String]
-        #     +filter+ can be used to specify a subset of queues. Any {Google::Cloud::Tasks::V2beta2::Queue Queue}
+        #     `filter` can be used to specify a subset of queues. Any {Google::Cloud::Tasks::V2beta2::Queue Queue}
         #     field can be used as a filter and several operators as supported.
-        #     For example: +<=, <, >=, >, !=, =, :+. The filter syntax is the same as
+        #     For example: `<=, <, >=, >, !=, =, :`. The filter syntax is the same as
         #     described in
         #     [Stackdriver's Advanced Logs Filters](https://cloud.google.com/logging/docs/view/advanced_filters).
         #
@@ -80,7 +80,7 @@ module Google
         #     Required.
         #
         #     The resource name of the queue. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         class GetQueueRequest; end
 
         # Request message for {Google::Cloud::Tasks::V2beta2::CloudTasks::CreateQueue CreateQueue}.
@@ -89,7 +89,7 @@ module Google
         #     Required.
         #
         #     The location name in which the queue will be created.
-        #     For example: +projects/PROJECT_ID/locations/LOCATION_ID+
+        #     For example: `projects/PROJECT_ID/locations/LOCATION_ID`
         #
         #     The list of allowed locations can be obtained by calling Cloud
         #     Tasks' implementation of
@@ -128,7 +128,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         class DeleteQueueRequest; end
 
         # Request message for {Google::Cloud::Tasks::V2beta2::CloudTasks::PurgeQueue PurgeQueue}.
@@ -137,7 +137,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
         class PurgeQueueRequest; end
 
         # Request message for {Google::Cloud::Tasks::V2beta2::CloudTasks::PauseQueue PauseQueue}.
@@ -146,7 +146,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
         class PauseQueueRequest; end
 
         # Request message for {Google::Cloud::Tasks::V2beta2::CloudTasks::ResumeQueue ResumeQueue}.
@@ -155,7 +155,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
         class ResumeQueueRequest; end
 
         # Request message for listing tasks using {Google::Cloud::Tasks::V2beta2::CloudTasks::ListTasks ListTasks}.
@@ -164,7 +164,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         # @!attribute [rw] response_view
         #   @return [Google::Cloud::Tasks::V2beta2::Task::View]
         #     The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
@@ -177,7 +177,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         # @!attribute [rw] page_size
         #   @return [Integer]
@@ -222,7 +222,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         # @!attribute [rw] response_view
         #   @return [Google::Cloud::Tasks::V2beta2::Task::View]
         #     The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
@@ -235,7 +235,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         class GetTaskRequest; end
 
@@ -245,7 +245,7 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         #
         #     The queue must already exist.
         # @!attribute [rw] task
@@ -255,7 +255,7 @@ module Google
         #     The task to add.
         #
         #     Task names have the following format:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+.
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.
         #     The user can optionally specify a task {Google::Cloud::Tasks::V2beta2::Task#name name}. If a
         #     name is not specified then the system will generate a random
         #     unique task id, which will be set in the task returned in the
@@ -297,7 +297,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         class CreateTaskRequest; end
 
@@ -308,7 +308,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         class DeleteTaskRequest; end
 
         # Request message for leasing tasks using {Google::Cloud::Tasks::V2beta2::CloudTasks::LeaseTasks LeaseTasks}.
@@ -317,15 +317,15 @@ module Google
         #     Required.
         #
         #     The queue name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         # @!attribute [rw] max_tasks
         #   @return [Integer]
         #     The maximum number of tasks to lease.
         #
         #     The system will make a best effort to return as close to as
-        #     +max_tasks+ as possible.
+        #     `max_tasks` as possible.
         #
-        #     The largest that +max_tasks+ can be is 1000.
+        #     The largest that `max_tasks` can be is 1000.
         # @!attribute [rw] lease_duration
         #   @return [Google::Protobuf::Duration]
         #     After the worker has successfully finished the work associated
@@ -336,7 +336,7 @@ module Google
         #     that another worker can retry it.
         #
         #     The maximum lease duration is 1 week.
-        #     +lease_duration+ will be truncated to the nearest second.
+        #     `lease_duration` will be truncated to the nearest second.
         # @!attribute [rw] response_view
         #   @return [Google::Cloud::Tasks::V2beta2::Task::View]
         #     The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
@@ -349,30 +349,30 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         # @!attribute [rw] filter
         #   @return [String]
-        #     +filter+ can be used to specify a subset of tasks to lease.
+        #     `filter` can be used to specify a subset of tasks to lease.
         #
-        #     When +filter+ is set to +tag=<my-tag>+ then the
+        #     When `filter` is set to `tag=<my-tag>` then the
         #     {Google::Cloud::Tasks::V2beta2::LeaseTasksResponse response} will contain only tasks whose
-        #     {Google::Cloud::Tasks::V2beta2::PullMessage#tag tag} is equal to +<my-tag>+. +<my-tag>+ must be
+        #     {Google::Cloud::Tasks::V2beta2::PullMessage#tag tag} is equal to `<my-tag>`. `<my-tag>` must be
         #     less than 500 characters.
         #
-        #     When +filter+ is set to +tag_function=oldest_tag()+, only tasks which have
+        #     When `filter` is set to `tag_function=oldest_tag()`, only tasks which have
         #     the same tag as the task with the oldest
         #     {Google::Cloud::Tasks::V2beta2::Task#schedule_time schedule_time} will be returned.
         #
         #     Grammar Syntax:
         #
-        #     * +filter = "tag=" tag | "tag_function=" function+
+        #     * `filter = "tag=" tag | "tag_function=" function`
         #
-        #     * +tag = string+
+        #     * `tag = string`
         #
-        #     * +function = "oldest_tag()"+
+        #     * `function = "oldest_tag()"`
         #
-        #     The +oldest_tag()+ function returns tasks which have the same tag as the
+        #     The `oldest_tag()` function returns tasks which have the same tag as the
         #     oldest task (ordered by schedule time).
         #
         #     SDK compatibility: Although the SDK allows tags to be either
@@ -397,7 +397,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         # @!attribute [rw] schedule_time
         #   @return [Google::Protobuf::Timestamp]
         #     Required.
@@ -416,7 +416,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         # @!attribute [rw] schedule_time
         #   @return [Google::Protobuf::Timestamp]
         #     Required.
@@ -434,7 +434,7 @@ module Google
         #
         #
         #     The maximum lease duration is 1 week.
-        #     +lease_duration+ will be truncated to the nearest second.
+        #     `lease_duration` will be truncated to the nearest second.
         # @!attribute [rw] response_view
         #   @return [Google::Cloud::Tasks::V2beta2::Task::View]
         #     The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
@@ -447,7 +447,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         class RenewLeaseRequest; end
 
@@ -458,7 +458,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         # @!attribute [rw] schedule_time
         #   @return [Google::Protobuf::Timestamp]
         #     Required.
@@ -480,7 +480,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         class CancelLeaseRequest; end
 
@@ -491,7 +491,7 @@ module Google
         #     Required.
         #
         #     The task name. For example:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         # @!attribute [rw] response_view
         #   @return [Google::Cloud::Tasks::V2beta2::Task::View]
         #     The response_view specifies which subset of the {Google::Cloud::Tasks::V2beta2::Task Task} will be
@@ -504,7 +504,7 @@ module Google
         #     contains.
         #
         #     Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-        #     +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+        #     `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
         #     permission on the {Google::Cloud::Tasks::V2beta2::Task Task} resource.
         class RunTaskRequest; end
       end

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/queue.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/queue.rb
@@ -28,17 +28,17 @@ module Google
         #     The queue name.
         #
         #     The queue name must have the following format:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
         #
-        #     * +PROJECT_ID+ can contain letters ([A-Za-z]), numbers ([0-9]),
+        #     * `PROJECT_ID` can contain letters ([A-Za-z]), numbers ([0-9]),
         #       hyphens (-), colons (:), or periods (.).
         #       For more information, see
         #       [Identifying projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)
-        #     * +LOCATION_ID+ is the canonical ID for the queue's location.
+        #     * `LOCATION_ID` is the canonical ID for the queue's location.
         #       The list of available locations can be obtained by calling
         #       {Google::Cloud::Location::Locations::ListLocations ListLocations}.
         #       For more information, see https://cloud.google.com/about/locations/.
-        #     * +QUEUE_ID+ can contain letters ([A-Za-z]), numbers ([0-9]), or
+        #     * `QUEUE_ID` can contain letters ([A-Za-z]), numbers ([0-9]), or
         #       hyphens (-). The maximum length is 100 characters.
         # @!attribute [rw] app_engine_http_target
         #   @return [Google::Cloud::Tasks::V2beta2::AppEngineHttpTarget]
@@ -82,11 +82,11 @@ module Google
         #   @return [Google::Cloud::Tasks::V2beta2::Queue::State]
         #     Output only. The state of the queue.
         #
-        #     +state+ can only be changed by called
+        #     `state` can only be changed by called
         #     {Google::Cloud::Tasks::V2beta2::CloudTasks::PauseQueue PauseQueue},
         #     {Google::Cloud::Tasks::V2beta2::CloudTasks::ResumeQueue ResumeQueue}, or uploading
         #     [queue.yaml/xml](https://cloud.google.com/appengine/docs/python/config/queueref).
-        #     {Google::Cloud::Tasks::V2beta2::CloudTasks::UpdateQueue UpdateQueue} cannot be used to change +state+.
+        #     {Google::Cloud::Tasks::V2beta2::CloudTasks::UpdateQueue UpdateQueue} cannot be used to change `state`.
         # @!attribute [rw] purge_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The last time this queue was purged.
@@ -124,7 +124,7 @@ module Google
 
             # The queue is disabled.
             #
-            # A queue becomes +DISABLED+ when
+            # A queue becomes `DISABLED` when
             # [queue.yaml](https://cloud.google.com/appengine/docs/python/config/queueref) or
             # [queue.xml](https://cloud.google.com/appengine/docs/standard/java/config/queueref) is uploaded
             # which does not contain the queue. You cannot directly disable a queue.
@@ -132,7 +132,7 @@ module Google
             # When a queue is disabled, tasks can still be added to a queue
             # but the tasks are not dispatched and
             # {Google::Cloud::Tasks::V2beta2::CloudTasks::LeaseTasks LeaseTasks} calls return a
-            # +FAILED_PRECONDITION+ error.
+            # `FAILED_PRECONDITION` error.
             #
             # To permanently delete this queue and all of its tasks, call
             # {Google::Cloud::Tasks::V2beta2::CloudTasks::DeleteQueue DeleteQueue}.
@@ -157,7 +157,7 @@ module Google
         #     * For {Google::Cloud::Tasks::V2beta2::AppEngineHttpTarget App Engine queues}, the maximum allowed value
         #       is 500.
         #     * This field is output only   for {Google::Cloud::Tasks::V2beta2::PullTarget pull queues}. In addition to the
-        #       +max_tasks_dispatched_per_second+ limit, a maximum of 10 QPS of
+        #       `max_tasks_dispatched_per_second` limit, a maximum of 10 QPS of
         #       {Google::Cloud::Tasks::V2beta2::CloudTasks::LeaseTasks LeaseTasks} requests are allowed per pull queue.
         #
         #
@@ -176,22 +176,22 @@ module Google
         #     The [token bucket](https://wikipedia.org/wiki/Token_Bucket)
         #     algorithm is used to control the rate of task dispatches. Each
         #     queue has a token bucket that holds tokens, up to the maximum
-        #     specified by +max_burst_size+. Each time a task is dispatched, a
+        #     specified by `max_burst_size`. Each time a task is dispatched, a
         #     token is removed from the bucket. Tasks will be dispatched until
         #     the queue's bucket runs out of tokens. The bucket will be
         #     continuously refilled with new tokens based on
         #     {Google::Cloud::Tasks::V2beta2::RateLimits#max_tasks_dispatched_per_second max_tasks_dispatched_per_second}.
         #
-        #     Cloud Tasks will pick the value of +max_burst_size+ based on the
+        #     Cloud Tasks will pick the value of `max_burst_size` based on the
         #     value of
         #     {Google::Cloud::Tasks::V2beta2::RateLimits#max_tasks_dispatched_per_second max_tasks_dispatched_per_second}.
         #
         #     For App Engine queues that were created or updated using
-        #     +queue.yaml/xml+, +max_burst_size+ is equal to
+        #     `queue.yaml/xml`, `max_burst_size` is equal to
         #     [bucket_size](https://cloud.google.com/appengine/docs/standard/python/config/queueref#bucket_size).
-        #     Since +max_burst_size+ is output only, if
+        #     Since `max_burst_size` is output only, if
         #     {Google::Cloud::Tasks::V2beta2::CloudTasks::UpdateQueue UpdateQueue} is called on a queue
-        #     created by +queue.yaml/xml+, +max_burst_size+ will be reset based
+        #     created by `queue.yaml/xml`, `max_burst_size` will be reset based
         #     on the value of
         #     {Google::Cloud::Tasks::V2beta2::RateLimits#max_tasks_dispatched_per_second max_tasks_dispatched_per_second},
         #     regardless of whether
@@ -212,7 +212,7 @@ module Google
         #
         #     This field is output only for
         #     {Google::Cloud::Tasks::V2beta2::PullTarget pull queues} and always -1, which indicates no limit. No other
-        #     queue types can have +max_concurrent_tasks+ set to -1.
+        #     queue types can have `max_concurrent_tasks` set to -1.
         #
         #
         #     This field has the same meaning as
@@ -226,17 +226,17 @@ module Google
         #   @return [Integer]
         #     The maximum number of attempts for a task.
         #
-        #     Cloud Tasks will attempt the task +max_attempts+ times (that
+        #     Cloud Tasks will attempt the task `max_attempts` times (that
         #     is, if the first attempt fails, then there will be
-        #     +max_attempts - 1+ retries).  Must be > 0.
+        #     `max_attempts - 1` retries).  Must be > 0.
         # @!attribute [rw] unlimited_attempts
         #   @return [true, false]
         #     If true, then the number of attempts is unlimited.
         # @!attribute [rw] max_retry_duration
         #   @return [Google::Protobuf::Duration]
-        #     If positive, +max_retry_duration+ specifies the time limit for
+        #     If positive, `max_retry_duration` specifies the time limit for
         #     retrying a failed task, measured from when the task was first
-        #     attempted. Once +max_retry_duration+ time has passed *and* the
+        #     attempted. Once `max_retry_duration` time has passed *and* the
         #     task has been attempted {Google::Cloud::Tasks::V2beta2::RetryConfig#max_attempts max_attempts}
         #     times, no further attempts will be made and the task will be
         #     deleted.
@@ -249,7 +249,7 @@ module Google
         #     This field is output only for {Google::Cloud::Tasks::V2beta2::PullTarget pull queues}.
         #
         #
-        #     +max_retry_duration+ will be truncated to the nearest second.
+        #     `max_retry_duration` will be truncated to the nearest second.
         #
         #     This field has the same meaning as
         #     [task_age_limit in queue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).
@@ -267,7 +267,7 @@ module Google
         #     This field is output only for {Google::Cloud::Tasks::V2beta2::PullTarget pull queues}.
         #
         #
-        #     +min_backoff+ will be truncated to the nearest second.
+        #     `min_backoff` will be truncated to the nearest second.
         #
         #     This field has the same meaning as
         #     [min_backoff_seconds in queue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).
@@ -285,24 +285,24 @@ module Google
         #     This field is output only for {Google::Cloud::Tasks::V2beta2::PullTarget pull queues}.
         #
         #
-        #     +max_backoff+ will be truncated to the nearest second.
+        #     `max_backoff` will be truncated to the nearest second.
         #
         #     This field has the same meaning as
         #     [max_backoff_seconds in queue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).
         # @!attribute [rw] max_doublings
         #   @return [Integer]
-        #     The time between retries will double +max_doublings+ times.
+        #     The time between retries will double `max_doublings` times.
         #
         #     A task's retry interval starts at
         #     {Google::Cloud::Tasks::V2beta2::RetryConfig#min_backoff min_backoff}, then doubles
-        #     +max_doublings+ times, then increases linearly, and finally
+        #     `max_doublings` times, then increases linearly, and finally
         #     retries retries at intervals of
         #     {Google::Cloud::Tasks::V2beta2::RetryConfig#max_backoff max_backoff} up to
         #     {Google::Cloud::Tasks::V2beta2::RetryConfig#max_attempts max_attempts} times.
         #
         #     For example, if {Google::Cloud::Tasks::V2beta2::RetryConfig#min_backoff min_backoff} is 10s,
         #     {Google::Cloud::Tasks::V2beta2::RetryConfig#max_backoff max_backoff} is 300s, and
-        #     +max_doublings+ is 3, then the a task will first be retried in
+        #     `max_doublings` is 3, then the a task will first be retried in
         #     10s. The retry interval will double three times, and then
         #     increase linearly by 2^3 * 10s.  Finally, the task will retry at
         #     intervals of {Google::Cloud::Tasks::V2beta2::RetryConfig#max_backoff max_backoff} until the

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/target.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/target.rb
@@ -58,17 +58,17 @@ module Google
         # task's host URL is constructed.
         #
         # Using {Google::Cloud::Tasks::V2beta2::AppEngineHttpTarget AppEngineHttpTarget} requires
-        # [+appengine.applications.get+](https://cloud.google.com/appengine/docs/admin-api/access-control)
+        # [`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)
         # Google IAM permission for the project
         # and the following scope:
         #
-        # +https://www.googleapis.com/auth/cloud-platform+
+        # `https://www.googleapis.com/auth/cloud-platform`
         # @!attribute [rw] app_engine_routing_override
         #   @return [Google::Cloud::Tasks::V2beta2::AppEngineRouting]
         #     Overrides for the
         #     {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest#app_engine_routing task-level app_engine_routing}.
         #
-        #     If set, +app_engine_routing_override+ is used for all tasks in
+        #     If set, `app_engine_routing_override` is used for all tasks in
         #     the queue, no matter what the setting is for the
         #     {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest#app_engine_routing task-level app_engine_routing}.
         class AppEngineHttpTarget; end
@@ -82,11 +82,11 @@ module Google
         # {Google::Cloud::Tasks::V2beta2::Queue#app_engine_http_target app_engine_http_target} set.
         #
         # Using {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest AppEngineHttpRequest} requires
-        # [+appengine.applications.get+](https://cloud.google.com/appengine/docs/admin-api/access-control)
+        # [`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)
         # Google IAM permission for the project
         # and the following scope:
         #
-        # +https://www.googleapis.com/auth/cloud-platform+
+        # `https://www.googleapis.com/auth/cloud-platform`
         #
         # The task will be delivered to the App Engine app which belongs to the same
         # project as the queue. For more information, see
@@ -104,15 +104,15 @@ module Google
         #   {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest#app_engine_routing task-level app_engine_routing}.
         #
         #
-        # The +url+ that the task will be sent to is:
+        # The `url` that the task will be sent to is:
         #
-        # * +url =+ {Google::Cloud::Tasks::V2beta2::AppEngineRouting#host host} +++
+        # * `url =` {Google::Cloud::Tasks::V2beta2::AppEngineRouting#host host} `+`
         #   {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest#relative_url relative_url}
         #
         # The task attempt has succeeded if the app's request handler returns
-        # an HTTP response code in the range [+200+ - +299+]. +503+ is
+        # an HTTP response code in the range [`200` - `299`]. `503` is
         # considered an App Engine system error instead of an application
-        # error. Requests returning error +503+ will be retried regardless of
+        # error. Requests returning error `503` will be retried regardless of
         # retry configuration and not counted against retry counts.
         # Any other response code or a failure to receive a response before the
         # deadline is a failed attempt.
@@ -154,28 +154,28 @@ module Google
         #
         #     Cloud Tasks sets some headers to default values:
         #
-        #     * +User-Agent+: By default, this header is
-        #       +"AppEngine-Google; (+http://code.google.com/appengine)"+.
+        #     * `User-Agent`: By default, this header is
+        #       `"AppEngine-Google; (+http://code.google.com/appengine)"`.
         #       This header can be modified, but Cloud Tasks will append
-        #       +"AppEngine-Google; (+http://code.google.com/appengine)"+ to the
-        #       modified +User-Agent+.
+        #       `"AppEngine-Google; (+http://code.google.com/appengine)"` to the
+        #       modified `User-Agent`.
         #
         #     If the task has a {Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest#payload payload}, Cloud
         #     Tasks sets the following headers:
         #
-        #     * +Content-Type+: By default, the +Content-Type+ header is set to
-        #       +"application/octet-stream"+. The default can be overridden by explicitly
-        #       setting +Content-Type+ to a particular media type when the
+        #     * `Content-Type`: By default, the `Content-Type` header is set to
+        #       `"application/octet-stream"`. The default can be overridden by explicitly
+        #       setting `Content-Type` to a particular media type when the
         #       {Google::Cloud::Tasks::V2beta2::CloudTasks::CreateTask task is created}.
-        #       For example, +Content-Type+ can be set to +"application/json"+.
-        #     * +Content-Length+: This is computed by Cloud Tasks. This value is
+        #       For example, `Content-Type` can be set to `"application/json"`.
+        #     * `Content-Length`: This is computed by Cloud Tasks. This value is
         #       output only.   It cannot be changed.
         #
         #     The headers below cannot be set or overridden:
         #
-        #     * +Host+
-        #     * +X-Google-*+
-        #     * +X-AppEngine-*+
+        #     * `Host`
+        #     * `X-Google-*`
+        #     * `X-AppEngine-*`
         #
         #     In addition, Cloud Tasks sets some headers when the task is dispatched,
         #     such as headers containing information about the task; see
@@ -261,41 +261,41 @@ module Google
         #     The host is constructed as:
         #
         #
-        #     * +host = [application_domain_name]+</br>
-        #       +| [service] + '.' + [application_domain_name]+</br>
-        #       +| [version] + '.' + [application_domain_name]+</br>
-        #       +| [version_dot_service]+ '.' + [application_domain_name]+</br>
-        #       +| [instance] + '.' + [application_domain_name]+</br>
-        #       +| [instance_dot_service] + '.' + [application_domain_name]+</br>
-        #       +| [instance_dot_version] + '.' + [application_domain_name]+</br>
-        #       +| [instance_dot_version_dot_service] + '.' + [application_domain_name]+
+        #     * `host = [application_domain_name]`</br>
+        #       `| [service] + '.' + [application_domain_name]`</br>
+        #       `| [version] + '.' + [application_domain_name]`</br>
+        #       `| [version_dot_service]+ '.' + [application_domain_name]`</br>
+        #       `| [instance] + '.' + [application_domain_name]`</br>
+        #       `| [instance_dot_service] + '.' + [application_domain_name]`</br>
+        #       `| [instance_dot_version] + '.' + [application_domain_name]`</br>
+        #       `| [instance_dot_version_dot_service] + '.' + [application_domain_name]`
         #
-        #     * +application_domain_name+ = The domain name of the app, for
+        #     * `application_domain_name` = The domain name of the app, for
         #       example <app-id>.appspot.com, which is associated with the
         #       queue's project ID. Some tasks which were created using the App Engine
         #       SDK use a custom domain name.
         #
-        #     * +service =+ {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service}
+        #     * `service =` {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service}
         #
-        #     * +version =+ {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version}
+        #     * `version =` {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version}
         #
-        #     * +version_dot_service =+
-        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version} ++ '.' ++
+        #     * `version_dot_service =`
+        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version} `+ '.' +`
         #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service}
         #
-        #     * +instance =+ {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance}
+        #     * `instance =` {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance}
         #
-        #     * +instance_dot_service =+
-        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} ++ '.' ++
+        #     * `instance_dot_service =`
+        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} `+ '.' +`
         #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service}
         #
-        #     * +instance_dot_version =+
-        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} ++ '.' ++
+        #     * `instance_dot_version =`
+        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} `+ '.' +`
         #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version}
         #
-        #     * +instance_dot_version_dot_service =+
-        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} ++ '.' ++
-        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version} ++ '.' ++
+        #     * `instance_dot_version_dot_service =`
+        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#instance instance} `+ '.' +`
+        #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#version version} `+ '.' +`
         #       {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service}
         #
         #     If {Google::Cloud::Tasks::V2beta2::AppEngineRouting#service service} is empty, then the task will be sent

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/task.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/cloud/tasks/v2beta2/task.rb
@@ -25,19 +25,19 @@ module Google
         #     The task name.
         #
         #     The task name must have the following format:
-        #     +projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID+
+        #     `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
         #
-        #     * +PROJECT_ID+ can contain letters ([A-Za-z]), numbers ([0-9]),
+        #     * `PROJECT_ID` can contain letters ([A-Za-z]), numbers ([0-9]),
         #       hyphens (-), colons (:), or periods (.).
         #       For more information, see
         #       [Identifying projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)
-        #     * +LOCATION_ID+ is the canonical ID for the task's location.
+        #     * `LOCATION_ID` is the canonical ID for the task's location.
         #       The list of available locations can be obtained by calling
         #       {Google::Cloud::Location::Locations::ListLocations ListLocations}.
         #       For more information, see https://cloud.google.com/about/locations/.
-        #     * +QUEUE_ID+ can contain letters ([A-Za-z]), numbers ([0-9]), or
+        #     * `QUEUE_ID` can contain letters ([A-Za-z]), numbers ([0-9]), or
         #       hyphens (-). The maximum length is 100 characters.
-        #     * +TASK_ID+ can contain only letters ([A-Za-z]), numbers ([0-9]),
+        #     * `TASK_ID` can contain only letters ([A-Za-z]), numbers ([0-9]),
         #       hyphens (-), or underscores (_). The maximum length is 500 characters.
         # @!attribute [rw] app_engine_http_request
         #   @return [Google::Cloud::Tasks::V2beta2::AppEngineHttpRequest]
@@ -64,12 +64,12 @@ module Google
         #     the current lease expires, that is, the time that the task was
         #     leased plus the {Google::Cloud::Tasks::V2beta2::LeaseTasksRequest#lease_duration lease_duration}.
         #
-        #     +schedule_time+ will be truncated to the nearest microsecond.
+        #     `schedule_time` will be truncated to the nearest microsecond.
         # @!attribute [rw] create_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time that the task was created.
         #
-        #     +create_time+ will be truncated to the nearest second.
+        #     `create_time` will be truncated to the nearest second.
         # @!attribute [rw] status
         #   @return [Google::Cloud::Tasks::V2beta2::TaskStatus]
         #     Output only. The task status.
@@ -103,7 +103,7 @@ module Google
             # All information is returned.
             #
             # Authorization for {Google::Cloud::Tasks::V2beta2::Task::View::FULL FULL} requires
-            # +cloudtasks.tasks.fullView+ [Google IAM](https://cloud.google.com/iam/)
+            # `cloudtasks.tasks.fullView` [Google IAM](https://cloud.google.com/iam/)
             # permission on the {Google::Cloud::Tasks::V2beta2::Queue Queue} resource.
             FULL = 2
           end
@@ -141,17 +141,17 @@ module Google
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time that this attempt was scheduled.
         #
-        #     +schedule_time+ will be truncated to the nearest microsecond.
+        #     `schedule_time` will be truncated to the nearest microsecond.
         # @!attribute [rw] dispatch_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time that this attempt was dispatched.
         #
-        #     +dispatch_time+ will be truncated to the nearest microsecond.
+        #     `dispatch_time` will be truncated to the nearest microsecond.
         # @!attribute [rw] response_time
         #   @return [Google::Protobuf::Timestamp]
         #     Output only. The time that this attempt response was received.
         #
-        #     +response_time+ will be truncated to the nearest microsecond.
+        #     `response_time` will be truncated to the nearest microsecond.
         # @!attribute [rw] response_status
         #   @return [Google::Rpc::Status]
         #     Output only. The response from the target for this attempt.

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/iam_policy.rb
@@ -16,46 +16,46 @@
 module Google
   module Iam
     module V1
-      # Request message for +SetIamPolicy+ method.
+      # Request message for `SetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being specified.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] policy
       #   @return [Google::Iam::V1::Policy]
-      #     REQUIRED: The complete policy to be applied to the +resource+. The size of
+      #     REQUIRED: The complete policy to be applied to the `resource`. The size of
       #     the policy is limited to a few 10s of KB. An empty policy is a
       #     valid policy but certain Cloud Platform services (such as Projects)
       #     might reject them.
       class SetIamPolicyRequest; end
 
-      # Request message for +GetIamPolicy+ method.
+      # Request message for `GetIamPolicy` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       class GetIamPolicyRequest; end
 
-      # Request message for +TestIamPermissions+ method.
+      # Request message for `TestIamPermissions` method.
       # @!attribute [rw] resource
       #   @return [String]
       #     REQUIRED: The resource for which the policy detail is being requested.
-      #     +resource+ is usually specified as a path. For example, a Project
-      #     resource is specified as +projects/\\{project}+.
+      #     `resource` is usually specified as a path. For example, a Project
+      #     resource is specified as `projects/{project}`.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     The set of permissions to check for the +resource+. Permissions with
+      #     The set of permissions to check for the `resource`. Permissions with
       #     wildcards (such as '*' or 'storage.*') are not allowed. For more
       #     information see
       #     [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
       class TestIamPermissionsRequest; end
 
-      # Response message for +TestIamPermissions+ method.
+      # Response message for `TestIamPermissions` method.
       # @!attribute [rw] permissions
       #   @return [Array<String>]
-      #     A subset of +TestPermissionsRequest.permissions+ that the caller is
+      #     A subset of `TestPermissionsRequest.permissions` that the caller is
       #     allowed.
       class TestIamPermissionsResponse; end
     end

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/policy.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/iam/v1/policy.rb
@@ -20,9 +20,9 @@ module Google
       # specify access control policies for Cloud Platform resources.
       #
       #
-      # A +Policy+ consists of a list of +bindings+. A +Binding+ binds a list of
-      # +members+ to a +role+, where the members can be user accounts, Google groups,
-      # Google domains, and service accounts. A +role+ is a named list of permissions
+      # A `Policy` consists of a list of `bindings`. A `Binding` binds a list of
+      # `members` to a `role`, where the members can be user accounts, Google groups,
+      # Google domains, and service accounts. A `role` is a named list of permissions
       # defined by IAM.
       #
       # **Example**
@@ -49,55 +49,55 @@ module Google
       # [IAM developer's guide](https://cloud.google.com/iam).
       # @!attribute [rw] version
       #   @return [Integer]
-      #     Version of the +Policy+. The default version is 0.
+      #     Version of the `Policy`. The default version is 0.
       # @!attribute [rw] bindings
       #   @return [Array<Google::Iam::V1::Binding>]
-      #     Associates a list of +members+ to a +role+.
-      #     Multiple +bindings+ must not be specified for the same +role+.
-      #     +bindings+ with no members will result in an error.
+      #     Associates a list of `members` to a `role`.
+      #     Multiple `bindings` must not be specified for the same `role`.
+      #     `bindings` with no members will result in an error.
       # @!attribute [rw] etag
       #   @return [String]
-      #     +etag+ is used for optimistic concurrency control as a way to help
+      #     `etag` is used for optimistic concurrency control as a way to help
       #     prevent simultaneous updates of a policy from overwriting each other.
-      #     It is strongly suggested that systems make use of the +etag+ in the
+      #     It is strongly suggested that systems make use of the `etag` in the
       #     read-modify-write cycle to perform policy updates in order to avoid race
-      #     conditions: An +etag+ is returned in the response to +getIamPolicy+, and
-      #     systems are expected to put that etag in the request to +setIamPolicy+ to
+      #     conditions: An `etag` is returned in the response to `getIamPolicy`, and
+      #     systems are expected to put that etag in the request to `setIamPolicy` to
       #     ensure that their change will be applied to the same version of the policy.
       #
-      #     If no +etag+ is provided in the call to +setIamPolicy+, then the existing
+      #     If no `etag` is provided in the call to `setIamPolicy`, then the existing
       #     policy is overwritten blindly.
       class Policy; end
 
-      # Associates +members+ with a +role+.
+      # Associates `members` with a `role`.
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] members
       #   @return [Array<String>]
       #     Specifies the identities requesting access for a Cloud Platform resource.
-      #     +members+ can have the following values:
+      #     `members` can have the following values:
       #
-      #     * +allUsers+: A special identifier that represents anyone who is
+      #     * `allUsers`: A special identifier that represents anyone who is
       #       on the internet; with or without a Google account.
       #
-      #     * +allAuthenticatedUsers+: A special identifier that represents anyone
+      #     * `allAuthenticatedUsers`: A special identifier that represents anyone
       #       who is authenticated with a Google account or a service account.
       #
-      #     * +user:\\{emailid}+: An email address that represents a specific Google
-      #       account. For example, +alice@gmail.com+ or +joe@example.com+.
+      #     * `user:{emailid}`: An email address that represents a specific Google
+      #       account. For example, `alice@gmail.com` or `joe@example.com`.
       #
       #
-      #     * +serviceAccount:\\{emailid}+: An email address that represents a service
-      #       account. For example, +my-other-app@appspot.gserviceaccount.com+.
+      #     * `serviceAccount:{emailid}`: An email address that represents a service
+      #       account. For example, `my-other-app@appspot.gserviceaccount.com`.
       #
-      #     * +group:\\{emailid}+: An email address that represents a Google group.
-      #       For example, +admins@example.com+.
+      #     * `group:{emailid}`: An email address that represents a Google group.
+      #       For example, `admins@example.com`.
       #
-      #     * +domain:\\{domain}+: A Google Apps domain name that represents all the
-      #       users of that domain. For example, +google.com+ or +example.com+.
+      #     * `domain:{domain}`: A Google Apps domain name that represents all the
+      #       users of that domain. For example, `google.com` or `example.com`.
       class Binding; end
 
       # The difference delta between two policies.
@@ -114,8 +114,8 @@ module Google
       #     Required
       # @!attribute [rw] role
       #   @return [String]
-      #     Role that is assigned to +members+.
-      #     For example, +roles/viewer+, +roles/editor+, or +roles/owner+.
+      #     Role that is assigned to `members`.
+      #     For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
       #     Required
       # @!attribute [rw] member
       #   @return [String]

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/any.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/duration.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/empty.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/field_mask.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/field_mask.rb
@@ -15,14 +15,14 @@
 
 module Google
   module Protobuf
-    # +FieldMask+ represents a set of symbolic field paths, for example:
+    # `FieldMask` represents a set of symbolic field paths, for example:
     #
     #     paths: "f.a"
     #     paths: "f.b.d"
     #
-    # Here +f+ represents a field in some root message, +a+ and +b+
-    # fields in the message found in +f+, and +d+ a field found in the
-    # message in +f.b+.
+    # Here `f` represents a field in some root message, `a` and `b`
+    # fields in the message found in `f`, and `d` a field found in the
+    # message in `f.b`.
     #
     # Field masks are used to specify a subset of fields that should be
     # returned by a get operation or modified by an update operation.
@@ -85,7 +85,7 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a +paths+
+    # Note that a repeated field is only allowed in the last position of a `paths`
     # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
@@ -177,7 +177,7 @@ module Google
     #       string address = 2;
     #     }
     #
-    # In proto a field mask for +Profile+ may look as such:
+    # In proto a field mask for `Profile` may look as such:
     #
     #     mask {
     #       paths: "user.display_name"
@@ -221,7 +221,7 @@ module Google
     #
     # The implementation of any API method which has a FieldMask type field in the
     # request should verify the included field paths, and return an
-    # +INVALID_ARGUMENT+ error if any path is duplicated or unmappable.
+    # `INVALID_ARGUMENT` error if any path is duplicated or unmappable.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/rpc/status.rb
+++ b/google-cloud-tasks/lib/google/cloud/tasks/v2beta2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-tasks/synth.py
+++ b/google-cloud-tasks/synth.py
@@ -45,10 +45,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/doc/google/cloud/texttospeech/v1/cloud_tts.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/doc/google/cloud/texttospeech/v1/cloud_tts.rb
@@ -17,7 +17,7 @@ module Google
   module Cloud
     module Texttospeech
       module V1
-        # The top-level message sent by the client for the +ListVoices+ method.
+        # The top-level message sent by the client for the `ListVoices` method.
         # @!attribute [rw] language_code
         #   @return [String]
         #     Optional (but recommended)
@@ -30,7 +30,7 @@ module Google
         #     supported "yue-*" voices.
         class ListVoicesRequest; end
 
-        # The message returned to the client by the +ListVoices+ method.
+        # The message returned to the client by the `ListVoices` method.
         # @!attribute [rw] voices
         #   @return [Array<Google::Cloud::Texttospeech::V1::Voice>]
         #     The list of voices.
@@ -53,7 +53,7 @@ module Google
         #     The natural sample rate (in hertz) for this voice.
         class Voice; end
 
-        # The top-level message sent by the client for the +SynthesizeSpeech+ method.
+        # The top-level message sent by the client for the `SynthesizeSpeech` method.
         # @!attribute [rw] input
         #   @return [Google::Cloud::Texttospeech::V1::SynthesisInput]
         #     Required. The Synthesizer requires either plain text or SSML as input.
@@ -65,7 +65,7 @@ module Google
         #     Required. The configuration of the synthesized audio.
         class SynthesizeSpeechRequest; end
 
-        # Contains text input to be synthesized. Either +text+ or +ssml+ must be
+        # Contains text input to be synthesized. Either `text` or `ssml` must be
         # supplied. Supplying both or neither returns
         # {Google::Rpc::Code::INVALID_ARGUMENT}. The input size is limited to 5000
         # characters.
@@ -142,7 +142,7 @@ module Google
         #     and return {Google::Rpc::Code::INVALID_ARGUMENT}.
         class AudioConfig; end
 
-        # The message returned to the client by the +SynthesizeSpeech+ method.
+        # The message returned to the client by the `SynthesizeSpeech` method.
         # @!attribute [rw] audio_content
         #   @return [String]
         #     The audio data bytes encoded as specified in the request, including the

--- a/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
+++ b/google-cloud-text_to_speech/lib/google/cloud/text_to_speech/v1/text_to_speech_client.rb
@@ -239,13 +239,13 @@ module Google
           #
           #   text_to_speech_client = Google::Cloud::TextToSpeech.new(version: :v1)
           #
-          #   # TODO: Initialize +input+:
+          #   # TODO: Initialize `input`:
           #   input = {}
           #
-          #   # TODO: Initialize +voice+:
+          #   # TODO: Initialize `voice`:
           #   voice = {}
           #
-          #   # TODO: Initialize +audio_config+:
+          #   # TODO: Initialize `audio_config`:
           #   audio_config = {}
           #   response = text_to_speech_client.synthesize_speech(input, voice, audio_config)
 

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/devtools/cloudtrace/v1/trace.rb
@@ -50,8 +50,8 @@ module Google
         # @!attribute [rw] kind
         #   @return [Google::Devtools::Cloudtrace::V1::TraceSpan::SpanKind]
         #     Distinguishes between spans generated in a particular context. For example,
-        #     two spans with the same name may be distinguished using +RPC_CLIENT+
-        #     and +RPC_SERVER+ to identify queueing latency associated with the span.
+        #     two spans with the same name may be distinguished using `RPC_CLIENT`
+        #     and `RPC_SERVER` to identify queueing latency associated with the span.
         # @!attribute [rw] name
         #   @return [String]
         #     Name of the span. Must be less than 128 bytes. The span name is sanitized
@@ -74,39 +74,39 @@ module Google
         #   @return [Hash{String => String}]
         #     Collection of labels associated with the span. Label keys must be less than
         #     128 bytes. Label values must be less than 16 kilobytes (10MB for
-        #     +/stacktrace+ values).
+        #     `/stacktrace` values).
         #
         #     Some predefined label keys exist, or you may create your own. When creating
         #     your own, we recommend the following formats:
         #
-        #     * +/category/product/key+ for agents of well-known products (e.g.
-        #       +/db/mongodb/read_size+).
-        #     * +short_host/path/key+ for domain-specific keys (e.g.
-        #       +foo.com/myproduct/bar+)
+        #     * `/category/product/key` for agents of well-known products (e.g.
+        #       `/db/mongodb/read_size`).
+        #     * `short_host/path/key` for domain-specific keys (e.g.
+        #       `foo.com/myproduct/bar`)
         #
         #     Predefined labels include:
         #
-        #     * +/agent+
-        #     * +/component+
-        #     * +/error/message+
-        #     * +/error/name+
-        #     * +/http/client_city+
-        #     * +/http/client_country+
-        #     * +/http/client_protocol+
-        #     * +/http/client_region+
-        #     * +/http/host+
-        #     * +/http/method+
-        #     * +/http/path+
-        #     * +/http/redirected_url+
-        #     * +/http/request/size+
-        #     * +/http/response/size+
-        #     * +/http/route+
-        #     * +/http/status_code+
-        #     * +/http/url+
-        #     * +/http/user_agent+
-        #     * +/pid+
-        #     * +/stacktrace+
-        #     * +/tid+
+        #     * `/agent`
+        #     * `/component`
+        #     * `/error/message`
+        #     * `/error/name`
+        #     * `/http/client_city`
+        #     * `/http/client_country`
+        #     * `/http/client_protocol`
+        #     * `/http/client_region`
+        #     * `/http/host`
+        #     * `/http/method`
+        #     * `/http/path`
+        #     * `/http/redirected_url`
+        #     * `/http/request/size`
+        #     * `/http/response/size`
+        #     * `/http/route`
+        #     * `/http/status_code`
+        #     * `/http/url`
+        #     * `/http/user_agent`
+        #     * `/pid`
+        #     * `/stacktrace`
+        #     * `/tid`
         class TraceSpan
           # Type of span. Can be used to specify additional relationships between spans
           # in addition to a parent/child relationship.
@@ -124,7 +124,7 @@ module Google
           end
         end
 
-        # The request message for the +ListTraces+ method. All fields are required
+        # The request message for the `ListTraces` method. All fields are required
         # unless specified.
         # @!attribute [rw] project_id
         #   @return [String]
@@ -132,7 +132,7 @@ module Google
         # @!attribute [rw] view
         #   @return [Google::Devtools::Cloudtrace::V1::ListTracesRequest::ViewType]
         #     Type of data returned for traces in the list. Optional. Default is
-        #     +MINIMAL+.
+        #     `MINIMAL`.
         # @!attribute [rw] page_size
         #   @return [Integer]
         #     Maximum number of traces to return. If not specified or <= 0, the
@@ -141,7 +141,7 @@ module Google
         # @!attribute [rw] page_token
         #   @return [String]
         #     Token identifying the page of results to return. If provided, use the
-        #     value of the +next_page_token+ field from a previous request. Optional.
+        #     value of the `next_page_token` field from a previous request. Optional.
         # @!attribute [rw] start_time
         #   @return [Google::Protobuf::Timestamp]
         #     Start of the time interval (inclusive) during which the trace data was
@@ -155,52 +155,52 @@ module Google
         #     An optional filter against labels for the request.
         #
         #     By default, searches use prefix matching. To specify exact match, prepend
-        #     a plus symbol (+++) to the search term.
+        #     a plus symbol (`+`) to the search term.
         #     Multiple terms are ANDed. Syntax:
         #
-        #     * +root:NAME_PREFIX+ or +NAME_PREFIX+: Return traces where any root
-        #       span starts with +NAME_PREFIX+.
-        #     * ++root:NAME+ or ++NAME+: Return traces where any root span's name is
-        #       exactly +NAME+.
-        #     * +span:NAME_PREFIX+: Return traces where any span starts with
-        #       +NAME_PREFIX+.
-        #     * ++span:NAME+: Return traces where any span's name is exactly
-        #       +NAME+.
-        #     * +latency:DURATION+: Return traces whose overall latency is
-        #       greater or equal to than +DURATION+. Accepted units are nanoseconds
-        #       (+ns+), milliseconds (+ms+), and seconds (+s+). Default is +ms+. For
-        #       example, +latency:24ms+ returns traces whose overall latency
+        #     * `root:NAME_PREFIX` or `NAME_PREFIX`: Return traces where any root
+        #       span starts with `NAME_PREFIX`.
+        #     * `+root:NAME` or `+NAME`: Return traces where any root span's name is
+        #       exactly `NAME`.
+        #     * `span:NAME_PREFIX`: Return traces where any span starts with
+        #       `NAME_PREFIX`.
+        #     * `+span:NAME`: Return traces where any span's name is exactly
+        #       `NAME`.
+        #     * `latency:DURATION`: Return traces whose overall latency is
+        #       greater or equal to than `DURATION`. Accepted units are nanoseconds
+        #       (`ns`), milliseconds (`ms`), and seconds (`s`). Default is `ms`. For
+        #       example, `latency:24ms` returns traces whose overall latency
         #       is greater than or equal to 24 milliseconds.
-        #     * +label:LABEL_KEY+: Return all traces containing the specified
+        #     * `label:LABEL_KEY`: Return all traces containing the specified
         #       label key (exact match, case-sensitive) regardless of the key:value
         #       pair's value (including empty values).
-        #     * +LABEL_KEY:VALUE_PREFIX+: Return all traces containing the specified
+        #     * `LABEL_KEY:VALUE_PREFIX`: Return all traces containing the specified
         #       label key (exact match, case-sensitive) whose value starts with
-        #       +VALUE_PREFIX+. Both a key and a value must be specified.
-        #     * ++LABEL_KEY:VALUE+: Return all traces containing a key:value pair
+        #       `VALUE_PREFIX`. Both a key and a value must be specified.
+        #     * `+LABEL_KEY:VALUE`: Return all traces containing a key:value pair
         #       exactly matching the specified text. Both a key and a value must be
         #       specified.
-        #     * +method:VALUE+: Equivalent to +/http/method:VALUE+.
-        #     * +url:VALUE+: Equivalent to +/http/url:VALUE+.
+        #     * `method:VALUE`: Equivalent to `/http/method:VALUE`.
+        #     * `url:VALUE`: Equivalent to `/http/url:VALUE`.
         # @!attribute [rw] order_by
         #   @return [String]
         #     Field used to sort the returned traces. Optional.
         #     Can be one of the following:
         #
-        #     * +trace_id+
-        #     * +name+ (+name+ field of root span in the trace)
-        #     * +duration+ (difference between +end_time+ and +start_time+ fields of
+        #     * `trace_id`
+        #     * `name` (`name` field of root span in the trace)
+        #     * `duration` (difference between `end_time` and `start_time` fields of
         #       the root span)
-        #     * +start+ (+start_time+ field of the root span)
+        #     * `start` (`start_time` field of the root span)
         #
-        #     Descending order can be specified by appending +desc+ to the sort field
-        #     (for example, +name desc+).
+        #     Descending order can be specified by appending `desc` to the sort field
+        #     (for example, `name desc`).
         #
         #     Only one sort field is permitted.
         class ListTracesRequest
           # Type of data returned for traces in the list.
           module ViewType
-            # Default is +MINIMAL+ if unspecified.
+            # Default is `MINIMAL` if unspecified.
             VIEW_TYPE_UNSPECIFIED = 0
 
             # Minimal view of the trace record that contains only the project
@@ -212,13 +212,13 @@ module Google
             ROOTSPAN = 2
 
             # Complete view of the trace record that contains the actual trace data.
-            # This is equivalent to calling the REST +get+ or RPC +GetTrace+ method
+            # This is equivalent to calling the REST `get` or RPC `GetTrace` method
             # using the ID of each listed trace.
             COMPLETE = 3
           end
         end
 
-        # The response message for the +ListTraces+ method.
+        # The response message for the `ListTraces` method.
         # @!attribute [rw] traces
         #   @return [Array<Google::Devtools::Cloudtrace::V1::Trace>]
         #     List of trace records returned.
@@ -229,7 +229,7 @@ module Google
         #     retrieving additional traces.
         class ListTracesResponse; end
 
-        # The request message for the +GetTrace+ method.
+        # The request message for the `GetTrace` method.
         # @!attribute [rw] project_id
         #   @return [String]
         #     ID of the Cloud project where the trace data is stored.
@@ -238,7 +238,7 @@ module Google
         #     ID of the trace to return.
         class GetTraceRequest; end
 
-        # The request message for the +PatchTraces+ method.
+        # The request message for the `PatchTraces` method.
         # @!attribute [rw] project_id
         #   @return [String]
         #     ID of the Cloud project where the trace data is stored.

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/empty.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v1/trace_service_client.rb
@@ -219,10 +219,10 @@ module Google
           #
           #   trace_service_client = Google::Cloud::Trace.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +traces+:
+          #   # TODO: Initialize `traces`:
           #   traces = {}
           #   trace_service_client.patch_traces(project_id, traces)
 
@@ -259,10 +259,10 @@ module Google
           #
           #   trace_service_client = Google::Cloud::Trace.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
-          #   # TODO: Initialize +trace_id+:
+          #   # TODO: Initialize `trace_id`:
           #   trace_id = ''
           #   response = trace_service_client.get_trace(project_id, trace_id)
 
@@ -285,7 +285,7 @@ module Google
           #   ID of the Cloud project where the trace data is stored.
           # @param view [Google::Devtools::Cloudtrace::V1::ListTracesRequest::ViewType]
           #   Type of data returned for traces in the list. Optional. Default is
-          #   +MINIMAL+.
+          #   `MINIMAL`.
           # @param page_size [Integer]
           #   Maximum number of traces to return. If not specified or <= 0, the
           #   implementation selects a reasonable value.  The implementation may
@@ -304,45 +304,45 @@ module Google
           #   An optional filter against labels for the request.
           #
           #   By default, searches use prefix matching. To specify exact match, prepend
-          #   a plus symbol (+++) to the search term.
+          #   a plus symbol (`+`) to the search term.
           #   Multiple terms are ANDed. Syntax:
           #
-          #   * +root:NAME_PREFIX+ or +NAME_PREFIX+: Return traces where any root
-          #     span starts with +NAME_PREFIX+.
-          #   * ++root:NAME+ or ++NAME+: Return traces where any root span's name is
-          #     exactly +NAME+.
-          #   * +span:NAME_PREFIX+: Return traces where any span starts with
-          #     +NAME_PREFIX+.
-          #   * ++span:NAME+: Return traces where any span's name is exactly
-          #     +NAME+.
-          #   * +latency:DURATION+: Return traces whose overall latency is
-          #     greater or equal to than +DURATION+. Accepted units are nanoseconds
-          #     (+ns+), milliseconds (+ms+), and seconds (+s+). Default is +ms+. For
-          #     example, +latency:24ms+ returns traces whose overall latency
+          #   * `root:NAME_PREFIX` or `NAME_PREFIX`: Return traces where any root
+          #     span starts with `NAME_PREFIX`.
+          #   * `+root:NAME` or `+NAME`: Return traces where any root span's name is
+          #     exactly `NAME`.
+          #   * `span:NAME_PREFIX`: Return traces where any span starts with
+          #     `NAME_PREFIX`.
+          #   * `+span:NAME`: Return traces where any span's name is exactly
+          #     `NAME`.
+          #   * `latency:DURATION`: Return traces whose overall latency is
+          #     greater or equal to than `DURATION`. Accepted units are nanoseconds
+          #     (`ns`), milliseconds (`ms`), and seconds (`s`). Default is `ms`. For
+          #     example, `latency:24ms` returns traces whose overall latency
           #     is greater than or equal to 24 milliseconds.
-          #   * +label:LABEL_KEY+: Return all traces containing the specified
+          #   * `label:LABEL_KEY`: Return all traces containing the specified
           #     label key (exact match, case-sensitive) regardless of the key:value
           #     pair's value (including empty values).
-          #   * +LABEL_KEY:VALUE_PREFIX+: Return all traces containing the specified
+          #   * `LABEL_KEY:VALUE_PREFIX`: Return all traces containing the specified
           #     label key (exact match, case-sensitive) whose value starts with
-          #     +VALUE_PREFIX+. Both a key and a value must be specified.
-          #   * ++LABEL_KEY:VALUE+: Return all traces containing a key:value pair
+          #     `VALUE_PREFIX`. Both a key and a value must be specified.
+          #   * `+LABEL_KEY:VALUE`: Return all traces containing a key:value pair
           #     exactly matching the specified text. Both a key and a value must be
           #     specified.
-          #   * +method:VALUE+: Equivalent to +/http/method:VALUE+.
-          #   * +url:VALUE+: Equivalent to +/http/url:VALUE+.
+          #   * `method:VALUE`: Equivalent to `/http/method:VALUE`.
+          #   * `url:VALUE`: Equivalent to `/http/url:VALUE`.
           # @param order_by [String]
           #   Field used to sort the returned traces. Optional.
           #   Can be one of the following:
           #
-          #   * +trace_id+
-          #   * +name+ (+name+ field of root span in the trace)
-          #   * +duration+ (difference between +end_time+ and +start_time+ fields of
+          #   * `trace_id`
+          #   * `name` (`name` field of root span in the trace)
+          #   * `duration` (difference between `end_time` and `start_time` fields of
           #     the root span)
-          #   * +start+ (+start_time+ field of the root span)
+          #   * `start` (`start_time` field of the root span)
           #
-          #   Descending order can be specified by appending +desc+ to the sort field
-          #   (for example, +name desc+).
+          #   Descending order can be specified by appending `desc` to the sort field
+          #   (for example, `name desc`).
           #
           #   Only one sort field is permitted.
           # @param options [Google::Gax::CallOptions]
@@ -362,7 +362,7 @@ module Google
           #
           #   trace_service_client = Google::Cloud::Trace.new(version: :v1)
           #
-          #   # TODO: Initialize +project_id+:
+          #   # TODO: Initialize `project_id`:
           #   project_id = ''
           #
           #   # Iterate over all results.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/trace.rb
@@ -88,12 +88,12 @@ module Google
         #     An optional number of child spans that were generated while this span
         #     was active. If set, allows implementation to detect missing child spans.
         class Span
-          # A set of attributes, each in the format +[KEY]:[VALUE]+.
+          # A set of attributes, each in the format `[KEY]:[VALUE]`.
           # @!attribute [rw] attribute_map
           #   @return [Hash{String => Google::Devtools::Cloudtrace::V2::AttributeValue}]
           #     The set of attributes. Each attribute's key can be up to 128 bytes
           #     long. The value can be a string up to 256 bytes, an integer, or the
-          #     Boolean values +true+ and +false+. For example:
+          #     Boolean values `true` and `false`. For example:
           #
           #         "/instance_id": "my-instance"
           #         "/http/user_agent": ""
@@ -160,12 +160,12 @@ module Google
             end
           end
 
-          # A collection of +TimeEvent+s. A +TimeEvent+ is a time-stamped annotation
+          # A collection of `TimeEvent`s. A `TimeEvent` is a time-stamped annotation
           # on the span, consisting of either user-supplied key:value pairs, or
           # details of a message sent/received between Spans.
           # @!attribute [rw] time_event
           #   @return [Array<Google::Devtools::Cloudtrace::V2::Span::TimeEvent>]
-          #     A collection of +TimeEvent+s.
+          #     A collection of `TimeEvent`s.
           # @!attribute [rw] dropped_annotations_count
           #   @return [Integer]
           #     The number of dropped annotations in all the included time events.
@@ -220,7 +220,7 @@ module Google
           class Links; end
         end
 
-        # The allowed types for [VALUE] in a +[KEY]:[VALUE]+ attribute.
+        # The allowed types for [VALUE] in a `[KEY]:[VALUE]` attribute.
         # @!attribute [rw] string_value
         #   @return [Google::Devtools::Cloudtrace::V2::TruncatableString]
         #     A string up to 256 bytes long.
@@ -229,7 +229,7 @@ module Google
         #     A 64-bit signed integer.
         # @!attribute [rw] bool_value
         #   @return [true, false]
-        #     A Boolean value represented by +true+ or +false+.
+        #     A Boolean value represented by `true` or `false`.
         class AttributeValue; end
 
         # A call stack appearing in a trace.
@@ -243,10 +243,10 @@ module Google
         #
         #     Often multiple spans will have identical stack traces.
         #     The first occurrence of a stack trace should contain both the
-        #     +stackFrame+ content and a value in +stackTraceHashId+.
+        #     `stackFrame` content and a value in `stackTraceHashId`.
         #
         #     Subsequent spans within the same request can refer
-        #     to that stack trace by only setting +stackTraceHashId+.
+        #     to that stack trace by only setting `stackTraceHashId`.
         class StackTrace
           # Represents a single stack frame in a stack trace.
           # @!attribute [rw] function_name
@@ -255,7 +255,7 @@ module Google
           #     method that is active in this frame (up to 1024 bytes).
           # @!attribute [rw] original_function_name
           #   @return [Google::Devtools::Cloudtrace::V2::TruncatableString]
-          #     An un-mangled function name, if +function_name+ is
+          #     An un-mangled function name, if `function_name` is
           #     [mangled](http://www.avabodh.com/cxxin/namemangling.html). The name can
           #     be fully-qualified (up to 1024 bytes).
           # @!attribute [rw] file_name
@@ -264,7 +264,7 @@ module Google
           #     bytes).
           # @!attribute [rw] line_number
           #   @return [Integer]
-          #     The line number in +file_name+ where the function call appears.
+          #     The line number in `file_name` where the function call appears.
           # @!attribute [rw] column_number
           #   @return [Integer]
           #     The column number where the function call appears, if available.
@@ -305,7 +305,7 @@ module Google
         #   @return [String]
         #     The shortened string. For example, if the original string is 500
         #     bytes long and the limit of the string is 128 bytes, then
-        #     +value+ contains the first 128 bytes of the 500-byte string.
+        #     `value` contains the first 128 bytes of the 500-byte string.
         #
         #     Truncation always happens on a UTF8 character boundary. If there
         #     are multi-byte characters in the string, then the length of the

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/tracing.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/devtools/cloudtrace/v2/tracing.rb
@@ -17,11 +17,11 @@ module Google
   module Devtools
     module Cloudtrace
       module V2
-        # The request message for the +BatchWriteSpans+ method.
+        # The request message for the `BatchWriteSpans` method.
         # @!attribute [rw] name
         #   @return [String]
         #     Required. The name of the project where the spans belong. The format is
-        #     +projects/[PROJECT_ID]+.
+        #     `projects/[PROJECT_ID]`.
         # @!attribute [rw] spans
         #   @return [Array<Google::Devtools::Cloudtrace::V2::Span>]
         #     A list of new spans. The span names must not match existing

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/any.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/empty.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/empty.rb
@@ -23,7 +23,7 @@ module Google
     #       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
     #     }
     #
-    # The JSON representation for +Empty+ is empty JSON object +{}+.
+    # The JSON representation for `Empty` is empty JSON object `{}`.
     class Empty; end
   end
 end

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/timestamp.rb
@@ -29,13 +29,13 @@ module Google
     #
     # = Examples
     #
-    # Example 1: Compute Timestamp from POSIX +time()+.
+    # Example 1: Compute Timestamp from POSIX `time()`.
     #
     #     Timestamp timestamp;
     #     timestamp.set_seconds(time(NULL));
     #     timestamp.set_nanos(0);
     #
-    # Example 2: Compute Timestamp from POSIX +gettimeofday()+.
+    # Example 2: Compute Timestamp from POSIX `gettimeofday()`.
     #
     #     struct timeval tv;
     #     gettimeofday(&tv, NULL);
@@ -44,7 +44,7 @@ module Google
     #     timestamp.set_seconds(tv.tv_sec);
     #     timestamp.set_nanos(tv.tv_usec * 1000);
     #
-    # Example 3: Compute Timestamp from Win32 +GetSystemTimeAsFileTime()+.
+    # Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
     #
     #     FILETIME ft;
     #     GetSystemTimeAsFileTime(&ft);
@@ -56,7 +56,7 @@ module Google
     #     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
     #     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
     #
-    # Example 4: Compute Timestamp from Java +System.currentTimeMillis()+.
+    # Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
     #
     #     long millis = System.currentTimeMillis();
     #
@@ -87,10 +87,10 @@ module Google
     #
     # In JavaScript, one can convert a Date object to this format using the
     # standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
-    # method. In Python, a standard +datetime.datetime+ object can be converted
-    # to this format using [+strftime+](https://docs.python.org/2/library/time.html#time.strftime)
+    # method. In Python, a standard `datetime.datetime` object can be converted
+    # to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
     # with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
-    # can use the Joda Time's [+ISODateTimeFormat.dateTime()+](
+    # can use the Joda Time's [`ISODateTimeFormat.dateTime()`](
     # http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime--
     # ) to obtain a formatter capable of generating timestamps in this format.
     # @!attribute [rw] seconds

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/rpc/status.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
+++ b/google-cloud-trace/lib/google/cloud/trace/v2/trace_service_client.rb
@@ -218,7 +218,7 @@ module Google
           #
           # @param name [String]
           #   Required. The name of the project where the spans belong. The format is
-          #   +projects/[PROJECT_ID]+.
+          #   `projects/[PROJECT_ID]`.
           # @param spans [Array<Google::Devtools::Cloudtrace::V2::Span | Hash>]
           #   A list of new spans. The span names must not match existing
           #   spans, or the results are undefined.
@@ -237,7 +237,7 @@ module Google
           #   trace_service_client = Google::Cloud::Trace.new(version: :v2)
           #   formatted_name = Google::Cloud::Trace::V2::TraceServiceClient.project_path("[PROJECT]")
           #
-          #   # TODO: Initialize +spans+:
+          #   # TODO: Initialize `spans`:
           #   spans = []
           #   trace_service_client.batch_write_spans(formatted_name, spans)
 
@@ -342,16 +342,16 @@ module Google
           #   trace_service_client = Google::Cloud::Trace.new(version: :v2)
           #   formatted_name = Google::Cloud::Trace::V2::TraceServiceClient.span_path("[PROJECT]", "[TRACE]", "[SPAN]")
           #
-          #   # TODO: Initialize +span_id+:
+          #   # TODO: Initialize `span_id`:
           #   span_id = ''
           #
-          #   # TODO: Initialize +display_name+:
+          #   # TODO: Initialize `display_name`:
           #   display_name = {}
           #
-          #   # TODO: Initialize +start_time+:
+          #   # TODO: Initialize `start_time`:
           #   start_time = {}
           #
-          #   # TODO: Initialize +end_time+:
+          #   # TODO: Initialize `end_time`:
           #   end_time = {}
           #   response = trace_service_client.create_span(formatted_name, span_id, display_name, start_time, end_time)
 

--- a/google-cloud-trace/synth.py
+++ b/google-cloud-trace/synth.py
@@ -63,10 +63,10 @@ s.replace(
 
 # https://github.com/googleapis/gapic-generator/issues/2242
 def escape_braces(match):
-    expr = re.compile('([^\n#\\$\\\\])\\{([\\w,]+|\\.+)\\}')
+    expr = re.compile('^([^`]*(`[^`]*`[^`]*)*)([^`#\\$\\\\])\\{([\\w,]+)\\}')
     content = match.group(0)
     while True:
-        content, count = expr.subn('\\1\\\\\\\\{\\2}', content)
+        content, count = expr.subn('\\1\\3\\\\\\\\{\\4}', content)
         if count == 0:
             return content
 s.replace(

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/cloud/videointelligence/v1/video_intelligence.rb
@@ -23,18 +23,18 @@ module Google
         #     Input video location. Currently, only
         #     [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
         #     supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-        #     A video URI may include wildcards in +object-id+, and thus identify
+        #     A video URI may include wildcards in `object-id`, and thus identify
         #     multiple videos. Supported wildcards: '*' to match 0 or more characters;
         #     '?' to match 1 character. If unset, the input video should be embedded
-        #     in the request as +input_content+. If set, +input_content+ should be unset.
+        #     in the request as `input_content`. If set, `input_content` should be unset.
         # @!attribute [rw] input_content
         #   @return [String]
         #     The video data bytes.
-        #     If unset, the input video(s) should be specified via +input_uri+.
-        #     If set, +input_uri+ should be unset.
+        #     If unset, the input video(s) should be specified via `input_uri`.
+        #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
         #   @return [Array<Google::Cloud::Videointelligence::V1::Feature>]
         #     Requested video annotation features.
@@ -46,13 +46,13 @@ module Google
         #     Optional location where the output (in JSON format) should be stored.
         #     Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
         #     URIs are supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
         # @!attribute [rw] location_id
         #   @return [String]
         #     Optional cloud region where annotation should take place. Supported cloud
-        #     regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+        #     regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
         #     is specified, a region will be determined based on video file location.
         class AnnotateVideoRequest; end
 
@@ -81,12 +81,12 @@ module Google
         #   @return [Google::Cloud::Videointelligence::V1::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
-        #     If unspecified, defaults to +SHOT_MODE+.
+        #     If unspecified, defaults to `SHOT_MODE`.
         # @!attribute [rw] stationary_camera
         #   @return [true, false]
         #     Whether the video has been shot from a stationary (i.e. non-moving) camera.
         #     When set to true, might improve detection accuracy for moving objects.
-        #     Should be used with +SHOT_AND_FRAME_MODE+ enabled.
+        #     Should be used with `SHOT_AND_FRAME_MODE` enabled.
         # @!attribute [rw] model
         #   @return [String]
         #     Model to use for label detection.
@@ -159,10 +159,10 @@ module Google
         #     API](https://developers.google.com/knowledge-graph/).
         # @!attribute [rw] description
         #   @return [String]
-        #     Textual description, e.g. +Fixed-gear bicycle+.
+        #     Textual description, e.g. `Fixed-gear bicycle`.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Language code for +description+ in BCP-47 format.
+        #     Language code for `description` in BCP-47 format.
         class Entity; end
 
         # Label annotation.
@@ -172,9 +172,9 @@ module Google
         # @!attribute [rw] category_entities
         #   @return [Array<Google::Cloud::Videointelligence::V1::Entity>]
         #     Common categories for the detected entity.
-        #     E.g. when the label is +Terrier+ the category is likely +dog+. And in some
-        #     cases there might be more than one categories e.g. +Terrier+ could also be
-        #     a +pet+.
+        #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
+        #     cases there might be more than one categories e.g. `Terrier` could also be
+        #     a `pet`.
         # @!attribute [rw] segments
         #   @return [Array<Google::Cloud::Videointelligence::V1::LabelSegment>]
         #     All video segments where a label was detected.
@@ -276,16 +276,16 @@ module Google
         #     Explicit content annotation.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
-        #     If set, indicates an error. Note that for a single +AnnotateVideoRequest+
+        #     If set, indicates an error. Note that for a single `AnnotateVideoRequest`
         #     some videos may succeed and some may fail.
         class VideoAnnotationResults; end
 
-        # Video annotation response. Included in the +response+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation response. Included in the `response`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
         #   @return [Array<Google::Cloud::Videointelligence::V1::VideoAnnotationResults>]
-        #     Annotation results for all videos specified in +AnnotateVideoRequest+.
+        #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
         # Annotation progress for a single video.
@@ -305,12 +305,12 @@ module Google
         #     Time of the most recent update.
         class VideoAnnotationProgress; end
 
-        # Video annotation progress. Included in the +metadata+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation progress. Included in the `metadata`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
         #   @return [Array<Google::Cloud::Videointelligence::V1::VideoAnnotationProgress>]
-        #     Progress metadata for all videos specified in +AnnotateVideoRequest+.
+        #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
         # Video annotation feature.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1/video_intelligence_service_client.rb
@@ -186,25 +186,25 @@ module Google
           # Service calls
 
           # Performs asynchronous video annotation. Progress and results can be
-          # retrieved through the +google.longrunning.Operations+ interface.
-          # +Operation.metadata+ contains +AnnotateVideoProgress+ (progress).
-          # +Operation.response+ contains +AnnotateVideoResponse+ (results).
+          # retrieved through the `google.longrunning.Operations` interface.
+          # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+          # `Operation.response` contains `AnnotateVideoResponse` (results).
           #
           # @param input_uri [String]
           #   Input video location. Currently, only
           #   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
           #   supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-          #   A video URI may include wildcards in +object-id+, and thus identify
+          #   A video URI may include wildcards in `object-id`, and thus identify
           #   multiple videos. Supported wildcards: '*' to match 0 or more characters;
           #   '?' to match 1 character. If unset, the input video should be embedded
-          #   in the request as +input_content+. If set, +input_content+ should be unset.
+          #   in the request as `input_content`. If set, `input_content` should be unset.
           # @param input_content [String]
           #   The video data bytes.
-          #   If unset, the input video(s) should be specified via +input_uri+.
-          #   If set, +input_uri+ should be unset.
+          #   If unset, the input video(s) should be specified via `input_uri`.
+          #   If set, `input_uri` should be unset.
           # @param features [Array<Google::Cloud::Videointelligence::V1::Feature>]
           #   Requested video annotation features.
           # @param video_context [Google::Cloud::Videointelligence::V1::VideoContext | Hash]
@@ -215,12 +215,12 @@ module Google
           #   Optional location where the output (in JSON format) should be stored.
           #   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
           #   URIs are supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
           # @param location_id [String]
           #   Optional cloud region where annotation should take place. Supported cloud
-          #   regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+          #   regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
           #   is specified, a region will be determined based on video file location.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/cloud/videointelligence/v1beta1/video_intelligence.rb
@@ -23,17 +23,17 @@ module Google
         #     Input video location. Currently, only
         #     [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
         #     supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-        #     A video URI may include wildcards in +object-id+, and thus identify
+        #     A video URI may include wildcards in `object-id`, and thus identify
         #     multiple videos. Supported wildcards: '*' to match 0 or more characters;
         #     '?' to match 1 character. If unset, the input video should be embedded
-        #     in the request as +input_content+. If set, +input_content+ should be unset.
+        #     in the request as `input_content`. If set, `input_content` should be unset.
         # @!attribute [rw] input_content
         #   @return [String]
         #     The video data bytes. Encoding: base64. If unset, the input video(s)
-        #     should be specified via +input_uri+. If set, +input_uri+ should be unset.
+        #     should be specified via `input_uri`. If set, `input_uri` should be unset.
         # @!attribute [rw] features
         #   @return [Array<Google::Cloud::Videointelligence::V1beta1::Feature>]
         #     Requested video annotation features.
@@ -45,13 +45,13 @@ module Google
         #     Optional location where the output (in JSON format) should be stored.
         #     Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
         #     URIs are supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
         # @!attribute [rw] location_id
         #   @return [String]
         #     Optional cloud region where annotation should take place. Supported cloud
-        #     regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+        #     regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
         #     is specified, a region will be determined based on video file location.
         class AnnotateVideoRequest; end
 
@@ -65,7 +65,7 @@ module Google
         #   @return [Google::Cloud::Videointelligence::V1beta1::LabelDetectionMode]
         #     If label detection has been requested, what labels should be detected
         #     in addition to video-level labels or segment-level labels. If unspecified,
-        #     defaults to +SHOT_MODE+.
+        #     defaults to `SHOT_MODE`.
         # @!attribute [rw] stationary_camera
         #   @return [true, false]
         #     Whether the video has been shot from a stationary (i.e. non-moving) camera.
@@ -102,7 +102,7 @@ module Google
         #   @return [Google::Cloud::Videointelligence::V1beta1::VideoSegment]
         #     Video segment. Set to [-1, -1] for video-level labels.
         #     Set to [timestamp, timestamp] for frame-level labels.
-        #     Otherwise, corresponds to one of +AnnotateSpec.segments+
+        #     Otherwise, corresponds to one of `AnnotateSpec.segments`
         #     (if specified) or to shot boundaries (if requested).
         # @!attribute [rw] confidence
         #   @return [Float]
@@ -115,10 +115,10 @@ module Google
         # Label annotation.
         # @!attribute [rw] description
         #   @return [String]
-        #     Textual description, e.g. +Fixed-gear bicycle+.
+        #     Textual description, e.g. `Fixed-gear bicycle`.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Language code for +description+ in BCP-47 format.
+        #     Language code for `description` in BCP-47 format.
         # @!attribute [rw] locations
         #   @return [Array<Google::Cloud::Videointelligence::V1beta1::LabelLocation>]
         #     Where the label was detected and with what confidence.
@@ -127,7 +127,7 @@ module Google
         # Safe search annotation (based on per-frame visual signals only).
         # If no unsafe content has been detected in a frame, no annotations
         # are present for that frame. If only some types of unsafe content
-        # have been detected in a frame, the likelihood is set to +UNKNOWN+
+        # have been detected in a frame, the likelihood is set to `UNKNOWN`
         # for all other types of unsafe content.
         # @!attribute [rw] adult
         #   @return [Google::Cloud::Videointelligence::V1beta1::Likelihood]
@@ -207,16 +207,16 @@ module Google
         #     Safe search annotations.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
-        #     If set, indicates an error. Note that for a single +AnnotateVideoRequest+
+        #     If set, indicates an error. Note that for a single `AnnotateVideoRequest`
         #     some videos may succeed and some may fail.
         class VideoAnnotationResults; end
 
-        # Video annotation response. Included in the +response+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation response. Included in the `response`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
         #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoAnnotationResults>]
-        #     Annotation results for all videos specified in +AnnotateVideoRequest+.
+        #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
         # Annotation progress for a single video.
@@ -236,12 +236,12 @@ module Google
         #     Time of the most recent update.
         class VideoAnnotationProgress; end
 
-        # Video annotation progress. Included in the +metadata+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation progress. Included in the `metadata`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
         #   @return [Array<Google::Cloud::Videointelligence::V1beta1::VideoAnnotationProgress>]
-        #     Progress metadata for all videos specified in +AnnotateVideoRequest+.
+        #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
         # Video annotation feature.
@@ -270,7 +270,7 @@ module Google
           # Video-level. Corresponds to the whole video.
           VIDEO_LEVEL = 1
 
-          # Segment-level. Corresponds to one of +AnnotateSpec.segments+.
+          # Segment-level. Corresponds to one of `AnnotateSpec.segments`.
           SEGMENT_LEVEL = 2
 
           # Shot-level. Corresponds to a single shot (i.e. a series of frames

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta1/video_intelligence_service_client.rb
@@ -186,26 +186,26 @@ module Google
           # Service calls
 
           # Performs asynchronous video annotation. Progress and results can be
-          # retrieved through the +google.longrunning.Operations+ interface.
-          # +Operation.metadata+ contains +AnnotateVideoProgress+ (progress).
-          # +Operation.response+ contains +AnnotateVideoResponse+ (results).
+          # retrieved through the `google.longrunning.Operations` interface.
+          # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+          # `Operation.response` contains `AnnotateVideoResponse` (results).
           #
           # @param input_uri [String]
           #   Input video location. Currently, only
           #   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
           #   supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-          #   A video URI may include wildcards in +object-id+, and thus identify
+          #   A video URI may include wildcards in `object-id`, and thus identify
           #   multiple videos. Supported wildcards: '*' to match 0 or more characters;
           #   '?' to match 1 character. If unset, the input video should be embedded
-          #   in the request as +input_content+. If set, +input_content+ should be unset.
+          #   in the request as `input_content`. If set, `input_content` should be unset.
           # @param features [Array<Google::Cloud::Videointelligence::V1beta1::Feature>]
           #   Requested video annotation features.
           # @param input_content [String]
           #   The video data bytes. Encoding: base64. If unset, the input video(s)
-          #   should be specified via +input_uri+. If set, +input_uri+ should be unset.
+          #   should be specified via `input_uri`. If set, `input_uri` should be unset.
           # @param video_context [Google::Cloud::Videointelligence::V1beta1::VideoContext | Hash]
           #   Additional video context and/or feature-specific parameters.
           #   A hash of the same form as `Google::Cloud::Videointelligence::V1beta1::VideoContext`
@@ -214,12 +214,12 @@ module Google
           #   Optional location where the output (in JSON format) should be stored.
           #   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
           #   URIs are supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
           # @param location_id [String]
           #   Optional cloud region where annotation should take place. Supported cloud
-          #   regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+          #   regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
           #   is specified, a region will be determined based on video file location.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/cloud/videointelligence/v1beta2/video_intelligence.rb
@@ -23,18 +23,18 @@ module Google
         #     Input video location. Currently, only
         #     [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
         #     supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-        #     A video URI may include wildcards in +object-id+, and thus identify
+        #     A video URI may include wildcards in `object-id`, and thus identify
         #     multiple videos. Supported wildcards: '*' to match 0 or more characters;
         #     '?' to match 1 character. If unset, the input video should be embedded
-        #     in the request as +input_content+. If set, +input_content+ should be unset.
+        #     in the request as `input_content`. If set, `input_content` should be unset.
         # @!attribute [rw] input_content
         #   @return [String]
         #     The video data bytes.
-        #     If unset, the input video(s) should be specified via +input_uri+.
-        #     If set, +input_uri+ should be unset.
+        #     If unset, the input video(s) should be specified via `input_uri`.
+        #     If set, `input_uri` should be unset.
         # @!attribute [rw] features
         #   @return [Array<Google::Cloud::Videointelligence::V1beta2::Feature>]
         #     Requested video annotation features.
@@ -46,13 +46,13 @@ module Google
         #     Optional location where the output (in JSON format) should be stored.
         #     Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
         #     URIs are supported, which must be specified in the following format:
-        #     +gs://bucket-id/object-id+ (other URI formats return
+        #     `gs://bucket-id/object-id` (other URI formats return
         #     {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
         #     [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
         # @!attribute [rw] location_id
         #   @return [String]
         #     Optional cloud region where annotation should take place. Supported cloud
-        #     regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+        #     regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
         #     is specified, a region will be determined based on video file location.
         class AnnotateVideoRequest; end
 
@@ -81,12 +81,12 @@ module Google
         #   @return [Google::Cloud::Videointelligence::V1beta2::LabelDetectionMode]
         #     What labels should be detected with LABEL_DETECTION, in addition to
         #     video-level labels or segment-level labels.
-        #     If unspecified, defaults to +SHOT_MODE+.
+        #     If unspecified, defaults to `SHOT_MODE`.
         # @!attribute [rw] stationary_camera
         #   @return [true, false]
         #     Whether the video has been shot from a stationary (i.e. non-moving) camera.
         #     When set to true, might improve detection accuracy for moving objects.
-        #     Should be used with +SHOT_AND_FRAME_MODE+ enabled.
+        #     Should be used with `SHOT_AND_FRAME_MODE` enabled.
         # @!attribute [rw] model
         #   @return [String]
         #     Model to use for label detection.
@@ -159,10 +159,10 @@ module Google
         #     API](https://developers.google.com/knowledge-graph/).
         # @!attribute [rw] description
         #   @return [String]
-        #     Textual description, e.g. +Fixed-gear bicycle+.
+        #     Textual description, e.g. `Fixed-gear bicycle`.
         # @!attribute [rw] language_code
         #   @return [String]
-        #     Language code for +description+ in BCP-47 format.
+        #     Language code for `description` in BCP-47 format.
         class Entity; end
 
         # Label annotation.
@@ -172,9 +172,9 @@ module Google
         # @!attribute [rw] category_entities
         #   @return [Array<Google::Cloud::Videointelligence::V1beta2::Entity>]
         #     Common categories for the detected entity.
-        #     E.g. when the label is +Terrier+ the category is likely +dog+. And in some
-        #     cases there might be more than one categories e.g. +Terrier+ could also be
-        #     a +pet+.
+        #     E.g. when the label is `Terrier` the category is likely `dog`. And in some
+        #     cases there might be more than one categories e.g. `Terrier` could also be
+        #     a `pet`.
         # @!attribute [rw] segments
         #   @return [Array<Google::Cloud::Videointelligence::V1beta2::LabelSegment>]
         #     All video segments where a label was detected.
@@ -276,16 +276,16 @@ module Google
         #     Explicit content annotation.
         # @!attribute [rw] error
         #   @return [Google::Rpc::Status]
-        #     If set, indicates an error. Note that for a single +AnnotateVideoRequest+
+        #     If set, indicates an error. Note that for a single `AnnotateVideoRequest`
         #     some videos may succeed and some may fail.
         class VideoAnnotationResults; end
 
-        # Video annotation response. Included in the +response+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation response. Included in the `response`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_results
         #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoAnnotationResults>]
-        #     Annotation results for all videos specified in +AnnotateVideoRequest+.
+        #     Annotation results for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoResponse; end
 
         # Annotation progress for a single video.
@@ -305,12 +305,12 @@ module Google
         #     Time of the most recent update.
         class VideoAnnotationProgress; end
 
-        # Video annotation progress. Included in the +metadata+
-        # field of the +Operation+ returned by the +GetOperation+
-        # call of the +google::longrunning::Operations+ service.
+        # Video annotation progress. Included in the `metadata`
+        # field of the `Operation` returned by the `GetOperation`
+        # call of the `google::longrunning::Operations` service.
         # @!attribute [rw] annotation_progress
         #   @return [Array<Google::Cloud::Videointelligence::V1beta2::VideoAnnotationProgress>]
-        #     Progress metadata for all videos specified in +AnnotateVideoRequest+.
+        #     Progress metadata for all videos specified in `AnnotateVideoRequest`.
         class AnnotateVideoProgress; end
 
         # Video annotation feature.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/longrunning/operations.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/protobuf/duration.rb
@@ -82,9 +82,9 @@ module Google
     #   @return [Integer]
     #     Signed fractions of a second at nanosecond resolution of the span
     #     of time. Durations less than one second are represented with a 0
-    #     +seconds+ field and a positive or negative +nanos+ field. For durations
-    #     of one second or more, a non-zero value for the +nanos+ field must be
-    #     of the same sign as the +seconds+ field. Must be from -999,999,999
+    #     `seconds` field and a positive or negative `nanos` field. For durations
+    #     of one second or more, a non-zero value for the `nanos` field must be
+    #     of the same sign as the `seconds` field. Must be from -999,999,999
     #     to +999,999,999 inclusive.
     class Duration; end
   end

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
+++ b/google-cloud-video_intelligence/lib/google/cloud/video_intelligence/v1beta2/video_intelligence_service_client.rb
@@ -186,25 +186,25 @@ module Google
           # Service calls
 
           # Performs asynchronous video annotation. Progress and results can be
-          # retrieved through the +google.longrunning.Operations+ interface.
-          # +Operation.metadata+ contains +AnnotateVideoProgress+ (progress).
-          # +Operation.response+ contains +AnnotateVideoResponse+ (results).
+          # retrieved through the `google.longrunning.Operations` interface.
+          # `Operation.metadata` contains `AnnotateVideoProgress` (progress).
+          # `Operation.response` contains `AnnotateVideoResponse` (results).
           #
           # @param input_uri [String]
           #   Input video location. Currently, only
           #   [Google Cloud Storage](https://cloud.google.com/storage/) URIs are
           #   supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
-          #   A video URI may include wildcards in +object-id+, and thus identify
+          #   A video URI may include wildcards in `object-id`, and thus identify
           #   multiple videos. Supported wildcards: '*' to match 0 or more characters;
           #   '?' to match 1 character. If unset, the input video should be embedded
-          #   in the request as +input_content+. If set, +input_content+ should be unset.
+          #   in the request as `input_content`. If set, `input_content` should be unset.
           # @param input_content [String]
           #   The video data bytes.
-          #   If unset, the input video(s) should be specified via +input_uri+.
-          #   If set, +input_uri+ should be unset.
+          #   If unset, the input video(s) should be specified via `input_uri`.
+          #   If set, `input_uri` should be unset.
           # @param features [Array<Google::Cloud::Videointelligence::V1beta2::Feature>]
           #   Requested video annotation features.
           # @param video_context [Google::Cloud::Videointelligence::V1beta2::VideoContext | Hash]
@@ -215,12 +215,12 @@ module Google
           #   Optional location where the output (in JSON format) should be stored.
           #   Currently, only [Google Cloud Storage](https://cloud.google.com/storage/)
           #   URIs are supported, which must be specified in the following format:
-          #   +gs://bucket-id/object-id+ (other URI formats return
+          #   `gs://bucket-id/object-id` (other URI formats return
           #   {Google::Rpc::Code::INVALID_ARGUMENT}). For more information, see
           #   [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
           # @param location_id [String]
           #   Optional cloud region where annotation should take place. Supported cloud
-          #   regions: +us-east1+, +us-west1+, +europe-west1+, +asia-east1+. If no region
+          #   regions: `us-east1`, `us-west1`, `europe-west1`, `asia-east1`. If no region
           #   is specified, a region will be determined based on video file location.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/image_annotator.rb
@@ -18,15 +18,15 @@ module Google
     module Vision
       module V1
         # The type of Google Cloud Vision API detection to perform, and the maximum
-        # number of results to return for that type. Multiple +Feature+ objects can
-        # be specified in the +features+ list.
+        # number of results to return for that type. Multiple `Feature` objects can
+        # be specified in the `features` list.
         # @!attribute [rw] type
         #   @return [Google::Cloud::Vision::V1::Feature::Type]
         #     The feature type.
         # @!attribute [rw] max_results
         #   @return [Integer]
         #     Maximum number of results of this type. Does not apply to
-        #     +TEXT_DETECTION+, +DOCUMENT_TEXT_DETECTION+, or +CROP_HINTS+.
+        #     `TEXT_DETECTION`, `DOCUMENT_TEXT_DETECTION`, or `CROP_HINTS`.
         # @!attribute [rw] model
         #   @return [String]
         #     Model to use for the feature.
@@ -52,11 +52,11 @@ module Google
 
             # Run text detection / optical character recognition (OCR). Text detection
             # is optimized for areas of text within a larger image; if the image is
-            # a document, use +DOCUMENT_TEXT_DETECTION+ instead.
+            # a document, use `DOCUMENT_TEXT_DETECTION` instead.
             TEXT_DETECTION = 5
 
             # Run dense text document OCR. Takes precedence when both
-            # +DOCUMENT_TEXT_DETECTION+ and +TEXT_DETECTION+ are present.
+            # `DOCUMENT_TEXT_DETECTION` and `TEXT_DETECTION` are present.
             DOCUMENT_TEXT_DETECTION = 11
 
             # Run Safe Search to detect potentially unsafe
@@ -81,10 +81,10 @@ module Google
         # External image source (Google Cloud Storage or web URL image location).
         # @!attribute [rw] gcs_image_uri
         #   @return [String]
-        #     **Use +image_uri+ instead.**
+        #     **Use `image_uri` instead.**
         #
         #     The Google Cloud Storage  URI of the form
-        #     +gs://bucket_name/object_name+. Object versioning is not supported. See
+        #     `gs://bucket_name/object_name`. Object versioning is not supported. See
         #     [Google Cloud Storage Request
         #     URIs](https://cloud.google.com/storage/docs/reference-uris) for more info.
         # @!attribute [rw] image_uri
@@ -92,7 +92,7 @@ module Google
         #     The URI of the source image. Can be either:
         #
         #     1. A Google Cloud Storage URI of the form
-        #        +gs://bucket_name/object_name+. Object versioning is not supported. See
+        #        `gs://bucket_name/object_name`. Object versioning is not supported. See
         #        [Google Cloud Storage Request
         #        URIs](https://cloud.google.com/storage/docs/reference-uris) for more
         #        info.
@@ -104,7 +104,7 @@ module Google
         #        throttles requests to the site for abuse prevention. You should not
         #        depend on externally-hosted images for production applications.
         #
-        #     When both +gcs_image_uri+ and +image_uri+ are specified, +image_uri+ takes
+        #     When both `gcs_image_uri` and `image_uri` are specified, `image_uri` takes
         #     precedence.
         class ImageSource; end
 
@@ -112,12 +112,12 @@ module Google
         # @!attribute [rw] content
         #   @return [String]
         #     Image content, represented as a stream of bytes.
-        #     Note: As with all +bytes+ fields, protobuffers use a pure binary
+        #     Note: As with all `bytes` fields, protobuffers use a pure binary
         #     representation, whereas JSON representations use base64.
         # @!attribute [rw] source
         #   @return [Google::Cloud::Vision::V1::ImageSource]
         #     Google Cloud Storage image location, or publicly-accessible image
-        #     URL. If both +content+ and +source+ are provided for an image, +content+
+        #     URL. If both `content` and `source` are provided for an image, `content`
         #     takes precedence and is used to perform the image annotation request.
         class Image; end
 
@@ -125,16 +125,16 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding polygon around the face. The coordinates of the bounding box
-        #     are in the original image's scale, as returned in +ImageParams+.
+        #     are in the original image's scale, as returned in `ImageParams`.
         #     The bounding box is computed to "frame" the face in accordance with human
         #     expectations. It is based on the landmarker results.
         #     Note that one or more x and/or y coordinates may not be generated in the
-        #     +BoundingPoly+ (the polygon will be unbounded) if only a partial face
+        #     `BoundingPoly` (the polygon will be unbounded) if only a partial face
         #     appears in the image to be annotated.
         # @!attribute [rw] fd_bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
-        #     The +fd_bounding_poly+ bounding polygon is tighter than the
-        #     +boundingPoly+, and encloses only the skin part of the face. Typically, it
+        #     The `fd_bounding_poly` bounding polygon is tighter than the
+        #     `boundingPoly`, and encloses only the skin part of the face. Typically, it
         #     is used to eliminate the face from any image analysis that detects the
         #     "amount of skin" visible in an image. It is not based on the
         #     landmarker results, only on the initial face detection, hence
@@ -194,7 +194,7 @@ module Google
           class Landmark
             # Face landmark (feature) type.
             # Left and right are defined from the vantage of the viewer of the image
-            # without considering mirror projections typical of photos. So, +LEFT_EYE+,
+            # without considering mirror projections typical of photos. So, `LEFT_EYE`,
             # typically, is the person's right eye.
             module Type
               # Unknown face landmark detected. Should not be filled.
@@ -311,7 +311,7 @@ module Google
         #     lat/long location coordinates.
         class LocationInfo; end
 
-        # A +Property+ consists of a user-supplied name/value pair.
+        # A `Property` consists of a user-supplied name/value pair.
         # @!attribute [rw] name
         #   @return [String]
         #     Name of the property.
@@ -332,16 +332,16 @@ module Google
         # @!attribute [rw] locale
         #   @return [String]
         #     The language code for the locale in which the entity textual
-        #     +description+ is expressed.
+        #     `description` is expressed.
         # @!attribute [rw] description
         #   @return [String]
-        #     Entity textual description, expressed in its +locale+ language.
+        #     Entity textual description, expressed in its `locale` language.
         # @!attribute [rw] score
         #   @return [Float]
         #     Overall score of the result. Range [0, 1].
         # @!attribute [rw] confidence
         #   @return [Float]
-        #     **Deprecated. Use +score+ instead.**
+        #     **Deprecated. Use `score` instead.**
         #     The accuracy of the entity detection in an image.
         #     For example, for an image in which the "Eiffel Tower" entity is detected,
         #     this field represents the confidence that there is a tower in the query
@@ -356,17 +356,17 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     Image region to which this entity belongs. Not produced
-        #     for +LABEL_DETECTION+ features.
+        #     for `LABEL_DETECTION` features.
         # @!attribute [rw] locations
         #   @return [Array<Google::Cloud::Vision::V1::LocationInfo>]
         #     The location information for the detected entity. Multiple
-        #     +LocationInfo+ elements can be present because one location may
+        #     `LocationInfo` elements can be present because one location may
         #     indicate the location of the scene in the image, and another location
         #     may indicate the location of the place where the image was taken.
         #     Location information is usually present for landmarks.
         # @!attribute [rw] properties
         #   @return [Array<Google::Cloud::Vision::V1::Property>]
-        #     Some entities may have optional user-supplied +Property+ (name/value)
+        #     Some entities may have optional user-supplied `Property` (name/value)
         #     fields, such a score or string that qualifies the entity.
         class EntityAnnotation; end
 
@@ -381,7 +381,7 @@ module Google
         #     http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
         # @!attribute [rw] name
         #   @return [String]
-        #     Object name, expressed in its +language_code+ language.
+        #     Object name, expressed in its `language_code` language.
         # @!attribute [rw] score
         #   @return [Float]
         #     Score of the result. Range [0, 1].
@@ -417,7 +417,7 @@ module Google
         #     body areas.
         class SafeSearchAnnotation; end
 
-        # Rectangle determined by min and max +LatLng+ pairs.
+        # Rectangle determined by min and max `LatLng` pairs.
         # @!attribute [rw] min_lat_lng
         #   @return [Google::Type::LatLng]
         #     Min lat/long pair.
@@ -456,7 +456,7 @@ module Google
         # @!attribute [rw] bounding_poly
         #   @return [Google::Cloud::Vision::V1::BoundingPoly]
         #     The bounding polygon for the crop region. The coordinates of the bounding
-        #     box are in the original image's scale, as returned in +ImageParams+.
+        #     box are in the original image's scale, as returned in `ImageParams`.
         # @!attribute [rw] confidence
         #   @return [Float]
         #     Confidence of this being a salient region.  Range [0, 1].
@@ -497,7 +497,7 @@ module Google
         #   @return [Array<String>]
         #     List of languages to use for TEXT_DETECTION. In most cases, an empty value
         #     yields the best results since it enables automatic language detection. For
-        #     languages based on the Latin alphabet, setting +language_hints+ is not
+        #     languages based on the Latin alphabet, setting `language_hints` is not
         #     needed. In rare cases, when the language of the text in the image is known,
         #     setting a hint will help get better results (although it will be a
         #     significant hindrance if the hint is wrong). Text detection returns an
@@ -577,7 +577,7 @@ module Google
         #   @return [Google::Rpc::Status]
         #     If set, represents the error message for the operation.
         #     Note that filled-in image annotations are guaranteed to be
-        #     correct, even when +error+ is set.
+        #     correct, even when `error` is set.
         # @!attribute [rw] context
         #   @return [Google::Cloud::Vision::V1::ImageAnnotationContext]
         #     If present, contextual information is needed to understand where this image
@@ -662,9 +662,9 @@ module Google
         #     The valid range is [1, 100]. If not specified, the default value is 20.
         #
         #     For example, for one pdf file with 100 pages, 100 response protos will
-        #     be generated. If +batch_size+ = 20, then 5 json files each
+        #     be generated. If `batch_size` = 20, then 5 json files each
         #     containing 20 response protos will be written under the prefix
-        #     +gcs_destination+.+uri+.
+        #     `gcs_destination`.`uri`.
         #
         #     Currently, batch_size only applies to GcsDestination, with potential future
         #     support for other output configurations.
@@ -683,7 +683,7 @@ module Google
         #     Google Cloud Storage URI where the results will be stored. Results will
         #     be in JSON format and preceded by its corresponding input URI. This field
         #     can either represent a single file, or a prefix for multiple outputs.
-        #     Prefixes must end in a +/+.
+        #     Prefixes must end in a `/`.
         #
         #     Examples:
         #

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/text_annotation.rb
@@ -65,7 +65,7 @@ module Google
               EOL_SURE_SPACE = 3
 
               # End-line hyphen that is not present in text; does not co-occur with
-              # +SPACE+, +LEADER_SPACE+, or +LINE_BREAK+.
+              # `SPACE`, `LEADER_SPACE`, or `LINE_BREAK`.
               HYPHEN = 4
 
               # Line break that ends a paragraph.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/cloud/vision/v1/web_detection.rb
@@ -90,7 +90,7 @@ module Google
           #     Label for extra metadata.
           # @!attribute [rw] language_code
           #   @return [String]
-          #     The BCP-47 language code for +label+, such as "en-US" or "sr-Latn".
+          #     The BCP-47 language code for `label`, such as "en-US" or "sr-Latn".
           #     For more information, see
           #     http://www.unicode.org/reports/tr35/#Unicode_locale_identifier.
           class WebLabel; end

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/longrunning/operations.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/longrunning/operations.rb
@@ -21,7 +21,7 @@ module Google
     #   @return [String]
     #     The server-assigned name, which is only unique within the same service that
     #     originally returns it. If you use the default HTTP mapping, the
-    #     +name+ should have the format of +operations/some/unique/name+.
+    #     `name` should have the format of `operations/some/unique/name`.
     # @!attribute [rw] metadata
     #   @return [Google::Protobuf::Any]
     #     Service-specific metadata associated with the operation.  It typically
@@ -30,8 +30,8 @@ module Google
     #     long-running operation should document the metadata type, if any.
     # @!attribute [rw] done
     #   @return [true, false]
-    #     If the value is +false+, it means the operation is still in progress.
-    #     If true, the operation is completed, and either +error+ or +response+ is
+    #     If the value is `false`, it means the operation is still in progress.
+    #     If true, the operation is completed, and either `error` or `response` is
     #     available.
     # @!attribute [rw] error
     #   @return [Google::Rpc::Status]
@@ -39,13 +39,13 @@ module Google
     # @!attribute [rw] response
     #   @return [Google::Protobuf::Any]
     #     The normal response of the operation in case of success.  If the original
-    #     method returns no data on success, such as +Delete+, the response is
-    #     +google.protobuf.Empty+.  If the original method is standard
-    #     +Get+/+Create+/+Update+, the response should be the resource.  For other
-    #     methods, the response should have the type +XxxResponse+, where +Xxx+
+    #     method returns no data on success, such as `Delete`, the response is
+    #     `google.protobuf.Empty`.  If the original method is standard
+    #     `Get`/`Create`/`Update`, the response should be the resource.  For other
+    #     methods, the response should have the type `XxxResponse`, where `Xxx`
     #     is the original method name.  For example, if the original method name
-    #     is +TakeSnapshot()+, the inferred response type is
-    #     +TakeSnapshotResponse+.
+    #     is `TakeSnapshot()`, the inferred response type is
+    #     `TakeSnapshotResponse`.
     class Operation; end
 
     # The request message for {Google::Longrunning::Operations::GetOperation Operations::GetOperation}.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/any.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # `Any` contains an arbitrary serialized protocol buffer message along with a
     # URL that describes the type of the serialized message.
     #
     # Protobuf library provides support to pack/unpack Any values in the form
@@ -69,9 +69,9 @@ module Google
     #
     # = JSON
     #
-    # The JSON representation of an +Any+ value uses the regular
+    # The JSON representation of an `Any` value uses the regular
     # representation of the deserialized, embedded message, with an
-    # additional field +@type+ which contains the type URL. Example:
+    # additional field `@type` which contains the type URL. Example:
     #
     #     package google.profile;
     #     message Person {
@@ -87,7 +87,7 @@ module Google
     #
     # If the embedded message type is well-known and has a custom JSON
     # representation, that representation will be embedded adding a field
-    # +value+ which holds the custom JSON in addition to the +@type+
+    # `value` which holds the custom JSON in addition to the `@type`
     # field. Example (for message {Google::Protobuf::Duration}):
     #
     #     {
@@ -99,15 +99,15 @@ module Google
     #     A URL/resource name that uniquely identifies the type of the serialized
     #     protocol buffer message. The last segment of the URL's path must represent
     #     the fully qualified name of the type (as in
-    #     +path/google.protobuf.Duration+). The name should be in a canonical form
+    #     `path/google.protobuf.Duration`). The name should be in a canonical form
     #     (e.g., leading "." is not accepted).
     #
     #     In practice, teams usually precompile into the binary all types that they
     #     expect it to use in the context of Any. However, for URLs which use the
-    #     scheme +http+, +https+, or no scheme, one can optionally set up a type
+    #     scheme `http`, `https`, or no scheme, one can optionally set up a type
     #     server that maps type URLs to message definitions as follows:
     #
-    #     * If no scheme is provided, +https+ is assumed.
+    #     * If no scheme is provided, `https` is assumed.
     #     * An HTTP GET on the URL must yield a {Google::Protobuf::Type}
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -120,7 +120,7 @@ module Google
     #     protobuf release, and it is not used for type URLs beginning with
     #     type.googleapis.com.
     #
-    #     Schemes other than +http+, +https+ (or the empty scheme) might be
+    #     Schemes other than `http`, `https` (or the empty scheme) might be
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/protobuf/wrappers.rb
@@ -15,73 +15,73 @@
 
 module Google
   module Protobuf
-    # Wrapper message for +double+.
+    # Wrapper message for `double`.
     #
-    # The JSON representation for +DoubleValue+ is JSON number.
+    # The JSON representation for `DoubleValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The double value.
     class DoubleValue; end
 
-    # Wrapper message for +float+.
+    # Wrapper message for `float`.
     #
-    # The JSON representation for +FloatValue+ is JSON number.
+    # The JSON representation for `FloatValue` is JSON number.
     # @!attribute [rw] value
     #   @return [Float]
     #     The float value.
     class FloatValue; end
 
-    # Wrapper message for +int64+.
+    # Wrapper message for `int64`.
     #
-    # The JSON representation for +Int64Value+ is JSON string.
+    # The JSON representation for `Int64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int64 value.
     class Int64Value; end
 
-    # Wrapper message for +uint64+.
+    # Wrapper message for `uint64`.
     #
-    # The JSON representation for +UInt64Value+ is JSON string.
+    # The JSON representation for `UInt64Value` is JSON string.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint64 value.
     class UInt64Value; end
 
-    # Wrapper message for +int32+.
+    # Wrapper message for `int32`.
     #
-    # The JSON representation for +Int32Value+ is JSON number.
+    # The JSON representation for `Int32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The int32 value.
     class Int32Value; end
 
-    # Wrapper message for +uint32+.
+    # Wrapper message for `uint32`.
     #
-    # The JSON representation for +UInt32Value+ is JSON number.
+    # The JSON representation for `UInt32Value` is JSON number.
     # @!attribute [rw] value
     #   @return [Integer]
     #     The uint32 value.
     class UInt32Value; end
 
-    # Wrapper message for +bool+.
+    # Wrapper message for `bool`.
     #
-    # The JSON representation for +BoolValue+ is JSON +true+ and +false+.
+    # The JSON representation for `BoolValue` is JSON `true` and `false`.
     # @!attribute [rw] value
     #   @return [true, false]
     #     The bool value.
     class BoolValue; end
 
-    # Wrapper message for +string+.
+    # Wrapper message for `string`.
     #
-    # The JSON representation for +StringValue+ is JSON string.
+    # The JSON representation for `StringValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The string value.
     class StringValue; end
 
-    # Wrapper message for +bytes+.
+    # Wrapper message for `bytes`.
     #
-    # The JSON representation for +BytesValue+ is JSON string.
+    # The JSON representation for `BytesValue` is JSON string.
     # @!attribute [rw] value
     #   @return [String]
     #     The bytes value.

--- a/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/doc/google/rpc/status.rb
@@ -15,7 +15,7 @@
 
 module Google
   module Rpc
-    # The +Status+ type defines a logical error model that is suitable for different
+    # The `Status` type defines a logical error model that is suitable for different
     # programming environments, including REST APIs and RPC APIs. It is used by
     # [gRPC](https://github.com/grpc). The error model is designed to be:
     #
@@ -24,7 +24,7 @@ module Google
     #
     # = Overview
     #
-    # The +Status+ message contains three pieces of data: error code, error message,
+    # The `Status` message contains three pieces of data: error code, error message,
     # and error details. The error code should be an enum value of
     # {Google::Rpc::Code}, but it may accept additional error codes if needed.  The
     # error message should be a developer-facing English message that helps
@@ -32,40 +32,40 @@ module Google
     # error message is needed, put the localized message in the error details or
     # localize it in the client. The optional error details may contain arbitrary
     # information about the error. There is a predefined set of error detail types
-    # in the package +google.rpc+ that can be used for common error conditions.
+    # in the package `google.rpc` that can be used for common error conditions.
     #
     # = Language mapping
     #
-    # The +Status+ message is the logical representation of the error model, but it
-    # is not necessarily the actual wire format. When the +Status+ message is
+    # The `Status` message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the `Status` message is
     # exposed in different client libraries and different wire protocols, it can be
     # mapped differently. For example, it will likely be mapped to some exceptions
     # in Java, but more likely mapped to some error codes in C.
     #
     # = Other uses
     #
-    # The error model and the +Status+ message can be used in a variety of
+    # The error model and the `Status` message can be used in a variety of
     # environments, either with or without APIs, to provide a
     # consistent developer experience across different environments.
     #
     # Example uses of this error model include:
     #
     # * Partial errors. If a service needs to return partial errors to the client,
-    #   it may embed the +Status+ in the normal response to indicate the partial
+    #   it may embed the `Status` in the normal response to indicate the partial
     #   errors.
     #
     # * Workflow errors. A typical workflow has multiple steps. Each step may
-    #   have a +Status+ message for error reporting.
+    #   have a `Status` message for error reporting.
     #
     # * Batch operations. If a client uses batch request and batch response, the
-    #   +Status+ message should be used directly inside batch response, one for
+    #   `Status` message should be used directly inside batch response, one for
     #   each error sub-response.
     #
     # * Asynchronous operations. If an API call embeds asynchronous operation
     #   results in its response, the status of those operations should be
-    #   represented directly using the +Status+ message.
+    #   represented directly using the `Status` message.
     #
-    # * Logging. If some API errors are stored in logs, the message +Status+ could
+    # * Logging. If some API errors are stored in logs, the message `Status` could
     #   be used directly after any stripping needed for security/privacy reasons.
     # @!attribute [rw] code
     #   @return [Integer]

--- a/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
+++ b/google-cloud-vision/lib/google/cloud/vision/v1/image_annotator_client.rb
@@ -212,7 +212,7 @@ module Google
           #
           #   image_annotator_client = Google::Cloud::Vision::V1.new
           #
-          #   # TODO: Initialize +requests+:
+          #   # TODO: Initialize `requests`:
           #   requests = []
           #   response = image_annotator_client.batch_annotate_images(requests)
 
@@ -230,9 +230,9 @@ module Google
           # Run asynchronous image detection and annotation for a list of generic
           # files, such as PDF files, which may contain multiple pages and multiple
           # images per page. Progress and results can be retrieved through the
-          # +google.longrunning.Operations+ interface.
-          # +Operation.metadata+ contains +OperationMetadata+ (metadata).
-          # +Operation.response+ contains +AsyncBatchAnnotateFilesResponse+ (results).
+          # `google.longrunning.Operations` interface.
+          # `Operation.metadata` contains `OperationMetadata` (metadata).
+          # `Operation.response` contains `AsyncBatchAnnotateFilesResponse` (results).
           #
           # @param requests [Array<Google::Cloud::Vision::V1::AsyncAnnotateFileRequest | Hash>]
           #   Individual async file annotation requests for this batch.
@@ -248,7 +248,7 @@ module Google
           #
           #   image_annotator_client = Google::Cloud::Vision::V1.new
           #
-          #   # TODO: Initialize +requests+:
+          #   # TODO: Initialize `requests`:
           #   requests = []
           #
           #   # Register a callback during the method call.


### PR DESCRIPTION
Previously, the generator was transforming backticks in comments (signifying preformatted text in markdown) to plus signs (which was the corresponding rdoc syntax). Since we are on YARD and using markdown, I had that transform removed. This PR is the result of resynthing every gem with the changed gapic. This will fix a lot of preformatted strings in the docs.

One detail: Previously we were indiscriminately escaping curly braces in comments to stop YARD from trying to interpret them as links. However, a lot of those were in preformatted spans, and now that those are properly recognized (using backticks), I had to reverse the escaping for braces that appear between backticks. So the regex is a bit more complex: it only escapes braces that are outside a backtick span. That seems to be doing the right thing in the cases I've reviewed.