### PR TITLE
Fix Logger's add_trace_id method

### DIFF
--- a/google-cloud-logging/lib/google/cloud/logging/logger.rb
+++ b/google-cloud-logging/lib/google/cloud/logging/logger.rb
@@ -430,7 +430,7 @@ module Google
         # @deprecated Use add_request_info
         #
         def add_trace_id trace_id
-          add_request_id trace_id: trace_id
+          add_request_info trace_id: trace_id
         end
 
         ##


### PR DESCRIPTION
The method should be calling `add_request_info`.
The method `add_request_id` does not exist.