### PR TITLE
Fix bigtable's overview guide

### DIFF
--- a/google-cloud-bigtable/OVERVIEW.md
+++ b/google-cloud-bigtable/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Cloud Bigtable
 
-Ruby Client for Cloud Bigtable API Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+Ruby Client for Cloud Bigtable API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 
 [Cloud Bigtable API][Product Documentation]:
 API for reading and writing the contents of Bigtables associated with a
@@ -12,17 +12,19 @@ In order to use this library, you first need to go through the following
 steps:
 
 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
-2. [Enable billing for your oject.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_projec
-3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/api/bigtable)
-4. [Setup thentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/mast/guides/authentication)
+2. [Enable billing for your project.](https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project)
+3. [Enable the Cloud Bigtable API.](https://console.cloud.google.com/apis/library/bigtable.googleapis.com)
+4. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/docs/google-cloud/latest/file.AUTHENTICATION)
 
 ### Next Steps
 - Read the [Cloud Bigtable API Product documentation][Product Documentation]
   to learn more about the product and see How-to Guides.
-- View this [repository's main ADME](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
+- View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
   to see the full list of Cloud APIs that we cover.
 
 ## Additional information
 
 Google Bigtable can be configured to use gRPC's logging. To learn more, see the
 {file:LOGGING.md Logging guide}.
+
+[Product Documentation]: https://cloud.google.com/bigtable


### PR DESCRIPTION
Not sure what happened to this file, but it seemed to lose a bunch of two-character sequences, resulting in a bunch of syntax errors. Attempted fix. Also corrected the api enable and authentication links.