### PR TITLE
Pub/Sub update labels

### DIFF
--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -185,6 +185,8 @@ describe Google::Cloud::Pubsub, :pubsub do
       subscription.retention.must_equal 600
       subscription.labels.must_equal labels
       subscription.labels.must_be :frozen?
+      subscription.labels = {}
+      subscription.labels.must_be :empty?
       subscription.delete
     end
 

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -69,13 +69,15 @@ describe Google::Cloud::Pubsub, :pubsub do
       next_topics.token.must_be :nil?
     end
 
-    it "should be created and deleted" do
+    it "should be created, updated and deleted" do
       topic = pubsub.create_topic new_topic_name, labels: labels
       topic.must_be_kind_of Google::Cloud::Pubsub::Topic
       topic = pubsub.topic(topic.name)
       topic.wont_be :nil?
       topic.labels.must_equal labels
       topic.labels.must_be :frozen?
+      topic.labels = {}
+      topic.labels.must_be :empty?
       topic.delete
       pubsub.topic(topic.name).must_be :nil?
     end

--- a/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
+++ b/google-cloud-pubsub/acceptance/pubsub/pubsub_test.rb
@@ -270,6 +270,8 @@ describe Google::Cloud::Pubsub, :pubsub do
 
       snapshot.labels.must_equal labels
       snapshot.labels.must_be :frozen?
+      snapshot.labels = {}
+      snapshot.labels.must_be :empty?
 
       # Remove the subscription
       subscription.delete

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -333,6 +333,14 @@ module Google
           end
         end
 
+        def update_snapshot snapshot_obj, *fields
+          mask = Google::Protobuf::FieldMask.new paths: fields.map(&:to_s)
+          execute do
+            subscriber.update_snapshot \
+              snapshot_obj, mask, options: default_options
+          end
+        end
+
         ##
         # Deletes an existing snapshot.
         # All pending messages in the snapshot are immediately dropped.

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/service.rb
@@ -131,6 +131,14 @@ module Google
           end
         end
 
+        def update_topic topic_obj, *fields
+          mask = Google::Protobuf::FieldMask.new paths: fields.map(&:to_s)
+          execute do
+            publisher.update_topic \
+              topic_obj, mask, options: default_options
+          end
+        end
+
         ##
         # Deletes the topic with the given name. All subscriptions to this topic
         # are also deleted. Raises GRPC status code 5 if the topic does not

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/snapshot.rb
@@ -112,16 +112,37 @@ module Google
 
         ##
         # A hash of user-provided labels associated with this snapshot.
-        # Labels can be provided when the snapshot is created, and used to
-        # organize and group snapshots.See [Creating and Managing
-        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        # Labels can be used to organize and group snapshots.See [Creating and
+        # Managing Labels](https://cloud.google.com/pubsub/docs/labels).
         #
-        # The returned hash is frozen and changes are not allowed.
+        # The returned hash is frozen and changes are not allowed. Use
+        # {#labels=} to update the labels for this snapshot.
         #
         # @return [Hash] The frozen labels hash.
         #
         def labels
           @grpc.labels.to_h.freeze
+        end
+
+        ##
+        # Sets the hash of user-provided labels associated with this
+        # snapshot. Labels can be used to organize and group snapshots.
+        # Label keys and values can be no longer than 63 characters, can only
+        # contain lowercase letters, numeric characters, underscores and dashes.
+        # International characters are allowed. Label values are optional. Label
+        # keys must start with a letter and each label in the list must have a
+        # different key. See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # @param [Hash] new_labels The new labels hash.
+        #
+        def labels= new_labels
+          raise ArgumentError, "Value must be a Hash" if new_labels.nil?
+          labels_map = Google::Protobuf::Map.new(:string, :string)
+          Hash(new_labels).each { |k, v| labels_map[String(k)] = String(v) }
+          update_grpc = @grpc.dup
+          update_grpc.labels = labels_map
+          @grpc = service.update_snapshot update_grpc, :labels
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/subscription.rb
@@ -176,16 +176,38 @@ module Google
 
         ##
         # A hash of user-provided labels associated with this subscription.
-        # Labels can be provided when the subscription is created, and used to
-        # organize and group subscriptions.See [Creating and Managing
-        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        # Labels can be used to organize and group subscriptions.See [Creating
+        # and Managing Labels](https://cloud.google.com/pubsub/docs/labels).
         #
-        # The returned hash is frozen and changes are not allowed.
+        # The returned hash is frozen and changes are not allowed. Use
+        # {#labels=} to update the labels for this subscription.
         #
         # @return [Hash] The frozen labels hash.
         #
         def labels
           @grpc.labels.to_h.freeze
+        end
+
+        ##
+        # Sets the hash of user-provided labels associated with this
+        # subscription. Labels can be used to organize and group subscriptions.
+        # Label keys and values can be no longer than 63 characters, can only
+        # contain lowercase letters, numeric characters, underscores and dashes.
+        # International characters are allowed. Label values are optional. Label
+        # keys must start with a letter and each label in the list must have a
+        # different key. See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # @param [Hash] new_labels The new labels hash.
+        #
+        def labels= new_labels
+          raise ArgumentError, "Value must be a Hash" if new_labels.nil?
+          labels_map = Google::Protobuf::Map.new(:string, :string)
+          Hash(new_labels).each { |k, v| labels_map[String(k)] = String(v) }
+          update_grpc = @grpc.dup
+          update_grpc.labels = labels_map
+          @grpc = service.update_subscription update_grpc, :labels
+          @lazy = nil
         end
 
         ##

--- a/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
+++ b/google-cloud-pubsub/lib/google/cloud/pubsub/topic.rb
@@ -95,16 +95,38 @@ module Google
 
         ##
         # A hash of user-provided labels associated with this topic. Labels can
-        # be provided when the topic is created, and used to organize and group
-        # topics.See [Creating and Managing
+        # be used to organize and group topics. See [Creating and Managing
         # Labels](https://cloud.google.com/pubsub/docs/labels).
         #
-        # The returned hash is frozen and changes are not allowed.
+        # The returned hash is frozen and changes are not allowed. Use
+        # {#labels=} to update the labels for this topic.
         #
         # @return [Hash] The frozen labels hash.
         #
         def labels
           @grpc.labels.to_h.freeze
+        end
+
+        ##
+        # Sets the hash of user-provided labels associated with this
+        # topic. Labels can be used to organize and group topics.
+        # Label keys and values can be no longer than 63 characters, can only
+        # contain lowercase letters, numeric characters, underscores and dashes.
+        # International characters are allowed. Label values are optional. Label
+        # keys must start with a letter and each label in the list must have a
+        # different key. See [Creating and Managing
+        # Labels](https://cloud.google.com/pubsub/docs/labels).
+        #
+        # @param [Hash] new_labels The new labels hash.
+        #
+        def labels= new_labels
+          raise ArgumentError, "Value must be a Hash" if new_labels.nil?
+          labels_map = Google::Protobuf::Map.new(:string, :string)
+          Hash(new_labels).each { |k, v| labels_map[String(k)] = String(v) }
+          update_grpc = @grpc.dup
+          update_grpc.labels = labels_map
+          @grpc = service.update_topic update_grpc, :labels
+          @lazy = nil
         end
 
         ##

--- a/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/snapshot_test.rb
@@ -17,8 +17,15 @@ require "helper"
 describe Google::Cloud::Pubsub::Snapshot, :mock_pubsub do
   let(:topic_name) { "topic-name-goes-here" }
   let(:snapshot_name) { "snapshot-name-goes-here" }
-  let(:snapshot_grpc) { Google::Pubsub::V1::Snapshot.decode_json(snapshot_json(topic_name, snapshot_name)) }
+  let(:labels) { { "foo" => "bar" } }
+  let(:snapshot_grpc) { Google::Pubsub::V1::Snapshot.decode_json(snapshot_json(topic_name, snapshot_name, labels: labels)) }
   let(:snapshot) { Google::Cloud::Pubsub::Snapshot.from_grpc snapshot_grpc, pubsub.service }
+  let(:new_labels) { { "baz" => "qux" } }
+  let(:new_labels_map) do
+    labels_map = Google::Protobuf::Map.new(:string, :string)
+    new_labels.each { |k, v| labels_map[String(k)] = String(v) }
+    labels_map
+  end
 
   it "knows its name" do
     snapshot.name.must_equal snapshot_path(snapshot_name)
@@ -32,6 +39,55 @@ describe Google::Cloud::Pubsub::Snapshot, :mock_pubsub do
 
   it "knows its expiration_time" do
     snapshot.expiration_time.must_be_kind_of ::Time
+  end
+
+  it "knows its labels" do
+    snapshot.labels.must_equal labels
+  end
+
+
+  it "updates labels" do
+    snapshot.labels.must_equal labels
+
+    update_sub = snapshot_grpc.dup
+    update_sub.labels = new_labels_map
+    update_mask = Google::Protobuf::FieldMask.new paths: ["labels"]
+    mock = Minitest::Mock.new
+    mock.expect :update_snapshot, update_sub, [update_sub, update_mask, options: default_options]
+    snapshot.service.mocked_subscriber = mock
+
+    snapshot.labels = new_labels
+
+    mock.verify
+
+    snapshot.labels.must_equal new_labels
+  end
+
+  it "updates labels to empty hash" do
+    snapshot.labels.must_equal labels
+
+    update_sub = snapshot_grpc.dup
+    update_sub.labels = Google::Protobuf::Map.new(:string, :string)
+
+    update_mask = Google::Protobuf::FieldMask.new paths: ["labels"]
+    mock = Minitest::Mock.new
+    mock.expect :update_snapshot, update_sub, [update_sub, update_mask, options: default_options]
+    snapshot.service.mocked_subscriber = mock
+
+    snapshot.labels = {}
+
+    mock.verify
+
+    snapshot.labels.wont_be :nil?
+    snapshot.labels.must_be :empty?
+  end
+
+  it "raises when setting labels to nil" do
+    snapshot.labels.must_equal labels
+
+    expect { snapshot.labels = nil }.must_raise ArgumentError
+
+    snapshot.labels.must_equal labels
   end
 
   it "can delete itself" do

--- a/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
+++ b/google-cloud-pubsub/test/google/cloud/pubsub/topic/update_test.rb
@@ -1,0 +1,96 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "helper"
+
+describe Google::Cloud::Pubsub::Topic, :update, :mock_pubsub do
+  let(:topic_name) { "topic-name-goes-here" }
+  let(:labels) { { "foo" => "bar" } }
+  let(:new_labels) { { "baz" => "qux" } }
+  let(:new_labels_map) do
+    labels_map = Google::Protobuf::Map.new(:string, :string)
+    new_labels.each { |k, v| labels_map[String(k)] = String(v) }
+    labels_map
+  end
+  let(:topic_grpc) { Google::Pubsub::V1::Topic.decode_json topic_json(topic_name, labels: labels) }
+  let(:topic) { Google::Cloud::Pubsub::Topic.from_grpc topic_grpc, pubsub.service }
+
+  it "updates labels" do
+    topic.labels.must_equal labels
+
+    update_grpc = topic_grpc.dup
+    update_grpc.labels = new_labels_map
+    update_mask = Google::Protobuf::FieldMask.new paths: ["labels"]
+    mock = Minitest::Mock.new
+    mock.expect :update_topic, update_grpc, [update_grpc, update_mask, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.labels = new_labels
+
+    mock.verify
+
+    topic.labels.must_equal new_labels
+  end
+
+  it "updates labels to empty hash" do
+    topic.labels.must_equal labels
+
+    update_grpc = topic_grpc.dup
+    update_grpc.labels = Google::Protobuf::Map.new(:string, :string)
+
+    update_mask = Google::Protobuf::FieldMask.new paths: ["labels"]
+    mock = Minitest::Mock.new
+    mock.expect :update_topic, update_grpc, [update_grpc, update_mask, options: default_options]
+    topic.service.mocked_publisher = mock
+
+    topic.labels = {}
+
+    mock.verify
+
+    topic.labels.wont_be :nil?
+    topic.labels.must_be :empty?
+  end
+
+  it "raises when setting labels to nil" do
+    topic.labels.must_equal labels
+
+    expect { topic.labels = nil }.must_raise ArgumentError
+
+    topic.labels.must_equal labels
+  end
+
+  describe :lazy do
+    let(:topic) { Google::Cloud::Pubsub::Topic.new_lazy topic_name, pubsub.service }
+
+    it "updates labels" do
+      topic.must_be :lazy?
+
+      update_grpc = Google::Pubsub::V1::Topic.new \
+        name: topic_path(topic_name),
+        labels: new_labels
+      topic_grpc.labels = new_labels_map
+      update_mask = Google::Protobuf::FieldMask.new paths: ["labels"]
+      mock = Minitest::Mock.new
+      mock.expect :update_topic, topic_grpc, [update_grpc, update_mask, options: default_options]
+      topic.service.mocked_publisher = mock
+
+      topic.labels = new_labels
+
+      mock.verify
+
+      topic.wont_be :lazy?
+      topic.labels.must_equal new_labels
+    end
+  end
+end


### PR DESCRIPTION
This PR is a follow-up to #2440, adding support for updates.

* Add `Subscription#labels=`
* Add `Snapshot#labels=`
* Add `Topic#labels=`